### PR TITLE
fix(docs): shorten the descriptions that trim without a rewrite

### DIFF
--- a/docs/de/develop/api-reference.md
+++ b/docs/de/develop/api-reference.md
@@ -1,6 +1,6 @@
 ---
 title: API-Referenz
-description: Wie du Tale von außen aufrufst — Authentifizierung, das Endpoint-Inventar, Pagination, die asynchronen Lauf- und Turn-Schleifen und das Fehlermodell. Die einzige Quelle der Wahrheit für die REST-Oberfläche.
+description: Wie du Tale von außen aufrufst — Authentifizierung, das Endpoint-Inventar, Pagination, die asynchronen Lauf- und Turn-Schleifen und das Fehlermodell.
 i18nLintExclude:
   - terminology-loanword
 ---

--- a/docs/de/develop/contributor-setup.md
+++ b/docs/de/develop/contributor-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Contributor-Setup
-description: Die zentrale Quelle der Wahrheit für das Aufsetzen von Tales Quellcode zur lokalen Entwicklung — Voraussetzungen, bun install, der Pre-flight-Check, was bun run dev tut, Port-Konflikte und die Pre-PR-Checkliste.
+description: Die zentrale Quelle der Wahrheit für das Aufsetzen von Tales Quellcode zur lokalen Entwicklung.
 ---
 
 Diese Seite ist für Contributors, die Tale aus dem Quellcode laufen lassen und eine Änderung zurückgeben wollen. Sie deckt die Voraussetzungen ab, das einmalige Setup, den Pre-flight-Check, der eine kaputte Maschine vor einem langen Boot erkennt, und was du von `bun run dev` erwarten kannst. Es ist nicht der Operator-Weg — willst du Tale benutzen statt verändern, installiert der [Self-hosted Quickstart](/de/self-hosted/install/quickstart) stattdessen den paketierten Stack mit der CLI.

--- a/docs/de/get-started/quickstart.md
+++ b/docs/de/get-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Von null zur ersten Agent-Antwort — Instanz besorgen, anmelden und die erste Nachricht senden. Fünf Minuten auf einer bereiten Instanz, fünfzehn, wenn du selbst eine aufstellst.
+description: Von null zur ersten Agent-Antwort — Instanz besorgen, anmelden und die erste Nachricht senden.
 ---
 
 Das ist der kürzeste Weg zu einem funktionierenden Chat mit einem Agent: Instanz besorgen, anmelden, Nachricht senden, der Antwort beim Streamen zusehen. Auf einer bereiten Instanz dauert das rund fünf Minuten, auf deiner eigenen Maschine fünfzehn — und es endet mit dem Bildschirm unten, einer echten Antwort eines Agents über deinen Arbeitsbereich.

--- a/docs/de/platform/admin/changelog.md
+++ b/docs/de/platform/admin/changelog.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog
-description: Der In-Produkt-Release-Viewer, der zeigt, was sich in der Tale-Plattform selbst geändert hat. Admins lesen das nach einem Upgrade, um zu sehen, was gelandet ist, und um die Highlights mit der Org zu teilen.
+description: Der In-Produkt-Release-Viewer, der zeigt, was sich in der Tale-Plattform selbst geändert hat.
 ---
 
 Der Changelog ist der In-Produkt-Viewer, der Release Notes für die Tale-Plattform selbst anzeigt — nicht für Inhalte, die deine Mitglieder produzieren. Nach einem selbst gehosteten Upgrade oder einem Managed-Cloud-Rollout listet der Viewer auf, was sich zwischen der vorherigen Version und der jetzt laufenden geändert hat. Admins lesen ihn nach einem Upgrade, um das Team einzuweisen und alles zu markieren, was die Arbeit der Mitglieder berührt.

--- a/docs/de/platform/admin/connectors.md
+++ b/docs/de/platform/admin/connectors.md
@@ -1,6 +1,6 @@
 ---
 title: Zugangsdaten für Connectors
-description: Unter Einstellungen > Connectors legt eine Organisation die Zugangsdaten an, mit denen sich jeder mitgelieferte Connector anmeldet — benennen, zum Standard machen, deaktivieren, neu verbinden.
+description: Unter Einstellungen > Connectors legt eine Organisation die Zugangsdaten an, mit denen sich jeder mitgelieferte Connector anmeldet.
 ---
 
 Jeder Connector wird mit der Plattform ausgeliefert, deshalb besteht die Arbeit eines Admins nie aus Installation, sondern aus einer Entscheidung: als welche Konten Tale handeln darf, und wie diese Zugangsdaten gesund bleiben. Ein Connector hält so viele Einträge, wie du brauchst — einen pro Workspace, Shop, Postfach oder Bot — und einer davon antwortet für jeden Aufrufer, der keinen benennt. Diese Seite ist die Betriebsseite davon: was die Seite zeigt, wie jede Authentifizierungsmethode ausgefüllt wird und was beim Hochstufen, Deaktivieren, Löschen oder Neuverbinden einer Zeile geschieht.

--- a/docs/de/platform/admin/enterprise-sso.md
+++ b/docs/de/platform/admin/enterprise-sso.md
@@ -1,6 +1,6 @@
 ---
 title: Enterprise-SSO und Bereitstellung
-description: Single Sign-On (OIDC, OAuth2, SAML 2.0) und SCIM-Bereitstellung von Benutzern und Gruppen für deine Organisation konfigurieren. Schritt-für-Schritt-Einrichtung für Microsoft Entra ID, Google, generisches OIDC und SAML, plus Rollenzuordnung, Gruppe-zu-Team-Synchronisierung und Deaktivierung. Lies dies, wenn du die Unternehmensidentität für die Organisation einrichtest.
+description: Single Sign-On (OIDC, OAuth2, SAML 2.0) und SCIM-Bereitstellung von Benutzern und Gruppen für deine Organisation konfigurieren.
 ---
 
 Mit Enterprise-SSO melden sich deine Mitglieder über deinen Identitätsanbieter (IdP) an, statt mit einem Tale-Passwort, und SCIM lässt den IdP Mitglieder und Gruppen automatisch anlegen, aktualisieren und deaktivieren — ohne manuelle Einladungen. Eine Verbindung pro Organisation trägt das Anmeldeprotokoll, die Bereitstellungsrichtlinie und das SCIM-Token gemeinsam. Alles liegt auf einer Seite: **Einstellungen > Enterprise-SSO** (nur Administratoren).

--- a/docs/de/platform/admin/governance/content-models.md
+++ b/docs/de/platform/admin/governance/content-models.md
@@ -1,6 +1,6 @@
 ---
 title: Inhalte und Modelle
-description: Modell-Ebenen-Kontrollen — welche Modelle pro Rolle oder Team erlaubt sind und das Default-Modell, auf dem jede Benutzergruppe landet. Admins und Inhaber lesen das, wenn eine Compliance-Regel eine Last an ein freigegebenes Modell bindet oder wenn ein Team einen günstigeren Default braucht.
+description: Modell-Ebenen-Kontrollen — welche Modelle pro Rolle oder Team erlaubt sind und das Default-Modell, auf dem jede Benutzergruppe landet.
 ---
 
 Inhalte und Modelle ist die Oberfläche, auf der du entscheidest, welche LLMs die Personen in deiner Organisation erreichen können und auf welchem jede Gruppe per Default landet. Sie verbindet eine Zulassungs- oder Sperrliste pro Bereich (Organisation, Team, Rolle) mit einer Default-Modell-Regel, die der Resolver anwendet, wenn keine explizite Wahl sie überschrieben hat. Admins und Inhaber lesen diese Seite, wenn eine Compliance-Regel eine Last an ein freigegebenes Modell bindet, wenn ein Team auf einem günstigeren Modell als der Rest der Organisation landen soll, oder wenn ein neues Modell eines bestehenden Anbieters erreichbar gemacht werden muss.

--- a/docs/de/platform/admin/governance/data-subject-requests.md
+++ b/docs/de/platform/admin/governance/data-subject-requests.md
@@ -1,6 +1,6 @@
 ---
 title: Anfragen betroffener Personen
-description: Der Workflow nach DSGVO Artikel 17 zur Löschung der Daten einer Person über Chats, Dokumente, Uploads und Einstellungen hinweg. Admins und Inhaber lesen das, wenn ein Benutzer eine Anfrage stellt oder wenn eine SLA-Frist näher rückt.
+description: Der Workflow nach DSGVO Artikel 17 zur Löschung der Daten einer Person über Chats, Dokumente, Uploads und Einstellungen hinweg.
 ---
 
 Anfragen betroffener Personen ist der Workflow, den Tale für die Einhaltung von DSGVO Artikel 17 (Recht auf Löschung) und das entsprechende CCPA-Recht nach kalifornischem Recht ausliefert. Jede Anfrage wird zu einem Beleg: er nennt die betroffene Person, den Begründungs-Code, die SLA-Frist und die Kaskade von Zeilen, die das System über Threads, Dokumente, Uploads und die übrigen Zeilen hinweg gelöscht hat, die die Person identifizieren. Admins und Inhaber lesen diese Seite, wenn eine Person eine Anfrage stellt, wenn eine Frist näher rückt, oder wenn ein Audit den Beleg einer vergangenen Löschung verlangt.

--- a/docs/de/platform/admin/governance/feedback-analytics.md
+++ b/docs/de/platform/admin/governance/feedback-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Feedback-Analyse
-description: Aggregierte Daumen-hoch- und Daumen-runter-Bewertungen auf Assistenten-Antworten plus Arena-Urteile, aufgeschlüsselt pro Assistent und pro Modell. Admins und Inhaber lesen das, wenn eine Agent-Regression eine Zahl dahinter braucht.
+description: Aggregierte Daumen-hoch- und Daumen-runter-Bewertungen auf Assistenten-Antworten plus Arena-Urteile, aufgeschlüsselt pro Assistent und pro Modell.
 ---
 
 Feedback-Analyse ist das Dashboard, das die Per-Nachricht-Daumen und die Arena-Urteile in Trendlinien verwandelt. Mitglieder hinterlassen das Feedback inline im Chat; diese Seite aggregiert es pro Assistent, pro Modell und über die Zeit, sodass die Regression aus der Stimmänderung letzter Woche als Zahl sichtbar ist und nicht als Bauchgefühl. Admins und Inhaber lesen diese Seite, wenn ein Modellwechsel wie eine Verschlechterung aussieht, wenn ein Assistent schlechter abschneidet als die anderen, oder wenn die Führung die grobe Qualitätshaltung jedes Assistenten in der Organisation will.

--- a/docs/de/platform/admin/governance/guardrails.md
+++ b/docs/de/platform/admin/governance/guardrails.md
@@ -1,6 +1,6 @@
 ---
 title: Guardrails
-description: Die drei Filterebenen — Inhaltssicherheit, PII-Erkennung und ein Moderationsanbieter — die Chat-Eingaben und -Ausgaben vor und nach dem Modell prüfen. Admins und Inhaber lesen das, wenn ein Regulierer eine Inhaltsregel benennt oder wenn ein Leck eine strengere Richtlinie rechtfertigt.
+description: Die drei Filterebenen — Inhaltssicherheit, PII-Erkennung und ein Moderationsanbieter — die Chat-Eingaben und -Ausgaben vor und nach dem Modell prüfen.
 ---
 
 Guardrails ist die Oberfläche, auf der du die drei Filterebenen konfigurierst, die Tale auf jede Chat-Nachricht in deiner Organisation anwendet. Jede Nachricht durchläuft Inhaltssicherheit (Wortlisten und Admin-Regex), dann PII-Erkennung (eingebaute Muster plus eigene), dann einen optionalen externen Moderationsanbieter — in dieser festen Reihenfolge, auf dem Weg hinein und auf dem Weg hinaus. Admins und Inhaber lesen diese Seite, wenn ein Regulierer eine Inhaltsregel benennt, wenn ein Leck eine strengere Richtlinie rechtfertigt, oder wenn die Antworten eines Agents bereinigt werden müssen, bevor sie das Modell verlassen.

--- a/docs/de/platform/admin/governance/policies-and-limits.md
+++ b/docs/de/platform/admin/governance/policies-and-limits.md
@@ -1,6 +1,6 @@
 ---
 title: Richtlinien und Limits
-description: Per-Org-Limits für Token-Kosten, Anzahl Anfragen, Upload-Größe, Bildgenerierung und Feature-Zugriff — eingegrenzt nach Benutzer, Team, Rolle oder einzelnem API-Schlüssel. Admins und Inhaber lesen das, wenn eine Last über Budget ist oder wenn ein Feature einen engeren Radius braucht.
+description: Per-Org-Limits für Token-Kosten, Anzahl Anfragen, Upload-Größe, Bildgenerierung und Feature-Zugriff.
 ---
 
 Richtlinien und Limits ist die Oberfläche, auf der du deckelst, was deine Mitglieder und Agents verbrauchen können. Budgets deckeln Tokens, Kosten und Anfragen pro Abrechnungsperiode; Feature-Kontrollen deckeln das Kontextfenster pro Bereich; Upload-Richtlinie regelt Dateitypen und Größen, die ein Mitglied anhängen darf; Aufbewahrungsrichtlinie entscheidet, wie lange jeder Datentyp lebt, bevor Cleanup eingreift. Admins und Inhaber lesen diese Seite, wenn eine Last über Budget ist, wenn eine Gruppe mit einem kleineren Kontextfenster arbeiten soll, oder wenn ein Regulierer ein Aufbewahrungsfenster benennt, das vom Default abweicht.

--- a/docs/de/platform/admin/governance/run-code-policy.md
+++ b/docs/de/platform/admin/governance/run-code-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Run-code-Richtlinie
-description: Die Paket-Zulassungsliste und -Sperrliste, die regeln, was sandgeboxtes Run code installieren darf. Admins und Inhaber lesen das, wenn ein Agent eine neue Bibliothek braucht oder wenn ein Audit fragt, warum ein Paket zu einem bestimmten Zeitpunkt blockiert war.
+description: Die Paket-Zulassungsliste und -Sperrliste, die regeln, was sandgeboxtes Run code installieren darf.
 ---
 
 Run-code-Richtlinie ist die Oberfläche, auf der du entscheidest, welche Python- und Node-Pakete die Sandbox zur Laufzeit installieren kann. Skills mit Skripten und das Run-code-Tool laufen beide in derselben Sandbox; diese Richtlinie ist die einzige Naht, an der du anziehst oder lockerst, was sie installieren dürfen. Admins und Inhaber lesen diese Seite, wenn ein Agent eine neue Bibliothek braucht oder wenn ein Audit fragt, warum ein Paket zu einem bestimmten Zeitpunkt blockiert war.

--- a/docs/de/platform/admin/governance/usage-analytics.md
+++ b/docs/de/platform/admin/governance/usage-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Nutzungs-Analyse
-description: Das Dashboard für Tokens, Kosten und Anfragenvolumen nach Benutzer, Team, Modell und Agent — mit Trends und einer Top-Agent-Rangliste. Admins und Inhaber lesen das, wenn eine Rechnung unerwartet ist oder wenn die Führung die grobe Form der AI-Ausgaben will.
+description: Das Dashboard für Tokens, Kosten und Anfragenvolumen nach Benutzer, Team, Modell und Agent — mit Trends und einer Top-Agent-Rangliste.
 ---
 
 Nutzungs-Analyse ist das Dashboard, das jeden abrechenbaren AI-Aufruf in einer einzigen Ansicht von Tokens, Kosten und Anfragenvolumen aggregiert. Es schneidet nach Benutzer, Team, Rolle, Modell, Agent und Zeit, sodass die unerwartete Zeile auf der Rechnung zur Last zurückführbar ist, die sie verursacht hat. Admins und Inhaber lesen diese Seite, wenn eine Rechnung unerwartet ist, wenn die Führung die grobe Form der AI-Ausgaben will, oder wenn eine Budgetwarnung auslöst und die nächste Frage _wer und was_ ist.

--- a/docs/de/platform/admin/members-and-roles.md
+++ b/docs/de/platform/admin/members-and-roles.md
@@ -1,6 +1,6 @@
 ---
 title: Mitglieder und Rollen
-description: Die sechs Rollen, die Tale mitbringt, und die Berechtigungs-Matrix auf Ressourcen-Ebene, die sagt, wer was darf. Admins und Inhaber lesen das beim Aufsetzen eines Teams oder wenn ein Audit fragt, wer welchen Zugriff hat.
+description: Die sechs Rollen, die Tale mitbringt, und die Berechtigungs-Matrix auf Ressourcen-Ebene, die sagt, wer was darf.
 ---
 
 Mitglieder sind die Personen in deiner Organisation, die sich bei Tale anmelden können. Rollen kontrollieren, was jedes Mitglied tun darf — lesen, schreiben, konfigurieren, regeln. Diese Seite ist die kanonische Referenz für die sechs Rollen und die Berechtigungen pro Ressource, die jede Rolle trägt.

--- a/docs/de/platform/admin/overview.md
+++ b/docs/de/platform/admin/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Admin
-description: Admin ist die Konfigurationsebene — Mitglieder, Teams, Anbieter, API-Schlüssel, Connectors, Branding, Richtlinien. Die Seiten hier sind das, was ein Admin oder Inhaber durchklickt, um eine Organisation aufzusetzen und am Laufen zu halten.
+description: Admin ist die Konfigurationsebene — Mitglieder, Teams, Anbieter, API-Schlüssel, Connectors, Branding, Richtlinien.
 ---
 
 Admin ist die Konfigurationsebene von Tale. Sie umfasst die Personen, die sich anmelden dürfen, die Teams, die sie gruppieren, die KI-Anbieter hinter jeder Antwort, die API-Schlüssel, mit denen externer Code mit der Organisation spricht, die Drittanbieter-Connectors, durch die Agents nach außen greifen, und das Branding, das der Rest der Organisation sieht. Nur Admins und Inhaber sehen das volle Admin-Menü; Entwickler sehen eine Teilmenge, andere Rollen sehen es gar nicht.

--- a/docs/de/platform/admin/teams.md
+++ b/docs/de/platform/admin/teams.md
@@ -1,6 +1,6 @@
 ---
 title: Teams
-description: Teams sind benannte Gruppen von Mitgliedern, die sich Zugriff auf Dokumente, Projekte, Skills und Konversationen teilen. Admins erstellen und verwalten Teams unter Einstellungen > Teams; die Grenze, die sie ziehen, greift überall unterhalb der Rollen-Ebene.
+description: Teams sind benannte Gruppen von Mitgliedern, die sich Zugriff auf Dokumente, Projekte, Skills und Konversationen teilen.
 ---
 
 Ein Team ist eine benannte Gruppe von Mitgliedern, die sich Zugriff auf Dokumente, Projekte, Skills und Konversationen teilt. Wo Rollen definieren, was eine Person tun _kann_, definieren Teams, in welchem Ausschnitt der Organisationsdaten diese Person arbeitet. Die meisten Organisationen landen bei einer Handvoll Teams — Support, Vertrieb, Betrieb — und die meisten alltäglichen Berechtigungs-Entscheidungen liegen auf der Team-Grenze, nicht auf der Rollen-Grenze. Admins verwalten Teams unter **Einstellungen > Teams**.

--- a/docs/de/platform/automations/assistant.md
+++ b/docs/de/platform/automations/assistant.md
@@ -1,6 +1,6 @@
 ---
 title: Automatisierungs-Assistent
-description: Einen Chat-Agent, der auf eine Automatisierung fixiert ist, gibt es in dieser Version nicht — eine Automatisierung bearbeitest du auf ihrer eigenen Seite, und ein Modell verfasst sie über den MCP-Endpoint.
+description: Einen Chat-Agent, der auf eine Automatisierung fixiert ist, gibt es in dieser Version nicht.
 ---
 
 Diese Seite beschrieb einmal den **Automatisierungs-Assistenten**: einen Chat-Agent, der auf eine einzelne Automatisierung ausgerichtet war, deren Dokument, Agents, Skills und Connectors im Kontext hatte und für dich Nodes editieren, Versionen speichern und Mocks laufen lassen konnte. In dieser Version von Tale gibt es ihn nicht. Der Chat kennt keinen Agent, der auf irgendetwas ausgerichtet wäre — der Chat-Assistent trägt drei nur lesende Retrieval-Tools und kann eine Automatisierung weder lesen noch bearbeiten —, und der Canvas hat kein Assistenten-Panel. Was bleibt, sind die zwei Wege, auf denen eine Automatisierung tatsächlich gebaut und verstanden wird: ihre eigene Seite und der MCP-Endpoint.

--- a/docs/de/platform/connectors/mcp-servers.md
+++ b/docs/de/platform/connectors/mcp-servers.md
@@ -1,6 +1,6 @@
 ---
 title: MCP-Server
-description: Externe MCP-Server zu registrieren, damit Agenten sie aufrufen, gibt es in dieser Version nicht — Tales einzige MCP-Oberfläche ist der eingehende Endpoint unter Einstellungen > API > MCP.
+description: Externe MCP-Server zu registrieren, damit Agenten sie aufrufen, gibt es in dieser Version nicht.
 ---
 
 Diese Seite hat früher ein Formular **MCP-Server hinzufügen** beschrieben: einen Transport, eine Authentifizierungsmethode, eine Liste erlaubter Agenten und eine Tabelle erkannter Tools mit Genehmigungs-Flags pro Tool. Nichts davon gibt es in dieser Version von Tale. Es gibt kein Panel für MCP-Server, kein Registrierungsformular und keinen Werkzeugkasten der Agenten, in den sich ein externer Server einreihen könnte — eine Capability, die zu einem externen MCP-Tool führen würde, lehnt die Laufzeit mit einer lesbaren Begründung ab. Ausgeliefert wird die Gegenrichtung: Tale ist selbst ein MCP-Server, mit dem sich Clients von außen verbinden.

--- a/docs/de/platform/connectors/webdav.md
+++ b/docs/de/platform/connectors/webdav.md
@@ -1,6 +1,6 @@
 ---
 title: WebDAV
-description: Hänge die Dokumente deiner Organisation als Netzlaufwerk im Finder, im Datei-Explorer oder in jedem WebDAV-Client ein — erzeuge ein App-Passwort unter Einstellungen > API > WebDAV und verbinde dich von deinem Gerät.
+description: Hänge die Dokumente deiner Organisation als Netzlaufwerk im Finder, im Datei-Explorer oder in jedem WebDAV-Client ein.
 ---
 
 WebDAV verwandelt Tales Dokumentenspeicher in einen entfernten Ordner, den du wie jedes geteilte Netzlaufwerk einhängst. Der dahinterliegende Speicher ist derselbe, den der Dokumenten-Hub zeigt — was du in den eingehängten Ordner legst, erscheint in der UI, und umgekehrt. Alles Nötige liegt auf einem Panel: **Einstellungen > API > WebDAV** trägt die Verbindungsdaten und den App-Passwort-Generator.

--- a/docs/de/platform/editor/overview.md
+++ b/docs/de/platform/editor/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Redakteur
-description: Redakteur ist die Bau-Oberfläche — Agents, Projekte, Automatisierungen und das Wissen erstellen, in das sie reichen. Die Seiten hier sind das, was eine Person mit Redakteurs-Rolle tagtäglich tut.
+description: Redakteur ist die Bau-Oberfläche — Agents, Projekte, Automatisierungen und das Wissen erstellen, in das sie reichen.
 ---
 
 Redakteur ist die Bau-Oberfläche von Tale. Während Mitglied die Rolle ist, die das Produkt nutzt, und Admin die Rolle ist, die es steuert, ist Redakteur die Rolle, die die Dinge erstellt, die alle anderen nutzen — Agents, Projekte, Automatisierungen, die Dokumente und strukturierten Daten, die die Wissensdatenbank hält, die Prompts, die fürs Team gespeichert sind. Personen mit Redakteurs-Rolle sehen das volle Set an Bau-Tabs ohne die Admin-Governance-Oberfläche und ohne die nur-Entwickler-Hebel.

--- a/docs/de/platform/index.md
+++ b/docs/de/platform/index.md
@@ -1,6 +1,6 @@
 ---
 title: Plattform
-description: Plattform ist die kanonische Produktreferenz — jedes nutzersichtbare Feature, identisch für Cloud und selbst gehostet. Chat, Projekte, Agents, Automatisierungen, Wissen, Genehmigungen, Verwaltung.
+description: Plattform ist die kanonische Produktreferenz — jedes nutzersichtbare Feature, identisch für Cloud und selbst gehostet.
 kind: index
 ---
 

--- a/docs/de/platform/knowledge/documents.md
+++ b/docs/de/platform/knowledge/documents.md
@@ -1,6 +1,6 @@
 ---
 title: Dokumente
-description: Auf dem Dokumente-Tab laden Redakteure Dateien in die Wissensdatenbank, sehen ihnen beim Indexieren zu und verwalten ihren Lebenszyklus — Upload-Quellen, RAG-Status, Team-Bindung, Ordner und Neuindexierung.
+description: Auf dem Dokumente-Tab laden Redakteure Dateien in die Wissensdatenbank, sehen ihnen beim Indexieren zu und verwalten ihren Lebenszyklus.
 ---
 
 Der Dokumente-Tab ist die Dateifläche der Wissensdatenbank. Redakteure laden Dateien hoch, Tale schickt jede durch die Indexierungs-Pipeline — Text extrahieren, chunken, die Chunks einbetten, speichern —, und Agenten, deren Wissens-Umfang das Dokument abdeckt, rufen zur Antwortzeit relevante Passagen ab und zitieren sie. Diese Seite behandelt die Operator-Seite: Hochladen, die Status-Spalte, Team-Bindung, Ordner und den Lebenszyklus eines Dokuments.

--- a/docs/de/platform/knowledge/structured-data.md
+++ b/docs/de/platform/knowledge/structured-data.md
@@ -1,6 +1,6 @@
 ---
 title: Strukturierte Daten
-description: Tales Wissensdatenbank bringt drei eingebaute strukturierte Entitäten mit — Kontakte, Produkte, Websites — neben den Dokumenten. Diese Seite gibt dir das mentale Modell dafür, wann ein typisierter Datensatz ein Dokument schlägt.
+description: Tales Wissensdatenbank bringt drei eingebaute strukturierte Entitäten mit — Kontakte, Produkte, Websites — neben den Dokumenten.
 ---
 
 Tales Wissensdatenbank führt zwei Formen nebeneinander. Dokumente sind Text, aus dem der Agent Chunks abruft; strukturierte Datensätze sind typisierte Zeilen, aus denen der Agent Felder liest. Die Form, die du wählst, ist die wichtigste Entscheidung dafür, wie ein Agent dein Wissen nutzt — liegst du falsch, verwässert der Agent entweder eine klare Antwort oder rät bei einem Wert, den du längst vorliegen hast.

--- a/docs/de/platform/member/overview.md
+++ b/docs/de/platform/member/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Mitglied
-description: Mitglied ist die Endbenutzer-Oberfläche — Chat, durch die Wissensdatenbank stöbern, in der Inbox einer installierten Automatisierung antworten. Die Seiten hier sind das, was eine Person mit Mitglieds-Rolle tagtäglich tut.
+description: Mitglied ist die Endbenutzer-Oberfläche — Chat, durch die Wissensdatenbank stöbern, in der Inbox einer installierten Automatisierung antworten.
 ---
 
 Mitglied ist die Standardrolle, die die meisten Personen in den meisten Organisationen tragen. Es ist die Endbenutzer-Oberfläche von Tale — mit dem Assistenten chatten, durch die Wissensdatenbank stöbern, in der Inbox einer installierten Automatisierung auf Kontakt-E-Mails antworten und Feedback zu Antworten hinterlassen. Mitglieder bauen keine Agents, konfigurieren keine Anbieter, installieren keine Automatisierungen. Sie nutzen das Produkt, das die Redakteure und Entwickler für sie gebaut haben.

--- a/docs/de/platform/projects/backlog.md
+++ b/docs/de/platform/projects/backlog.md
@@ -1,6 +1,6 @@
 ---
 title: Projekt-Backlog
-description: Backlog ist der Eingangsstatus des Boards für Arbeit, zu der sich noch niemand verpflichtet hat — wie eine Aufgabe dort landet und wie du sie mit denselben Steuerelementen wie in jeder anderen Spalte weiterbewegst.
+description: Backlog ist der Eingangsstatus des Boards für Arbeit, zu der sich noch niemand verpflichtet hat.
 ---
 
 Eine Aufgabe im Status **Backlog** ist vorgeschlagene Arbeit, zu der sich noch niemand verpflichtet hat. Sie liegt in der linken Spalte des Boards und im obersten Abschnitt der Liste, mit derselben Karte, demselben Detail-Sheet, demselben Status-Picker und demselben Zuweisungs-Picker wie jeder andere Status — Backlog-eigene Steuerelemente gibt es nicht. Nichts Mitgeliefertes füllt die Spalte in dieser Version von selbst: [GitHub-Issues sichten](/de/platform/automations/builtin) bewertet Issues und liefert einen Bericht, und keine Automatisierung synchronisiert Issues in Aufgaben. Das Backlog füllt sich, wenn ein Mensch oder ein Agent einen Vorschlag ablegt.

--- a/docs/de/platform/projects/concepts.md
+++ b/docs/de/platform/projects/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Projekt-Konzepte
-description: Ein Projekt bündelt Chats, Dateien, Anweisungen und Aufgaben in einem geteilten Arbeitsbereich. Diese Seite gibt dir das mentale Modell dafür, wann ein Projekt einen Einzel-Chat schlägt.
+description: Ein Projekt bündelt Chats, Dateien, Anweisungen und Aufgaben in einem geteilten Arbeitsbereich.
 ---
 
 Ein Projekt ist die Einheit, zu der Tale greift, wenn ein Arbeitsvorhaben dieselben Dateien, dieselben Anweisungen und dieselben Arbeitsflächen über viele Chats und viele Personen hinweg braucht. Diese Seite gibt dir das mentale Modell — lies sie, bevor du dein erstes Projekt erstellst, und komm zurück, wenn du entscheidest, ob ein wachsender Chat in eines befördert werden soll.

--- a/docs/de/platform/projects/manage-files.md
+++ b/docs/de/platform/projects/manage-files.md
@@ -1,6 +1,6 @@
 ---
 title: Projekt-Dateien verwalten
-description: Der Wissen-Tab eines Projekts hält die Dateien, aus denen jeder Chat im Projekt schöpfen kann — Ordner, Hochladen, Index-Status und wie Projekt-Dateien auf das Projekt begrenzt bleiben.
+description: Der Wissen-Tab eines Projekts hält die Dateien, aus denen jeder Chat im Projekt schöpfen kann.
 ---
 
 Der **Wissen**-Tab eines Projekts ist der geteilte Dateibereich, den jeder Chat im Projekt erreichen kann. Lade eine Datei einmal hoch, und jeder Chat im Projekt — und jeder Agent, der darin läuft — kann sie ohne erneutes Hochladen lesen. Diese Seite deckt den Ordnerbaum, den Upload-Mechanismus, das Anheften und die Grenzen ab.

--- a/docs/de/platform/projects/overview.md
+++ b/docs/de/platform/projects/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Projekte
-description: Ein Projekt ist ein geteilter Arbeitsbereich, der Chats, Dateien, Anweisungen und Aufgaben rund um ein Stück Arbeit bündelt. Diese Übersicht führt durch die Projekt-Tabs und verweist auf die Seite, die den jeweiligen Tab vertieft.
+description: Ein Projekt ist ein geteilter Arbeitsbereich, der Chats, Dateien, Anweisungen und Aufgaben rund um ein Stück Arbeit bündelt.
 ---
 
 Ein Projekt ist ein geteilter Arbeitsbereich, der alles bündelt, was ein Stück Arbeit braucht — die Chats, die Referenzdateien, die Anweisungen und das Aufgaben-Board —, damit der Kontext der Arbeit folgt, statt in jeden Chat neu kopiert zu werden. Wo ein einzelner Chat eine Frage beantwortet, ist ein Projekt der Ort, an dem ein Team einen Kontakt, einen Launch oder eine länger laufende Untersuchung in Bewegung hält.

--- a/docs/de/self-hosted/configuration/video-ingestion.md
+++ b/docs/de/self-hosted/configuration/video-ingestion.md
@@ -1,6 +1,6 @@
 ---
 title: Video-Ingestion
-description: Konfiguriere, wie eine selbst gehostete Bereitstellung Video-Transkripte an YouTubes Bot-Abfrage vorbei abruft — der eingebaute PO-Token-Provider, ein Egress-Proxy und der vorgewärmte Browser-Session-Pool.
+description: Konfiguriere, wie eine selbst gehostete Bereitstellung Video-Transkripte an YouTubes Bot-Abfrage vorbei abruft.
 ---
 
 Liest Tale einen Videolink ein, ruft es das Transkript des Videos mit `yt-dlp` ab. Video-Plattformen — YouTube am aggressivsten — fordern Anfragen von Rechenzentrums- und Server-IPs mit einer „Bist du ein Mensch?"-Abfrage heraus, sodass eine frische, selbst gehostete Bereitstellung auf einer Cloud-VM beim Einlesen scheitern kann, wo ein Laptop an einem Heimanschluss durchkäme. Diese Seite behandelt die drei Ebenen, die Tale mitbringt, um daran vorbeizukommen — von der, die keine Konfiguration braucht, bis zu der, die am meisten verlangt.

--- a/docs/de/self-hosted/index.md
+++ b/docs/de/self-hosted/index.md
@@ -1,6 +1,6 @@
 ---
 title: Selbst gehostet
-description: Selbst gehostetes Tale läuft auf deiner Infrastruktur — on-premise, in deiner VPC oder air-gapped. Neun Container, deine Daten auf deinem Storage, keine Pro-Sitz-Abrechnung.
+description: Selbst gehostetes Tale läuft auf deiner Infrastruktur — on-premise, in deiner VPC oder air-gapped.
 kind: index
 ---
 

--- a/docs/de/self-hosted/operate/observability/troubleshooting.md
+++ b/docs/de/self-hosted/operate/observability/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-description: Symptomorientierter Index für die Probleme, die Operator auf Tale-Instanzen tatsächlich getroffen haben — was der Benutzer meldet, was kaputt ist und was zu tun ist.
+description: Symptomorientierter Index für die Probleme, die Operator auf Tale-Instanzen tatsächlich getroffen haben.
 ---
 
 Diese Seite ist das symptomorientierte Nachschlagen, wenn jetzt gerade etwas falsch ist. Jeder Abschnitt fängt mit dem an, was der Benutzer tatsächlich meldet — was der Browser zeigt, woran der Agent scheitert, was der Upload-Bildschirm sagt — und geht zurück zur Ursache und zum Fix. Alles, was hier nicht gelistet ist, ist ein Kandidat für einen neuen Abschnitt, sobald es zweimal aufgetaucht ist.

--- a/docs/de/self-hosted/operate/security/audit-log-integrity.md
+++ b/docs/de/self-hosted/operate/security/audit-log-integrity.md
@@ -1,6 +1,6 @@
 ---
 title: Audit-Log-Integritätswarnungen
-description: Wie du reagierst, wenn die tägliche Integritätsprüfung des Audit-Logs eine Warnung auslöst — den Befund lesen, Manipulation von einer harmlosen Konfigurationslücke unterscheiden und Beweise sichern.
+description: Wie du reagierst, wenn die tägliche Integritätsprüfung des Audit-Logs eine Warnung auslöst.
 ---
 
 Tale verifiziert die Audit-Log-Hash-Kette jeder Organisation nach Zeitplan und löst in dem Moment eine Warnung aus, in dem eine Verifizierung fehlschlägt. Diese Seite ist das Runbook für den Operator oder Admin, der diese Warnung erhalten hat: wie du den Befund liest, wie du ein echtes Manipulationssignal von einem gewöhnlichen Aufbewahrungs- oder Konfigurationsartefakt trennst und was du sicherst, bevor du irgendetwas anfasst. Die Warnung ist absichtlich laut, weil ein echter Bruch selten und ernst ist — aber die meisten Brüche, die in der Praxis feuern, haben eine alltägliche Erklärung, also besteht die Arbeit darin, diese methodisch auszuschließen, statt in Panik zu verfallen.

--- a/docs/de/self-hosted/operate/security/cryptography.md
+++ b/docs/de/self-hosted/operate/security/cryptography.md
@@ -1,6 +1,6 @@
 ---
 title: Kryptografie
-description: Die Algorithmen, die Tale für Daten im Ruhezustand, Daten bei der Übertragung, Passwort-Hashing und Audit-Log-Integrität nutzt — und wie sie auf BSI TR-02102-1 abgebildet sind.
+description: Die Algorithmen, die Tale für Daten im Ruhezustand, Daten bei der Übertragung, Passwort-Hashing und Audit-Log-Integrität nutzt.
 ---
 
 Diese Seite ist die Inventur jedes kryptografischen Primitivs, auf das sich Tale stützt: was Secrets auf der Festplatte schützt, was den Verkehr auf der Leitung schützt, wie Passwörter gehasht werden und wie das Audit-Log beweist, dass es nicht manipuliert wurde. Sie ist für Betreiber und Compliance-Prüfer geschrieben, die "welche Algorithmen, welche Schlüssellängen, wo liegen die Schlüssel" gegen einen Standard wie BSI TR-02102-1 beantworten müssen — Tale nutzt bereits konforme Primitive, und auf dieser Seite sind sie festgehalten.

--- a/docs/de/tutorials/editor/first-agent-end-to-end.md
+++ b/docs/de/tutorials/editor/first-agent-end-to-end.md
@@ -1,6 +1,6 @@
 ---
 title: Deinen ersten Agent bauen
-description: Bring ein frisches Projekt von „ich will einen Agent“ zu einem geprüften Aufgaben-Ergebnis — leg einen Projekt-Agenten mit Agent-Laufzeit, Modell und einem Absatz Anweisungen an, gib ihm eine echte Aufgabe und prüfe, was zurückkommt.
+description: Bring ein frisches Projekt von „ich will einen Agent“ zu einem geprüften Aufgaben-Ergebnis.
 ---
 
 Ein erster Agent ist das kleinste nützliche Ding in Tale: ein Name, eine Agent-Laufzeit, ein Modell und ein Absatz Anweisungen im Tab **Agenten** eines Projekts. Dieser Durchlauf legt einen an, gibt ihm eine echte Aufgabe und prüft das Ergebnis dort, wo die Arbeit jedes Agenten wartet — in der Spalte **In Prüfung**. Die Form verallgemeinert sich: Jeder Agent, den du später baust, sind dieselben vier Züge mit anderen Entscheidungen, und die Schleife am Ende ist die, in der du die meiste Zeit verbringst.

--- a/docs/de/tutorials/member/chat-effectively.md
+++ b/docs/de/tutorials/member/chat-effectively.md
@@ -1,6 +1,6 @@
 ---
 title: Effektiv chatten
-description: Fünf Gewohnheiten, die einen Chat von „danke für die Textwand" zu „genau, was ich brauchte" drehen — fragen statt beauftragen, das Modell wählen, Wissen füttern, den Denkverlauf lesen und die Quellen prüfen.
+description: Fünf Gewohnheiten, die einen Chat von „danke für die Textwand" zu „genau, was ich brauchte" drehen.
 ---
 
 Effektives Chatten in Tale dreht sich nicht um clevere Prompts; es dreht sich darum, dem Assistenten genug mitzugeben, damit er deine Absicht beim ersten Lesen erfasst — und zu wissen, welche Arbeit gar nicht in einen Chat gehört. Fünf kleine Gewohnheiten — fragen statt beauftragen, das passende Modell wählen, Wissen füttern statt einfügen, den Denkverlauf lesen, die Quellen prüfen — drehen die durchschnittliche Antwort von „danke für die Textwand" zu „genau, was ich brauchte". Diese Seite geht die Gewohnheiten der Reihe nach in einem frischen Chat durch.

--- a/docs/de/tutorials/member/use-projects.md
+++ b/docs/de/tutorials/member/use-projects.md
@@ -1,6 +1,6 @@
 ---
 title: Projekte nutzen, um Dateien und Chats zu bündeln
-description: Verwandle einen Einmal-Chat in einen geteilten Arbeitsraum, der dieselben Dateien, Instruktionen und Konversationen zusammenhält — und hör auf, jedes Mal dieselben Dokumente erneut hochzuladen.
+description: Verwandle einen Einmal-Chat in einen geteilten Arbeitsraum, der dieselben Dateien, Instruktionen und Konversationen zusammenhält.
 ---
 
 Ein Projekt ist das, wozu du greifst, wenn du dich zum zweiten Mal beim Einkopieren desselben Kontexts in einen Chat ertappst. Es bündelt Dateien, Instruktionen und Chats rund um eine Arbeitssache — einen Kontakt, einen Launch, eine lange Untersuchung — damit jede neue Konversation mit bereits geladenem Kontext beginnt. Dieser Spaziergang führt ein frisches Projekt von „ich lade immer dasselbe Briefing erneut hoch" zu „jeder Chat in diesem Projekt kennt das Briefing schon" auf einer Instanz.

--- a/docs/de/tutorials/videos/index.md
+++ b/docs/de/tutorials/videos/index.md
@@ -1,6 +1,6 @@
 ---
 title: Video-Tutorials
-description: Kurze, produzierte Rundgänge durch die Plattform — was Tale kann, wo KI hilft und wo dein Urteil gefragt bleibt. Jede Episode erscheint auf Deutsch, Englisch und Französisch.
+description: Kurze, produzierte Rundgänge durch die Plattform — was Tale kann, wo KI hilft und wo dein Urteil gefragt bleibt.
 ---
 
 Die Videoserie zeigt dir die Plattform so, wie ein Kollege sie dir zeigen würde: am Bildschirm, Bereich für Bereich, mit den ehrlichen Einschränkungen laut ausgesprochen. Die Episoden sind kurz — drei bis vier Minuten — und jede nimmt nebenbei ein Stück allgemeiner KI-Kompetenz mit: was Verankerung bedeutet, warum Halluzinationen entstehen, wo der Mensch in den Ablauf gehört.

--- a/docs/en/develop/api-reference.md
+++ b/docs/en/develop/api-reference.md
@@ -1,6 +1,6 @@
 ---
 title: API reference
-description: How to call Tale from outside — authentication, the endpoint inventory, pagination, the async run and turn loops, and the error model. The single source of truth for the REST surface.
+description: How to call Tale from outside — authentication, the endpoint inventory, pagination, the async run and turn loops, and the error model.
 i18nLintExclude:
   - terminology-loanword
 ---

--- a/docs/en/get-started/quickstart.md
+++ b/docs/en/get-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: From nothing to your first agent answer — get an instance, sign in, and send your first message. Five minutes on a ready instance, fifteen if you stand one up on your own machine.
+description: From nothing to your first agent answer — get an instance, sign in, and send your first message.
 ---
 
 This is the shortest path to a working chat with an agent: get an instance, sign in, send a message, watch the reply stream. It takes about five minutes on a ready instance and fifteen if you stand one up on your own machine, and it ends with the screen below — a real answer from an agent over your workspace.

--- a/docs/en/platform/admin/enterprise-sso.md
+++ b/docs/en/platform/admin/enterprise-sso.md
@@ -1,6 +1,6 @@
 ---
 title: Enterprise SSO and provisioning
-description: Configure single sign-on (OIDC, OAuth2, SAML 2.0) and SCIM user and group provisioning for your organisation. Step-by-step setup for Microsoft Entra ID, Google, generic OIDC, and SAML, plus role mapping, group-to-team sync, and deactivation. Read this when wiring enterprise identity for the org.
+description: Configure single sign-on (OIDC, OAuth2, SAML 2.0) and SCIM user and group provisioning for your organisation.
 ---
 
 Enterprise SSO lets your members sign in with your identity provider (IdP) instead of a Tale password, and SCIM lets the IdP provision, update, and deactivate members and groups automatically — no manual invites. One connection per organisation carries the sign-in protocol, the provisioning policy, and the SCIM token together. Everything lives on one page: **Settings > Enterprise SSO** (admins only).

--- a/docs/en/platform/admin/governance/audit-logs.md
+++ b/docs/en/platform/admin/governance/audit-logs.md
@@ -1,6 +1,6 @@
 ---
 title: Audit logs
-description: The chronological log of who-did-what across your organisation — sign-ins, role changes, provider edits, agent edits, run-code invocations. Admins and Owners read this when an audit asks who touched a resource and when.
+description: The chronological log of who-did-what across your organisation — sign-ins, role changes, provider edits, agent edits, run-code invocations.
 ---
 
 The audit log is the immutable record of every consequential action inside your organisation. Every sign-in, role change, provider edit, agent save, workflow run, and sandbox invocation lands here with the actor, the resource, the before/after state, and the timestamp. Admins and Owners read this when an audit asks who touched a resource and when, when a compliance officer needs an export, or when something goes sideways and the question is _who changed what at 03:14_.

--- a/docs/en/platform/admin/governance/content-models.md
+++ b/docs/en/platform/admin/governance/content-models.md
@@ -1,6 +1,6 @@
 ---
 title: Content and models
-description: Model-level controls — which models are allowed per role or team, and the default model each user group lands on. Admins and Owners read this when a compliance rule pins a workload to an approved model or when a team needs a cheaper default.
+description: Model-level controls — which models are allowed per role or team, and the default model each user group lands on.
 ---
 
 Content and models is the surface where you decide which LLMs the people in your organisation can reach and which one each group lands on by default. It pairs an allowlist or blocklist per scope (org, team, role) with a default-model rule the resolver applies when no explicit choice has overridden it. Admins and Owners read this page when a compliance rule pins a workload to an approved model, when a team should default to a cheaper model than the rest of the org, or when a new model from an existing provider needs to be made reachable.

--- a/docs/en/platform/admin/governance/data-subject-requests.md
+++ b/docs/en/platform/admin/governance/data-subject-requests.md
@@ -1,6 +1,6 @@
 ---
 title: Data subject requests
-description: The GDPR Article 17 workflow for erasing a person's data across chats, documents, uploads, and preferences. Admins and Owners read this when a user files a request or when an SLA deadline is closing in.
+description: The GDPR Article 17 workflow for erasing a person's data across chats, documents, uploads, and preferences.
 ---
 
 Data subject requests is the workflow Tale ships for honouring GDPR Article 17 (right to erasure) and the equivalent CCPA right under California law. Each request becomes a receipt: it names the subject, the reason code, the SLA deadline, and the cascade of rows the system erased across threads, documents, uploads, and the other rows that identify the subject. Admins and Owners read this page when a subject files a request, when a deadline is closing in, or when an audit asks for the receipt of a past erasure.

--- a/docs/en/platform/admin/governance/feedback-analytics.md
+++ b/docs/en/platform/admin/governance/feedback-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Feedback analytics
-description: Aggregated thumbs-up and thumbs-down on assistant replies plus arena verdicts, broken down per assistant and per model. Admins and Owners read this when an agent regression needs a number behind it.
+description: Aggregated thumbs-up and thumbs-down on assistant replies plus arena verdicts, broken down per assistant and per model.
 ---
 
 Feedback analytics is the dashboard that turns the per-message thumbs and the arena verdicts into trend lines. Members leave the feedback inline in chat; this page aggregates it by assistant, by model, and over time so the regression in last week's voice change is visible as a number, not a hunch. Admins and Owners read this page when a model swap looks like a downgrade, when one assistant is underperforming the others, or when leadership wants the rough quality posture of every assistant in the org.

--- a/docs/en/platform/admin/governance/guardrails.md
+++ b/docs/en/platform/admin/governance/guardrails.md
@@ -1,6 +1,6 @@
 ---
 title: Guardrails
-description: The three filter layers — content safety, PII detection, and a moderation provider — that screen chat inputs and outputs before and after the model. Admins and Owners read this when a regulator names a content rule or when a leak warrants a tighter policy.
+description: The three filter layers — content safety, PII detection, and a moderation provider — that screen chat inputs and outputs before and after the model.
 ---
 
 Guardrails is the surface where you configure the three filter layers Tale runs on every chat message in your organisation. Each message passes through content safety (word lists and admin regex), then PII detection (built-in patterns plus custom), then an optional external moderation provider — in that fixed order, on the way in and on the way out. Admins and Owners read this page when a regulator names a content rule, when a leak warrants a tighter policy, or when an agent's replies need to be sanitised before they leave the model.

--- a/docs/en/platform/admin/governance/legal-hold.md
+++ b/docs/en/platform/admin/governance/legal-hold.md
@@ -1,6 +1,6 @@
 ---
 title: Legal hold
-description: The dual-controlled freeze that pauses retention sweeps and erasure cascades for a specific user or the whole organisation during litigation. Admins and Owners read this when counsel asks them to preserve evidence.
+description: The dual-controlled freeze that pauses retention sweeps and erasure cascades for a specific user or the whole organisation during litigation.
 ---
 
 Legal hold is the mechanism Tale ships for preserving evidence under litigation hold. A hold pins a target — a user as custodian, or the whole organisation — out of reach of the retention sweep and the data-subject erasure cascade. Admins and Owners read this page when counsel asks them to preserve a custodian's data, when a release request needs the dual-control sign-off, or when an audit reconciles which holds were in force on a given date.

--- a/docs/en/platform/admin/governance/policies-and-limits.md
+++ b/docs/en/platform/admin/governance/policies-and-limits.md
@@ -1,6 +1,6 @@
 ---
 title: Policies and limits
-description: Per-org caps on token cost, request count, upload size, image generation, and feature access — scoped by user, team, role, or individual API key. Admins and Owners read this when a workload is over budget or when a feature needs a tighter blast radius.
+description: Per-org caps on token cost, request count, upload size, image generation, and feature access — scoped by user, team, role, or individual API key.
 ---
 
 Policies and limits is the surface where you cap what your members and agents can consume. Budgets cap tokens, cost, and requests per billing period; feature controls cap the context window per scope; upload policy gates the file types and sizes a member can attach; retention policy decides how long each data type lives before cleanup. Admins and Owners read this page when a workload is over budget, when one group's replies should run with a smaller context window, or when a regulator names a retention window that differs from the default.

--- a/docs/en/platform/admin/governance/usage-analytics.md
+++ b/docs/en/platform/admin/governance/usage-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Usage analytics
-description: The dashboard for tokens, cost, and request volume by user, team, model, and agent — with trends and a top-agent leaderboard. Admins and Owners read this when a bill is unexpected or when leadership wants the rough shape of AI spend.
+description: The dashboard for tokens, cost, and request volume by user, team, model, and agent — with trends and a top-agent leaderboard.
 ---
 
 Usage analytics is the dashboard that aggregates every billable AI call into a single view of tokens, cost, and request volume. It slices by user, team, role, model, agent, and time so the unexpected line on the bill is traceable to the workload that drove it. Admins and Owners read this page when a bill is unexpected, when leadership wants the rough shape of AI spend, or when a budget alert fires and the next question is _who and what_.

--- a/docs/en/platform/admin/members-and-roles.md
+++ b/docs/en/platform/admin/members-and-roles.md
@@ -1,6 +1,6 @@
 ---
 title: Members and roles
-description: The six roles that ship with Tale and the resource-level matrix that says who can do what. Admins and Owners read this when they set up a team or when an audit asks who has access to what.
+description: The six roles that ship with Tale and the resource-level matrix that says who can do what.
 ---
 
 Members are the people in your organisation who can sign in to Tale. Roles control what each member can do — read, write, configure, govern. This page is the canonical reference for the six roles and the resource-level permissions each role carries.

--- a/docs/en/platform/admin/overview.md
+++ b/docs/en/platform/admin/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Admin
-description: Admin is the configuration plane — members, teams, providers, API keys, connectors, branding, governance. The pages here are what an Admin or Owner clicks through to set up an org and keep it running.
+description: Admin is the configuration plane — members, teams, providers, API keys, connectors, branding, governance.
 ---
 
 Admin is the configuration plane of Tale. It covers the people who can sign in, the teams that group them, the AI providers behind every reply, the API keys that let external code talk to the org, the third-party connectors agents reach through, and the branding the rest of the org sees. Only Admins and Owners see the full Admin menu; Developers see a subset, and other roles do not see it at all.

--- a/docs/en/platform/admin/teams.md
+++ b/docs/en/platform/admin/teams.md
@@ -1,6 +1,6 @@
 ---
 title: Teams
-description: Teams are named groups of members that share access to documents, projects, skills, and conversations. Admins create and manage teams under Settings > Teams; the boundary they draw is the scoping layer for everything below the role layer.
+description: Teams are named groups of members that share access to documents, projects, skills, and conversations.
 ---
 
 A team is a named group of members that shares access to documents, projects, skills, and conversations. Where roles define what a person _can_ do, teams define which slice of the org's data that person works in. Most orgs end up with a handful of teams — support, sales, ops — and most of the day-to-day permission decisions land on the team boundary, not the role boundary. Admins manage teams under **Settings > Teams**.

--- a/docs/en/platform/admin/two-factor-authentication.md
+++ b/docs/en/platform/admin/two-factor-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Two-factor authentication
-description: TOTP enrolment, passkeys, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator. Read this when wiring 2FA for the org or recovering an account.
+description: TOTP enrolment, passkeys, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator.
 ---
 
 Two-factor authentication adds a second proof of identity on top of the password — a six-digit code from an authenticator app, or a WebAuthn passkey. Tale ships TOTP (time-based one-time passwords) compatible with Google Authenticator, 1Password, Authy, and any other app that follows the standard, plus passkeys for a phishing-resistant alternative. The page covers per-user enrolment, passkeys, the backup codes that recover an account when the phone is gone, the org-wide enforce policy, and the admin reset for a locked-out member.

--- a/docs/en/platform/approvals/concepts.md
+++ b/docs/en/platform/approvals/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Approval concepts
-description: An approval is a parked step in a live automation run — a connector write waiting on the run's detail page until a person approves or rejects it. This page names what fires one, the decision it offers, and what it leaves behind.
+description: An approval is a parked step in a live automation run — a connector write waiting on the run's detail page until a person approves or rejects it.
 ---
 
 An approval is the seam between an automation's initiative and your judgement. When a live run reaches a connector write that your organization's policy gates — sending mail, posting a message, opening an issue — the step does not run: the run parks, and its detail page shows a card with the operation and the exact input the step would call with, until a person decides. Nothing is sent while the card is pending, and a rejected step fails the run rather than being retried behind your back.

--- a/docs/en/platform/chat/overview.md
+++ b/docs/en/platform/chat/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Chat
-description: Chat is where you ask and retrieve — send a message, let Auto pick the model or pin your own, read a reply with its steps and sources visible. This overview maps the screen and draws the line between chat, task, and automation work.
+description: Chat is where you ask and retrieve — send a message, let Auto pick the model or pin your own, read a reply with its steps and sources visible.
 ---
 
 Chat is the everyday entry point to Tale. You ask, the assistant searches the organisation's knowledge or fetches a page when the question needs it, and the reply streams back with every step and source on display. Chat deliberately does one job — questions and retrieval. Work that needs an owner and a reviewable result — a presentation, a translated document, a data export — lives on a task; a fixed process lives in an automation. The assistant knows that boundary and points you to a task the moment a request crosses it, so nothing heavy ever gets half-built inside a chat.

--- a/docs/en/platform/connectors/webdav.md
+++ b/docs/en/platform/connectors/webdav.md
@@ -1,6 +1,6 @@
 ---
 title: WebDAV
-description: Mount your organisation's documents as a network drive in Finder, File Explorer, or any WebDAV client — generate an app-password under Settings > API > WebDAV and connect from your device.
+description: Mount your organisation's documents as a network drive in Finder, File Explorer, or any WebDAV client.
 ---
 
 WebDAV turns Tale's document store into a remote folder you mount like any shared network drive. The backing store is the same one the Document Hub shows — what you drop into the mounted folder appears in the UI, and vice versa. Everything you need is on one panel: **Settings > API > WebDAV** carries the connection details and the app-password generator.

--- a/docs/en/platform/editor/overview.md
+++ b/docs/en/platform/editor/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Editor
-description: Editor is the build surface — creating agents, projects, automations, and the knowledge they reach into. The pages here are what someone with the Editor role does day to day.
+description: Editor is the build surface — creating agents, projects, automations, and the knowledge they reach into.
 ---
 
 Editor is the build surface of Tale. Where Member is the role that runs the product and Admin is the role that governs it, Editor is the role that creates the things everyone else uses — agents, projects, automations, the documents and structured data the knowledge base holds, the prompts saved for the team. People with the Editor role see the full set of build tabs without the admin governance surface and without the developer-only levers.

--- a/docs/en/platform/index.md
+++ b/docs/en/platform/index.md
@@ -1,6 +1,6 @@
 ---
 title: Platform
-description: Platform is the canonical product reference — every user-visible feature, identical for Cloud and self-hosted. Chat, projects, agents, automations, knowledge, approvals, admin.
+description: Platform is the canonical product reference — every user-visible feature, identical for Cloud and self-hosted.
 kind: index
 ---
 

--- a/docs/en/platform/knowledge/documents.md
+++ b/docs/en/platform/knowledge/documents.md
@@ -1,6 +1,6 @@
 ---
 title: Documents
-description: The Documents tab is where Editors upload files into the knowledge base, watch them index, and manage their lifecycle — upload sources, RAG status, team scoping, folders, and reindexing.
+description: The Documents tab is where Editors upload files into the knowledge base, watch them index, and manage their lifecycle.
 ---
 
 The Documents tab is the knowledge base's file surface. Editors upload files, Tale runs each one through the indexing pipeline — extract the text, chunk it, embed the chunks, store them — and agents whose knowledge scope covers the document retrieve relevant passages at reply time and cite them. This page covers the operator side: uploading, the status column, team scoping, folders, and the document lifecycle.

--- a/docs/en/platform/knowledge/overview.md
+++ b/docs/en/platform/knowledge/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Knowledge
-description: Knowledge is the org's shared library — documents, small facts, crawled websites, and typed records — that agents ground their replies in. This overview names the tabs and points at the per-area pages.
+description: Knowledge is the org's shared library — documents, small facts, crawled websites, and typed records — that agents ground their replies in.
 ---
 
 Knowledge is the area where the org's data lives so agents can read and cite it. Editors curate it once; agents retrieve over it at reply time, which is why an agent in Tale can answer with your reality instead of the model's training data. The area opens on five tabs: **Documents**, **Knowledge entries**, **Websites**, **Products**, and **Contacts**.

--- a/docs/en/platform/knowledge/structured-data.md
+++ b/docs/en/platform/knowledge/structured-data.md
@@ -1,6 +1,6 @@
 ---
 title: Structured data
-description: Tale's knowledge base ships three built-in structured entities — Contacts, Products, Websites — alongside Documents. This page hands you the mental model for when to pick a typed record over a document.
+description: Tale's knowledge base ships three built-in structured entities — Contacts, Products, Websites — alongside Documents.
 ---
 
 Tale's knowledge base ships two shapes side by side. Documents are text the agent retrieves chunks from; structured records are typed rows the agent reads fields from. The shape you pick is the most important decision in how an agent will use your knowledge — get it wrong and the agent either dilutes a clear answer or guesses at a value you have on file.

--- a/docs/en/platform/member/overview.md
+++ b/docs/en/platform/member/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Member
-description: Member is the end-user surface — chat, browse the knowledge base, reply in an installed automation's Inbox. The pages here are what someone with the Member role does day to day.
+description: Member is the end-user surface — chat, browse the knowledge base, reply in an installed automation's Inbox.
 ---
 
 Member is the default role most people in most orgs carry. It is the end-user surface of Tale — chat with the assistant, browse the knowledge base, reply to contact email in an installed automation's Inbox, and leave feedback on replies. Members do not build agents, do not configure providers, do not install automations. They use the product the Editors and Developers built for them.

--- a/docs/en/platform/projects/overview.md
+++ b/docs/en/platform/projects/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Projects
-description: A project is a shared workspace that bundles chats, files, instructions, and tasks around one piece of work. This overview maps the project tabs and points to the page that goes deeper on each.
+description: A project is a shared workspace that bundles chats, files, instructions, and tasks around one piece of work.
 ---
 
 A project is a shared workspace that bundles everything one piece of work needs — the chats, the reference files, the instructions, and the task board — so the context follows the work instead of being re-pasted into every chat. Where a single chat answers one question, a project is where a team keeps a contact, a launch, or a long-running investigation moving.

--- a/docs/en/tutorials/member/chat-effectively.md
+++ b/docs/en/tutorials/member/chat-effectively.md
@@ -1,6 +1,6 @@
 ---
 title: Chat effectively
-description: Five habits that turn a chat from "thanks for the wall of text" into "exactly what I needed" — asking instead of commissioning, picking the model, feeding Knowledge, reading the timeline, and checking the sources.
+description: Five habits that turn a chat from "thanks for the wall of text" into "exactly what I needed".
 ---
 
 Chatting effectively in Tale is not about clever prompts; it is about giving the assistant enough to read your intent the first time — and knowing which work does not belong in a chat at all. Five small habits — asking instead of commissioning, picking the right model, feeding Knowledge instead of pasting, reading the thought timeline, and checking the sources — turn the average reply from "thanks for the wall of text" into "exactly what I needed". This page walks the habits in order on a fresh chat.

--- a/docs/en/tutorials/member/use-projects.md
+++ b/docs/en/tutorials/member/use-projects.md
@@ -1,6 +1,6 @@
 ---
 title: Use projects to bundle files and chats
-description: Turn a one-off chat into a shared workspace that keeps the same files, instructions, and conversations together — and stops you from re-uploading the same documents every time.
+description: Turn a one-off chat into a shared workspace that keeps the same files, instructions, and conversations together.
 ---
 
 A project is what you reach for the second time you find yourself pasting the same context into a chat. It bundles files, instructions, and chats around one body of work — a contact, a launch, a long investigation — so every new conversation starts with the context already loaded. This walk takes a fresh project from "I keep re-uploading the same brief" to "every chat inside this project already knows the brief" on one instance.

--- a/docs/en/tutorials/videos/index.md
+++ b/docs/en/tutorials/videos/index.md
@@ -1,6 +1,6 @@
 ---
 title: Video tutorials
-description: Short, produced walkthroughs of the platform — what Tale does, where AI helps, and where it needs your judgment. Every episode ships in English, German, and French.
+description: Short, produced walkthroughs of the platform — what Tale does, where AI helps, and where it needs your judgment.
 ---
 
 The video series walks the platform the way a colleague would show it to you: on screen, area by area, with the honest caveats spoken out loud. Episodes are short — three to four minutes — and each one picks up a piece of general AI literacy along the way: what grounding means, why hallucinations happen, where a human belongs in the loop.

--- a/docs/fr/develop/contributor-setup.md
+++ b/docs/fr/develop/contributor-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration contributeur
-description: La source unique de vérité pour mettre en place le code source de Tale en développement local — prérequis, bun install, la vérification pré-vol, ce que fait bun run dev, les conflits de port et la checklist pré-PR.
+description: La source unique de vérité pour mettre en place le code source de Tale en développement local.
 ---
 
 Cette page est pour les contributeurs qui veulent faire tourner Tale depuis le code source et renvoyer une modification. Elle couvre les prérequis, la mise en place unique, la vérification pré-vol qui détecte une machine cassée avant un long démarrage, et ce que tu peux attendre de `bun run dev`. Ce n'est pas le chemin de l'opérateur — si tu veux faire tourner Tale pour l'utiliser, pas le modifier, le [démarrage rapide auto-hébergé](/fr/self-hosted/install/quickstart) installe la stack empaquetée avec la CLI à la place.

--- a/docs/fr/get-started/quickstart.md
+++ b/docs/fr/get-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Démarrage rapide
-description: De rien à ta première réponse d’agent — obtiens une instance, connecte-toi et envoie ton premier message. Cinq minutes sur une instance prête, quinze si tu en montes une sur ta propre machine.
+description: De rien à ta première réponse d’agent — obtiens une instance, connecte-toi et envoie ton premier message.
 ---
 
 C’est le chemin le plus court vers un chat qui répond : obtenir une instance, se connecter, envoyer un message, regarder la réponse arriver en streaming. Compte environ cinq minutes sur une instance prête et quinze sur ta propre machine ; à la fin tu vois l’écran ci-dessous — une vraie réponse d’un agent sur ton espace de travail.

--- a/docs/fr/platform/admin/api-keys.md
+++ b/docs/fr/platform/admin/api-keys.md
@@ -1,6 +1,6 @@
 ---
 title: Clés API
-description: Identifiants Bearer personnels qui permettent à du code externe d’appeler l’API REST de Tale. Les Administrateurs et Développeurs les créent, rotent et révoquent sous Paramètres > API > REST.
+description: Identifiants Bearer personnels qui permettent à du code externe d’appeler l’API REST de Tale.
 ---
 
 Les clés API sont les identifiants que Tale émet pour qu’un code externe appelle son API REST sans humain dans la boucle. Une clé authentifie l’appelant comme étant la personne qui l’a fabriquée, et porte le rôle de cette personne dans l’organisation. Les Administrateurs et Développeurs gèrent les clés ; les autres rôles ne voient pas la page. Voilà la référence pour ce qu’est une clé, comment en créer une, comment elle est scopée, et comment la retirer sans casser ce qui en dépend.

--- a/docs/fr/platform/admin/changelog.md
+++ b/docs/fr/platform/admin/changelog.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog
-description: Le visualiseur de releases in-produit qui montre ce qui a changé dans la plateforme Tale elle-même. Les Administrateurs lisent ceci après une mise à jour pour voir ce qui a atterri et partager les points saillants avec l'org.
+description: Le visualiseur de releases in-produit qui montre ce qui a changé dans la plateforme Tale elle-même.
 ---
 
 Le changelog est le visualiseur in-produit qui montre les notes de version pour la plateforme Tale elle-même — pas pour le contenu que tes membres produisent. Après une mise à jour auto-hébergée ou un déploiement en cloud géré, le visualiseur liste ce qui a changé entre la version précédente et celle qui tourne maintenant. Les Administrateurs le lisent après une mise à jour pour briefer l'équipe et signaler tout ce qui affecte le travail des membres.

--- a/docs/fr/platform/admin/enterprise-sso.md
+++ b/docs/fr/platform/admin/enterprise-sso.md
@@ -1,6 +1,6 @@
 ---
 title: SSO d’entreprise et provisionnement
-description: Configurer l’authentification unique (OIDC, OAuth2, SAML 2.0) et le provisionnement SCIM des utilisateurs et des groupes pour ton organisation. Configuration pas à pas pour Microsoft Entra ID, Google, OIDC générique et SAML, ainsi que le mappage des rôles, la synchronisation groupe-vers-équipe et la désactivation. À lire pour câbler l’identité d’entreprise de l’organisation.
+description: Configurer l’authentification unique (OIDC, OAuth2, SAML 2.0) et le provisionnement SCIM des utilisateurs et des groupes pour ton organisation.
 ---
 
 Le SSO d’entreprise permet à tes membres de se connecter via ton fournisseur d’identité (IdP) plutôt qu’avec un mot de passe Tale, et SCIM laisse l’IdP créer, mettre à jour et désactiver automatiquement les membres et les groupes — sans invitation manuelle. Une connexion par organisation porte ensemble le protocole de connexion, la politique de provisionnement et le jeton SCIM. Tout se trouve sur une seule page : **Paramètres > SSO d'entreprise** (administrateurs uniquement).

--- a/docs/fr/platform/admin/governance/content-models.md
+++ b/docs/fr/platform/admin/governance/content-models.md
@@ -1,6 +1,6 @@
 ---
 title: Contenu et modèles
-description: Contrôles au niveau modèle — quels modèles sont autorisés par rôle ou équipe, et le modèle par défaut sur lequel chaque groupe d’utilisateurs atterrit. Les Administrateurs et Propriétaires lisent ceci quand une règle de conformité épingle une charge à un modèle approuvé ou quand une équipe a besoin d’un défaut moins cher.
+description: Contrôles au niveau modèle — quels modèles sont autorisés par rôle ou équipe, et le modèle par défaut sur lequel chaque groupe d’utilisateurs atterrit.
 ---
 
 Contenu et modèles est la surface où tu décides quels LLMs les personnes de ton organisation peuvent atteindre et celui sur lequel chaque groupe atterrit par défaut. Elle associe une liste d’autorisation ou de blocage par scope (organisation, équipe, rôle) à une règle de modèle par défaut que le résolveur applique quand aucun choix explicite ne l’a outrepassée. Les Administrateurs et Propriétaires lisent cette page quand une règle de conformité épingle une charge à un modèle approuvé, quand une équipe doit avoir un modèle par défaut moins cher que le reste de l’organisation, ou quand un nouveau modèle d’un fournisseur existant doit être rendu joignable.

--- a/docs/fr/platform/admin/governance/data-subject-requests.md
+++ b/docs/fr/platform/admin/governance/data-subject-requests.md
@@ -1,6 +1,6 @@
 ---
 title: Demandes des personnes concernées
-description: Le workflow RGPD article 17 pour effacer les données d’une personne dans les chats, documents, téléversements et préférences. Les Administrateurs et Propriétaires lisent ceci quand un utilisateur dépose une demande ou quand une échéance SLA approche.
+description: Le workflow RGPD article 17 pour effacer les données d’une personne dans les chats, documents, téléversements et préférences.
 ---
 
 Demandes des personnes concernées est le workflow que Tale livre pour honorer l’article 17 du RGPD (droit à l’effacement) et le droit équivalent CCPA sous la loi californienne. Chaque demande devient un reçu : il nomme la personne concernée, le code de motif, l’échéance SLA et la cascade de lignes que le système a effacées dans les threads, documents, téléversements et les autres lignes qui identifient la personne. Les Administrateurs et Propriétaires lisent cette page quand une personne dépose une demande, quand une échéance approche, ou quand un audit demande le reçu d’un effacement passé.

--- a/docs/fr/platform/admin/governance/feedback-analytics.md
+++ b/docs/fr/platform/admin/governance/feedback-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Analyse des retours
-description: Pouces haut et bas agrégés sur les réponses d'assistant et verdicts d'arène, ventilés par assistant et par modèle. Les Administrateurs et Propriétaires lisent ceci quand une régression d'agent a besoin d'un chiffre derrière.
+description: Pouces haut et bas agrégés sur les réponses d'assistant et verdicts d'arène, ventilés par assistant et par modèle.
 ---
 
 Analyse des retours est le dashboard qui transforme les pouces par message et les verdicts d'arène en courbes de tendance. Les membres laissent le retour inline dans le chat ; cette page l'agrège par assistant, par modèle et dans le temps, pour que la régression du changement de voix de la semaine dernière soit visible comme un chiffre, pas comme un pressentiment. Les Administrateurs et Propriétaires lisent cette page quand un changement de modèle ressemble à une dégradation, quand un assistant performe moins que les autres, ou quand la direction veut la posture qualité approximative de chaque assistant dans l'organisation.

--- a/docs/fr/platform/admin/governance/policies-and-limits.md
+++ b/docs/fr/platform/admin/governance/policies-and-limits.md
@@ -1,6 +1,6 @@
 ---
 title: Politiques et limites
-description: Plafonds par organisation sur le coût des tokens, le nombre de requêtes, la taille d’upload, la génération d’images et l’accès aux fonctionnalités — cadrés par utilisateur, équipe, rôle ou clé API individuelle. Les Administrateurs et Propriétaires lisent ceci quand une charge dépasse le budget ou quand une fonctionnalité a besoin d’un rayon plus serré.
+description: Plafonds par organisation sur le coût des tokens, le nombre de requêtes, la taille d’upload, la génération d’images et l’accès aux fonctionnalités.
 ---
 
 Politiques et limites est la surface où tu plafonnes ce que tes membres et agents peuvent consommer. Les budgets plafonnent les tokens, le coût et les requêtes par période de facturation ; les contrôles de fonctionnalité plafonnent la fenêtre de contexte par scope ; la politique d’upload régit les types et tailles de fichiers qu’un membre peut joindre ; la politique de rétention décide combien de temps chaque type de donnée vit avant le nettoyage. Les Administrateurs et Propriétaires lisent cette page quand une charge dépasse le budget, quand un groupe doit travailler avec une fenêtre de contexte plus petite, ou quand un régulateur nomme une fenêtre de rétention différente du défaut.

--- a/docs/fr/platform/admin/governance/run-code-policy.md
+++ b/docs/fr/platform/admin/governance/run-code-policy.md
@@ -1,6 +1,6 @@
 ---
 title: Politique run-code
-description: La liste d’autorisation et la liste de blocage de paquets qui régissent ce que Run code en sandbox peut installer. Les Administrateurs et Propriétaires lisent ceci quand un agent a besoin d’une nouvelle bibliothèque ou quand un audit demande pourquoi un paquet était bloqué à un moment donné.
+description: La liste d’autorisation et la liste de blocage de paquets qui régissent ce que Run code en sandbox peut installer.
 ---
 
 Politique run-code est la surface où tu décides quels paquets Python et Node la sandbox peut installer à l’exécution. Les skills avec scripts et l’outil Run code tournent tous deux dans la même sandbox ; cette politique est la couture unique où tu serres ou desserres ce qu’ils peuvent installer. Les Administrateurs et Propriétaires lisent cette page quand un agent a besoin d’une nouvelle bibliothèque, ou quand un audit demande pourquoi un paquet était bloqué à un moment donné.

--- a/docs/fr/platform/admin/governance/usage-analytics.md
+++ b/docs/fr/platform/admin/governance/usage-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Analyse d'utilisation
-description: Le dashboard des tokens, du coût et du volume de requêtes par utilisateur, équipe, modèle et agent — avec tendances et un classement des top agents. Les Administrateurs et Propriétaires lisent ceci quand une facture est inattendue ou quand la direction veut la forme approximative des dépenses AI.
+description: Le dashboard des tokens, du coût et du volume de requêtes par utilisateur, équipe, modèle et agent — avec tendances et un classement des top agents.
 ---
 
 Analyse d'utilisation est le dashboard qui agrège chaque appel AI facturable dans une vue unique de tokens, coût et volume de requêtes. Il découpe par utilisateur, équipe, rôle, modèle, agent et temps, pour que la ligne inattendue sur la facture soit traçable jusqu'à la charge qui l'a portée. Les Administrateurs et Propriétaires lisent cette page quand une facture est inattendue, quand la direction veut la forme approximative des dépenses AI, ou quand une alerte de budget se déclenche et la question suivante est _qui et quoi_.

--- a/docs/fr/platform/admin/members-and-roles.md
+++ b/docs/fr/platform/admin/members-and-roles.md
@@ -1,6 +1,6 @@
 ---
 title: Membres et rôles
-description: Les six rôles que Tale ship et la matrice de permissions au niveau ressource qui dit qui peut faire quoi. Les Administrateurs et Propriétaires lisent ceci quand ils montent une équipe ou quand un audit demande qui a quel accès.
+description: Les six rôles que Tale ship et la matrice de permissions au niveau ressource qui dit qui peut faire quoi.
 ---
 
 Les membres sont les personnes de ton organisation qui peuvent se connecter à Tale. Les rôles contrôlent ce que chaque membre peut faire — lire, écrire, configurer, gouverner. Cette page est la référence canonique pour les six rôles et les permissions par ressource que chaque rôle porte.

--- a/docs/fr/platform/admin/overview.md
+++ b/docs/fr/platform/admin/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Admin
-description: Admin est le plan de configuration — membres, équipes, fournisseurs, clés API, connectors, branding, gouvernance. Les pages ici sont ce qu’un Administrateur ou Propriétaire parcourt pour monter une organisation et la faire tourner.
+description: Admin est le plan de configuration — membres, équipes, fournisseurs, clés API, connectors, branding, gouvernance.
 ---
 
 Admin est le plan de configuration de Tale. Cela couvre les personnes qui peuvent se connecter, les équipes qui les regroupent, les fournisseurs IA derrière chaque réponse, les clés API qui permettent à du code externe de parler à l’organisation, les connectors tierces que les agents traversent, et le branding que le reste de l’organisation voit. Seuls les Administrateurs et Propriétaires voient le menu Admin complet ; les Développeurs en voient un sous-ensemble, et les autres rôles ne le voient pas du tout.

--- a/docs/fr/platform/admin/teams.md
+++ b/docs/fr/platform/admin/teams.md
@@ -1,6 +1,6 @@
 ---
 title: Équipes
-description: Les équipes sont des groupes nommés de membres qui partagent l’accès aux documents, projets, skills et conversations. Les Administrateurs créent et gèrent les équipes sous Paramètres > Équipes ; la frontière qu’elles tracent est la couche de cadrage pour tout ce qui est sous la couche de rôle.
+description: Les équipes sont des groupes nommés de membres qui partagent l’accès aux documents, projets, skills et conversations.
 ---
 
 Une équipe est un groupe nommé de membres qui partage l’accès aux documents, projets, skills et conversations. Là où les rôles définissent ce qu’une personne _peut_ faire, les équipes définissent dans quelle tranche des données de l’org cette personne travaille. La plupart des orgs finissent avec une poignée d’équipes — support, ventes, opérations — et la plupart des décisions quotidiennes de permission atterrissent sur la frontière équipe, pas sur la frontière rôle. Les Administrateurs gèrent les équipes sous **Paramètres > Équipes**.

--- a/docs/fr/platform/admin/two-factor-authentication.md
+++ b/docs/fr/platform/admin/two-factor-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Authentification à deux facteurs
-description: Inscription TOTP, passkeys, codes de secours, la politique d’application org-large et comment un admin réinitialise un membre qui a perdu son authenticator. Lis ceci quand tu câbles la 2FA pour l’org ou que tu récupères un compte.
+description: Inscription TOTP, passkeys, codes de secours, la politique d’application org-large et comment un admin réinitialise un membre qui a perdu son authenticator.
 ---
 
 L’authentification à deux facteurs ajoute une seconde preuve d’identité par-dessus le mot de passe — un code à six chiffres d’une appli authenticator, ou un passkey WebAuthn. Tale embarque TOTP (mots de passe à usage unique basés sur le temps) compatible avec Google Authenticator, 1Password, Authy et toute autre appli qui suit le standard, plus les passkeys comme alternative résistante au phishing. La page couvre l’inscription par utilisateur, les passkeys, les codes de secours qui récupèrent un compte quand le téléphone n’est plus là, la politique d’application org-large et la réinitialisation admin pour un membre verrouillé.

--- a/docs/fr/platform/connectors/mcp-servers.md
+++ b/docs/fr/platform/connectors/mcp-servers.md
@@ -1,6 +1,6 @@
 ---
 title: Serveurs MCP
-description: Enregistrer des serveurs MCP externes pour que les agents les appellent ne fait pas partie de cette version — la seule surface MCP de Tale est l’endpoint entrant sous Paramètres > API > MCP.
+description: Enregistrer des serveurs MCP externes pour que les agents les appellent ne fait pas partie de cette version.
 ---
 
 Cette page décrivait un formulaire **Ajouter un serveur MCP** : un transport, une méthode d’authentification, une liste d’agents autorisés et une table d’outils découverts avec un drapeau d’approbation par outil. Rien de tout cela n’existe dans cette version de Tale. Il n’y a ni panneau de serveurs MCP, ni formulaire d’enregistrement, ni trousse d’agent qu’un serveur externe pourrait rejoindre — une capacité qui mènerait à un outil MCP externe est refusée à l’exécution avec une raison lisible. Ce qui est livré, c’est la direction inverse : Tale est lui-même un serveur MCP auquel des clients extérieurs se connectent.

--- a/docs/fr/platform/connectors/webdav.md
+++ b/docs/fr/platform/connectors/webdav.md
@@ -1,6 +1,6 @@
 ---
 title: WebDAV
-description: Monte les documents de ton organisation comme un lecteur réseau dans le Finder, l’Explorateur de fichiers ou n’importe quel client WebDAV — génère un mot de passe applicatif sous Paramètres > API > WebDAV et connecte-toi depuis ton appareil.
+description: Monte les documents de ton organisation comme un lecteur réseau dans le Finder, l’Explorateur de fichiers ou n’importe quel client WebDAV.
 ---
 
 WebDAV transforme le magasin de documents de Tale en un dossier distant que tu montes comme n’importe quel lecteur réseau partagé. Le magasin sous-jacent est le même que celui que montre le hub documentaire — ce que tu déposes dans le dossier monté apparaît dans l’interface, et inversement. Tout ce qu’il te faut tient sur un panneau : **Paramètres > API > WebDAV** porte les détails de connexion et le générateur de mots de passe applicatifs.

--- a/docs/fr/platform/editor/overview.md
+++ b/docs/fr/platform/editor/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Éditeur
-description: Éditeur est la surface de construction — créer agents, projets, automatisations et la connaissance dans laquelle ils s’étendent. Les pages ici sont ce que fait au quotidien une personne de rôle Éditeur.
+description: Éditeur est la surface de construction — créer agents, projets, automatisations et la connaissance dans laquelle ils s’étendent.
 ---
 
 Éditeur est la surface de construction de Tale. Là où Membre est le rôle qui utilise le produit et Administrateur le rôle qui le gouverne, Éditeur est le rôle qui crée les choses que tout le monde consomme — agents, projets, automatisations, les documents et données structurées que tient la base de connaissances, les prompts enregistrés pour l’équipe. Les personnes de rôle Éditeur voient l’ensemble complet d’onglets de construction sans la surface gouvernance admin et sans les leviers réservés aux développeurs.

--- a/docs/fr/platform/index.md
+++ b/docs/fr/platform/index.md
@@ -1,6 +1,6 @@
 ---
 title: Plateforme
-description: Plateforme est la référence produit canonique — chaque fonctionnalité visible par l’utilisateur, identique pour Cloud et auto-hébergé. Chat, projets, agents, automatisations, connaissances, approbations, administration.
+description: Plateforme est la référence produit canonique — chaque fonctionnalité visible par l’utilisateur, identique pour Cloud et auto-hébergé.
 kind: index
 ---
 

--- a/docs/fr/platform/knowledge/documents.md
+++ b/docs/fr/platform/knowledge/documents.md
@@ -1,6 +1,6 @@
 ---
 title: Documents
-description: L’onglet Documents est l’endroit où les éditeurs téléversent des fichiers dans la base de connaissances, suivent leur indexation et gèrent leur cycle de vie — sources de téléversement, statut RAG, portée par équipe, dossiers et réindexation.
+description: L’onglet Documents est l’endroit où les éditeurs téléversent des fichiers dans la base de connaissances, suivent leur indexation et gèrent leur cycle de vie.
 ---
 
 L’onglet Documents est la surface fichiers de la base de connaissances. Les éditeurs téléversent des fichiers, Tale fait passer chacun par le pipeline d’indexation — extraire le texte, le découper, calculer les embeddings, les stocker — et les agents dont le périmètre de connaissances couvre le document récupèrent les passages pertinents au moment de répondre et les citent. Cette page couvre le côté opérateur : le téléversement, la colonne de statut, la portée par équipe, les dossiers et le cycle de vie d’un document.

--- a/docs/fr/platform/knowledge/structured-data.md
+++ b/docs/fr/platform/knowledge/structured-data.md
@@ -1,6 +1,6 @@
 ---
 title: Données structurées
-description: La base de connaissances de Tale embarque trois entités structurées intégrées — Contacts, Produits, Sites web — à côté des Documents. Cette page te donne le modèle mental pour choisir une fiche typée plutôt qu’un document.
+description: La base de connaissances de Tale embarque trois entités structurées intégrées — Contacts, Produits, Sites web — à côté des Documents.
 ---
 
 La base de connaissances de Tale embarque deux formes côte à côte. Les documents sont du texte dont l’agent récupère des fragments ; les fiches structurées sont des lignes typées dont l’agent lit les champs. La forme que tu choisis est la décision la plus lourde dans la façon dont un agent exploitera tes connaissances — trompe-toi et l’agent dilue une réponse claire, ou devine une valeur que tu as pourtant en stock.

--- a/docs/fr/platform/member/overview.md
+++ b/docs/fr/platform/member/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Membre
-description: Membre est la surface utilisateur final — chatter, parcourir la base de connaissances, répondre dans la Boîte de réception d’une automatisation installée. Les pages ici sont ce que fait au quotidien une personne de rôle Membre.
+description: Membre est la surface utilisateur final — chatter, parcourir la base de connaissances, répondre dans la Boîte de réception d’une automatisation installée.
 ---
 
 Membre est le rôle par défaut que portent la plupart des personnes dans la plupart des orgs. C’est la surface utilisateur final de Tale — chatter avec l’assistant, parcourir la base de connaissances, répondre au courriel client dans la Boîte de réception d’une automatisation installée, et laisser des retours sur les réponses. Les Membres ne construisent pas d’agents, ne configurent pas de fournisseurs, n’installent pas d’automatisations. Ils utilisent le produit que les Éditeurs et Développeurs ont bâti pour eux.

--- a/docs/fr/platform/projects/backlog.md
+++ b/docs/fr/platform/projects/backlog.md
@@ -1,6 +1,6 @@
 ---
 title: Backlog du projet
-description: Le Backlog est le statut d’entrée du tableau pour le travail auquel personne ne s’est encore engagé — comment une tâche y atterrit et comment tu la fais avancer avec les mêmes contrôles que dans toute autre colonne.
+description: Le Backlog est le statut d’entrée du tableau pour le travail auquel personne ne s’est encore engagé.
 ---
 
 Une tâche au statut **Backlog** est du travail proposé auquel personne ne s’est encore engagé. Elle vit dans la colonne la plus à gauche du tableau et la section du haut de la liste, avec la même carte, la même fiche de détail, le même sélecteur de statut et le même sélecteur d’affectation que tout autre statut — il n’y a pas de contrôles réservés au backlog. Rien de livré ne remplit la colonne tout seul dans cette version : [Trier les issues GitHub](/fr/platform/automations/builtin) évalue les issues et renvoie un rapport, et aucune automatisation ne synchronise d’issues en tâches. Le Backlog se remplit quand une personne ou un agent dépose une proposition.

--- a/docs/fr/platform/projects/concepts.md
+++ b/docs/fr/platform/projects/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Concepts de projet
-description: Un projet regroupe chats, fichiers, instructions et tâches dans un même espace de travail partagé. Cette page te donne le modèle mental pour savoir quand préférer un projet à un chat isolé.
+description: Un projet regroupe chats, fichiers, instructions et tâches dans un même espace de travail partagé.
 ---
 
 Un projet est l’unité que Tale sort quand un chantier a besoin des mêmes fichiers, des mêmes instructions et des mêmes surfaces de travail à travers beaucoup de chats et beaucoup de personnes. Cette page te donne le modèle mental — lis-la avant de créer ton premier projet, et reviens-y au moment de décider si un chat qui grossit mérite d’être promu en projet.

--- a/docs/fr/platform/projects/overview.md
+++ b/docs/fr/platform/projects/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Projets
-description: Un projet est un espace de travail partagé qui regroupe chats, fichiers, instructions et tâches autour d’un même travail. Cet aperçu cartographie les onglets du projet et pointe vers la page qui approfondit chacun.
+description: Un projet est un espace de travail partagé qui regroupe chats, fichiers, instructions et tâches autour d’un même travail.
 ---
 
 Un projet est un espace de travail partagé qui regroupe tout ce dont un travail a besoin — les chats, les fichiers de référence, les instructions et le tableau des tâches — pour que le contexte suive le travail au lieu d’être recollé dans chaque chat. Là où un chat isolé répond à une question, un projet est l’endroit où une équipe fait avancer un contact, un lancement ou une enquête au long cours.

--- a/docs/fr/self-hosted/configuration/video-ingestion.md
+++ b/docs/fr/self-hosted/configuration/video-ingestion.md
@@ -1,6 +1,6 @@
 ---
 title: Ingestion vidéo
-description: Configure comment un déploiement auto-hébergé récupère les transcriptions vidéo au-delà du mur anti-bot de YouTube — le fournisseur de PO tokens intégré, un proxy de sortie et le pool de sessions de navigateur préchauffées.
+description: Configure comment un déploiement auto-hébergé récupère les transcriptions vidéo au-delà du mur anti-bot de YouTube.
 ---
 
 Quand Tale ingère un lien vidéo, il va chercher la transcription de la vidéo avec `yt-dlp`. Les plateformes vidéo — YouTube le plus agressivement — soumettent les requêtes venant d’IP de centres de données et de serveurs à un mur « confirme que tu n’es pas un robot », si bien qu’un déploiement auto-hébergé tout neuf sur une VM cloud peut voir l’ingestion échouer là où un ordinateur portable sur une connexion domestique réussirait. Cette page couvre les trois couches que Tale fournit pour passer outre, de celle qui ne demande aucune configuration à celle qui en demande le plus.

--- a/docs/fr/self-hosted/index.md
+++ b/docs/fr/self-hosted/index.md
@@ -1,6 +1,6 @@
 ---
 title: Auto-hébergé
-description: Tale auto-hébergé tourne sur ton infrastructure — on-premise, dans ton VPC, ou coupé du réseau. Neuf conteneurs, tes données sur ton stockage, aucune facturation au siège.
+description: Tale auto-hébergé tourne sur ton infrastructure — on-premise, dans ton VPC, ou coupé du réseau.
 kind: index
 ---
 

--- a/docs/fr/self-hosted/install/first-admin.md
+++ b/docs/fr/self-hosted/install/first-admin.md
@@ -1,6 +1,6 @@
 ---
 title: Créer le premier admin
-description: Faire passer une instance auto-hébergée toute neuve par son assistant de configuration unique — le premier compte devient Owner sans clé et les nouveaux arrivent par invitation.
+description: Faire passer une instance auto-hébergée toute neuve par son assistant de configuration unique.
 ---
 
 Une instance Tale toute neuve n'a pas encore d'utilisateurs. La première personne qui l'ouvre déroule un assistant de configuration unique qui crée son compte, la connecte, en fait l'**Owner** et nomme la première organisation — aucune clé de bootstrap, aucune promotion manuelle. Ce parcours couvre ce premier lancement et comment les coéquipiers arrivent ensuite.

--- a/docs/fr/self-hosted/operate/observability/troubleshooting.md
+++ b/docs/fr/self-hosted/operate/observability/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Dépannage
-description: Index par symptôme pour les problèmes que les opérateurs ont réellement rencontrés sur des instances Tale — ce que l'utilisateur rapporte, ce qui est cassé et quoi faire à ce sujet.
+description: Index par symptôme pour les problèmes que les opérateurs ont réellement rencontrés sur des instances Tale.
 ---
 
 Cette page est la recherche par symptôme quand quelque chose ne va pas, là, tout de suite. Chaque section commence par ce que l'utilisateur rapporte réellement — ce que le navigateur affiche, sur quoi l'agent échoue, ce que l'écran de téléversement dit — et remonte à la cause et au fix. Tout ce qui n'est pas listé ici est candidat pour une nouvelle section dès qu'il s'est présenté deux fois.

--- a/docs/fr/self-hosted/operate/security/audit-log-integrity.md
+++ b/docs/fr/self-hosted/operate/security/audit-log-integrity.md
@@ -1,6 +1,6 @@
 ---
 title: Alertes d’intégrité du journal d’audit
-description: Comment réagir quand le contrôle quotidien d’intégrité du journal d’audit lève une alerte — lire le constat, distinguer une falsification d’une lacune de configuration bénigne et préserver les preuves.
+description: Comment réagir quand le contrôle quotidien d’intégrité du journal d’audit lève une alerte.
 ---
 
 Tale vérifie la chaîne de hachage du journal d’audit de chaque organisation selon un planning et lève une alerte à l’instant où une vérification échoue. Cette page est le runbook de l’opérateur ou de l’admin qui a reçu cette alerte : comment lire le constat, comment séparer un vrai signal de falsification d’un artefact ordinaire de rétention ou de configuration, et quoi préserver avant de toucher à quoi que ce soit. L’alerte est volontairement bruyante parce qu’une vraie rupture est rare et grave — mais la plupart des ruptures qui se déclenchent en pratique ont une explication banale, donc le travail consiste à les écarter méthodiquement plutôt qu’à paniquer.

--- a/docs/fr/self-hosted/operate/security/cryptography.md
+++ b/docs/fr/self-hosted/operate/security/cryptography.md
@@ -1,6 +1,6 @@
 ---
 title: Cryptographie
-description: Les algorithmes que Tale utilise pour les données au repos, les données en transit, le hachage des mots de passe et l'intégrité du journal d'audit — et leur correspondance avec BSI TR-02102-1.
+description: Les algorithmes que Tale utilise pour les données au repos, les données en transit, le hachage des mots de passe et l'intégrité du journal d'audit.
 ---
 
 Cette page est l'inventaire de chaque primitive cryptographique sur laquelle Tale s'appuie : ce qui protège les secrets sur le disque, ce qui protège le trafic sur le réseau, comment les mots de passe sont hachés, et comment le journal d'audit prouve qu'il n'a pas été altéré. Elle est écrite pour les opérateurs et les auditeurs de conformité qui doivent répondre à « quels algorithmes, quelles longueurs de clé, où sont les clés » face à une norme comme BSI TR-02102-1 — Tale utilise déjà des primitives conformes, et cette page est l'endroit où elles sont consignées.

--- a/docs/fr/tutorials/admin/meeting-transcription.md
+++ b/docs/fr/tutorials/admin/meeting-transcription.md
@@ -1,5 +1,5 @@
 ---
-title: Piper les transcriptions de réunions dans la Base de connaissances
+title: Acheminer les transcriptions de réunions
 description: Câble Meetily (ou un outil local de transcription de réunions similaire) dans la Base de connaissances d'un projet Tale pour que les transcriptions atterrissent toutes seules comme documents, sans que personne ne charge un fichier.
 ---
 

--- a/docs/fr/tutorials/member/chat-effectively.md
+++ b/docs/fr/tutorials/member/chat-effectively.md
@@ -1,6 +1,6 @@
 ---
 title: Chatter efficacement
-description: Cinq habitudes qui font passer un chat de « merci pour le pavé » à « exactement ce qu’il me fallait » — demander au lieu de passer commande, choisir le modèle, nourrir la base de connaissances, lire le déroulé et vérifier les sources.
+description: Cinq habitudes qui font passer un chat de « merci pour le pavé » à « exactement ce qu’il me fallait ».
 ---
 
 Chatter efficacement dans Tale ne tient pas à des prompts astucieux ; il s’agit de donner à l’assistant de quoi lire ton intention du premier coup — et de savoir quel travail n’a pas sa place dans un chat. Cinq petites habitudes — demander au lieu de passer commande, choisir le bon modèle, nourrir la base de connaissances au lieu de coller, lire le déroulé de réflexion, vérifier les sources — font passer la réponse moyenne de « merci pour le pavé » à « exactement ce qu’il me fallait ». Cette page déroule les habitudes dans l’ordre sur un chat neuf.

--- a/docs/fr/tutorials/member/use-projects.md
+++ b/docs/fr/tutorials/member/use-projects.md
@@ -1,6 +1,6 @@
 ---
 title: Utiliser les projets pour grouper fichiers et chats
-description: Transforme un chat ponctuel en espace de travail partagé qui garde ensemble les mêmes fichiers, instructions et conversations — et arrête de re-charger les mêmes documents à chaque fois.
+description: Transforme un chat ponctuel en espace de travail partagé qui garde ensemble les mêmes fichiers, instructions et conversations.
 ---
 
 Un projet est ce vers quoi tu te tournes la deuxième fois que tu te surprends à coller le même contexte dans un chat. Il regroupe fichiers, instructions et chats autour d'une seule chose à faire — un contact, un lancement, une longue enquête — pour que chaque nouvelle conversation démarre avec le contexte déjà chargé. Ce parcours mène un projet neuf de « je recharge sans cesse le même brief » à « chaque chat dans ce projet connaît déjà le brief » sur une seule instance.

--- a/docs/fr/tutorials/videos/index.md
+++ b/docs/fr/tutorials/videos/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tutoriels vidéo
-description: Des visites guidées courtes et produites de la plateforme — ce que fait Tale, où l'IA aide, et où ton jugement reste nécessaire. Chaque épisode existe en français, en anglais et en allemand.
+description: Des visites guidées courtes et produites de la plateforme — ce que fait Tale, où l'IA aide, et où ton jugement reste nécessaire.
 ---
 
 La série vidéo te montre la plateforme comme un collègue le ferait : à l'écran, zone par zone, avec les limites honnêtes dites à voix haute. Les épisodes sont courts — trois à quatre minutes — et chacun aborde au passage un morceau de culture IA : ce que veut dire l'ancrage, pourquoi les hallucinations arrivent, où l'humain garde sa place dans la boucle.

--- a/packages/ui/src/seo/document-meta.ts
+++ b/packages/ui/src/seo/document-meta.ts
@@ -96,4 +96,4 @@ export function useDocumentMeta(meta: DocumentMeta): void {
 // Re-exported so the SSR entry points import the capture seam + serialiser
 // from one place (`@tale/ui/seo/document-meta`).
 export { HeadSinkContext, createHeadSink } from './head-sink';
-export { renderHeadToHtml } from './head-tags';
+export { renderHeadToHtml, resolveFullTitle } from './head-tags';

--- a/packages/ui/src/seo/head-tags.ts
+++ b/packages/ui/src/seo/head-tags.ts
@@ -59,6 +59,15 @@ export type HeadTag =
   | { tag: 'script'; jsonLd: string };
 
 /**
+ * The rendered `<title>`: a page title already naming the site stands on
+ * its own, otherwise the site name is appended. Exported so length budgets
+ * can be asserted against the string a crawler actually sees.
+ */
+export function resolveFullTitle(title: string, siteName = 'Tale'): string {
+  return title.includes(siteName) ? title : `${title} | ${siteName}`;
+}
+
+/**
  * Resolve a page's declared meta into the ordered tag list. Pure — no DOM,
  * no React — so it runs identically on the server and the client.
  */
@@ -82,7 +91,7 @@ export function resolveDocumentHead(meta: DocumentHeadInput): HeadTag[] {
     jsonLd,
   } = meta;
 
-  const fullTitle = title.includes(siteName) ? title : `${title} | ${siteName}`;
+  const fullTitle = resolveFullTitle(title, siteName);
   const resolvedOgImage = ogImage ?? defaultOgImage;
   const tags: HeadTag[] = [];
 

--- a/services/docs/app/content/frontmatter.json
+++ b/services/docs/app/content/frontmatter.json
@@ -147,7 +147,7 @@
     "slug": "tutorials/admin/meeting-transcription",
     "locale": "fr",
     "frontmatter": {
-      "title": "Piper les transcriptions de réunions dans la Base de connaissances",
+      "title": "Acheminer les transcriptions de réunions",
       "description": "Câble Meetily (ou un outil local de transcription de réunions similaire) dans la Base de connaissances d'un projet Tale pour que les transcriptions atterrissent toutes seules comme documents, sans que personne ne charge un fichier."
     }
   },

--- a/services/docs/app/content/frontmatter.json
+++ b/services/docs/app/content/frontmatter.json
@@ -52,7 +52,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Tutoriels vidéo",
-      "description": "Des visites guidées courtes et produites de la plateforme — ce que fait Tale, où l'IA aide, et où ton jugement reste nécessaire. Chaque épisode existe en français, en anglais et en allemand."
+      "description": "Des visites guidées courtes et produites de la plateforme — ce que fait Tale, où l'IA aide, et où ton jugement reste nécessaire."
     }
   },
   "fr:tutorials/videos/governance-and-trust": {
@@ -132,7 +132,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Chatter efficacement",
-      "description": "Cinq habitudes qui font passer un chat de « merci pour le pavé » à « exactement ce qu’il me fallait » — demander au lieu de passer commande, choisir le modèle, nourrir la base de connaissances, lire le déroulé et vérifier les sources."
+      "description": "Cinq habitudes qui font passer un chat de « merci pour le pavé » à « exactement ce qu’il me fallait »."
     }
   },
   "fr:tutorials/member/use-projects": {
@@ -140,7 +140,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Utiliser les projets pour grouper fichiers et chats",
-      "description": "Transforme un chat ponctuel en espace de travail partagé qui garde ensemble les mêmes fichiers, instructions et conversations — et arrête de re-charger les mêmes documents à chaque fois."
+      "description": "Transforme un chat ponctuel en espace de travail partagé qui garde ensemble les mêmes fichiers, instructions et conversations."
     }
   },
   "fr:tutorials/admin/meeting-transcription": {
@@ -220,7 +220,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Plateforme",
-      "description": "Plateforme est la référence produit canonique — chaque fonctionnalité visible par l’utilisateur, identique pour Cloud et auto-hébergé. Chat, projets, agents, automatisations, connaissances, approbations, administration.",
+      "description": "Plateforme est la référence produit canonique — chaque fonctionnalité visible par l’utilisateur, identique pour Cloud et auto-hébergé.",
       "kind": "index"
     }
   },
@@ -229,7 +229,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Éditeur",
-      "description": "Éditeur est la surface de construction — créer agents, projets, automatisations et la connaissance dans laquelle ils s’étendent. Les pages ici sont ce que fait au quotidien une personne de rôle Éditeur."
+      "description": "Éditeur est la surface de construction — créer agents, projets, automatisations et la connaissance dans laquelle ils s’étendent."
     }
   },
   "fr:platform/agents/harnesses": {
@@ -325,7 +325,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Projets",
-      "description": "Un projet est un espace de travail partagé qui regroupe chats, fichiers, instructions et tâches autour d’un même travail. Cet aperçu cartographie les onglets du projet et pointe vers la page qui approfondit chacun."
+      "description": "Un projet est un espace de travail partagé qui regroupe chats, fichiers, instructions et tâches autour d’un même travail."
     }
   },
   "fr:platform/projects/manage-files": {
@@ -357,7 +357,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Backlog du projet",
-      "description": "Le Backlog est le statut d’entrée du tableau pour le travail auquel personne ne s’est encore engagé — comment une tâche y atterrit et comment tu la fais avancer avec les mêmes contrôles que dans toute autre colonne."
+      "description": "Le Backlog est le statut d’entrée du tableau pour le travail auquel personne ne s’est encore engagé."
     }
   },
   "fr:platform/projects/concepts": {
@@ -365,7 +365,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Concepts de projet",
-      "description": "Un projet regroupe chats, fichiers, instructions et tâches dans un même espace de travail partagé. Cette page te donne le modèle mental pour savoir quand préférer un projet à un chat isolé."
+      "description": "Un projet regroupe chats, fichiers, instructions et tâches dans un même espace de travail partagé."
     }
   },
   "fr:platform/connectors/webdav": {
@@ -373,7 +373,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "WebDAV",
-      "description": "Monte les documents de ton organisation comme un lecteur réseau dans le Finder, l’Explorateur de fichiers ou n’importe quel client WebDAV — génère un mot de passe applicatif sous Paramètres > API > WebDAV et connecte-toi depuis ton appareil."
+      "description": "Monte les documents de ton organisation comme un lecteur réseau dans le Finder, l’Explorateur de fichiers ou n’importe quel client WebDAV."
     }
   },
   "fr:platform/connectors/overview": {
@@ -389,7 +389,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Serveurs MCP",
-      "description": "Enregistrer des serveurs MCP externes pour que les agents les appellent ne fait pas partie de cette version — la seule surface MCP de Tale est l’endpoint entrant sous Paramètres > API > MCP."
+      "description": "Enregistrer des serveurs MCP externes pour que les agents les appellent ne fait pas partie de cette version."
     }
   },
   "fr:platform/member/overview": {
@@ -397,7 +397,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Membre",
-      "description": "Membre est la surface utilisateur final — chatter, parcourir la base de connaissances, répondre dans la Boîte de réception d’une automatisation installée. Les pages ici sont ce que fait au quotidien une personne de rôle Membre."
+      "description": "Membre est la surface utilisateur final — chatter, parcourir la base de connaissances, répondre dans la Boîte de réception d’une automatisation installée."
     }
   },
   "fr:platform/member/install-as-app": {
@@ -437,7 +437,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Changelog",
-      "description": "Le visualiseur de releases in-produit qui montre ce qui a changé dans la plateforme Tale elle-même. Les Administrateurs lisent ceci après une mise à jour pour voir ce qui a atterri et partager les points saillants avec l'org."
+      "description": "Le visualiseur de releases in-produit qui montre ce qui a changé dans la plateforme Tale elle-même."
     }
   },
   "fr:platform/admin/overview": {
@@ -445,7 +445,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Admin",
-      "description": "Admin est le plan de configuration — membres, équipes, fournisseurs, clés API, connectors, branding, gouvernance. Les pages ici sont ce qu’un Administrateur ou Propriétaire parcourt pour monter une organisation et la faire tourner."
+      "description": "Admin est le plan de configuration — membres, équipes, fournisseurs, clés API, connectors, branding, gouvernance."
     }
   },
   "fr:platform/admin/enterprise-sso": {
@@ -453,7 +453,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "SSO d’entreprise et provisionnement",
-      "description": "Configurer l’authentification unique (OIDC, OAuth2, SAML 2.0) et le provisionnement SCIM des utilisateurs et des groupes pour ton organisation. Configuration pas à pas pour Microsoft Entra ID, Google, OIDC générique et SAML, ainsi que le mappage des rôles, la synchronisation groupe-vers-équipe et la désactivation. À lire pour câbler l’identité d’entreprise de l’organisation."
+      "description": "Configurer l’authentification unique (OIDC, OAuth2, SAML 2.0) et le provisionnement SCIM des utilisateurs et des groupes pour ton organisation."
     }
   },
   "fr:platform/admin/api-keys": {
@@ -461,7 +461,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Clés API",
-      "description": "Identifiants Bearer personnels qui permettent à du code externe d’appeler l’API REST de Tale. Les Administrateurs et Développeurs les créent, rotent et révoquent sous Paramètres > API > REST."
+      "description": "Identifiants Bearer personnels qui permettent à du code externe d’appeler l’API REST de Tale."
     }
   },
   "fr:platform/admin/governance/audit-logs": {
@@ -477,7 +477,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Contenu et modèles",
-      "description": "Contrôles au niveau modèle — quels modèles sont autorisés par rôle ou équipe, et le modèle par défaut sur lequel chaque groupe d’utilisateurs atterrit. Les Administrateurs et Propriétaires lisent ceci quand une règle de conformité épingle une charge à un modèle approuvé ou quand une équipe a besoin d’un défaut moins cher."
+      "description": "Contrôles au niveau modèle — quels modèles sont autorisés par rôle ou équipe, et le modèle par défaut sur lequel chaque groupe d’utilisateurs atterrit."
     }
   },
   "fr:platform/admin/governance/legal-hold": {
@@ -501,7 +501,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Politiques et limites",
-      "description": "Plafonds par organisation sur le coût des tokens, le nombre de requêtes, la taille d’upload, la génération d’images et l’accès aux fonctionnalités — cadrés par utilisateur, équipe, rôle ou clé API individuelle. Les Administrateurs et Propriétaires lisent ceci quand une charge dépasse le budget ou quand une fonctionnalité a besoin d’un rayon plus serré."
+      "description": "Plafonds par organisation sur le coût des tokens, le nombre de requêtes, la taille d’upload, la génération d’images et l’accès aux fonctionnalités."
     }
   },
   "fr:platform/admin/governance/usage-analytics": {
@@ -509,7 +509,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Analyse d'utilisation",
-      "description": "Le dashboard des tokens, du coût et du volume de requêtes par utilisateur, équipe, modèle et agent — avec tendances et un classement des top agents. Les Administrateurs et Propriétaires lisent ceci quand une facture est inattendue ou quand la direction veut la forme approximative des dépenses AI."
+      "description": "Le dashboard des tokens, du coût et du volume de requêtes par utilisateur, équipe, modèle et agent — avec tendances et un classement des top agents."
     }
   },
   "fr:platform/admin/governance/guardrails": {
@@ -525,7 +525,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Demandes des personnes concernées",
-      "description": "Le workflow RGPD article 17 pour effacer les données d’une personne dans les chats, documents, téléversements et préférences. Les Administrateurs et Propriétaires lisent ceci quand un utilisateur dépose une demande ou quand une échéance SLA approche."
+      "description": "Le workflow RGPD article 17 pour effacer les données d’une personne dans les chats, documents, téléversements et préférences."
     }
   },
   "fr:platform/admin/governance/feedback-analytics": {
@@ -533,7 +533,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Analyse des retours",
-      "description": "Pouces haut et bas agrégés sur les réponses d'assistant et verdicts d'arène, ventilés par assistant et par modèle. Les Administrateurs et Propriétaires lisent ceci quand une régression d'agent a besoin d'un chiffre derrière."
+      "description": "Pouces haut et bas agrégés sur les réponses d'assistant et verdicts d'arène, ventilés par assistant et par modèle."
     }
   },
   "fr:platform/admin/governance/run-code-policy": {
@@ -541,7 +541,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Politique run-code",
-      "description": "La liste d’autorisation et la liste de blocage de paquets qui régissent ce que Run code en sandbox peut installer. Les Administrateurs et Propriétaires lisent ceci quand un agent a besoin d’une nouvelle bibliothèque ou quand un audit demande pourquoi un paquet était bloqué à un moment donné."
+      "description": "La liste d’autorisation et la liste de blocage de paquets qui régissent ce que Run code en sandbox peut installer."
     }
   },
   "fr:platform/admin/connectors": {
@@ -573,7 +573,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Équipes",
-      "description": "Les équipes sont des groupes nommés de membres qui partagent l’accès aux documents, projets, skills et conversations. Les Administrateurs créent et gèrent les équipes sous Paramètres > Équipes ; la frontière qu’elles tracent est la couche de cadrage pour tout ce qui est sous la couche de rôle."
+      "description": "Les équipes sont des groupes nommés de membres qui partagent l’accès aux documents, projets, skills et conversations."
     }
   },
   "fr:platform/admin/two-factor-authentication": {
@@ -581,7 +581,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Authentification à deux facteurs",
-      "description": "Inscription TOTP, passkeys, codes de secours, la politique d’application org-large et comment un admin réinitialise un membre qui a perdu son authenticator. Lis ceci quand tu câbles la 2FA pour l’org ou que tu récupères un compte."
+      "description": "Inscription TOTP, passkeys, codes de secours, la politique d’application org-large et comment un admin réinitialise un membre qui a perdu son authenticator."
     }
   },
   "fr:platform/admin/members-and-roles": {
@@ -589,7 +589,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Membres et rôles",
-      "description": "Les six rôles que Tale ship et la matrice de permissions au niveau ressource qui dit qui peut faire quoi. Les Administrateurs et Propriétaires lisent ceci quand ils montent une équipe ou quand un audit demande qui a quel accès."
+      "description": "Les six rôles que Tale ship et la matrice de permissions au niveau ressource qui dit qui peut faire quoi."
     }
   },
   "fr:platform/admin/branding": {
@@ -605,7 +605,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Données structurées",
-      "description": "La base de connaissances de Tale embarque trois entités structurées intégrées — Contacts, Produits, Sites web — à côté des Documents. Cette page te donne le modèle mental pour choisir une fiche typée plutôt qu’un document."
+      "description": "La base de connaissances de Tale embarque trois entités structurées intégrées — Contacts, Produits, Sites web — à côté des Documents."
     }
   },
   "fr:platform/knowledge/overview": {
@@ -637,7 +637,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Documents",
-      "description": "L’onglet Documents est l’endroit où les éditeurs téléversent des fichiers dans la base de connaissances, suivent leur indexation et gèrent leur cycle de vie — sources de téléversement, statut RAG, portée par équipe, dossiers et réindexation."
+      "description": "L’onglet Documents est l’endroit où les éditeurs téléversent des fichiers dans la base de connaissances, suivent leur indexation et gèrent leur cycle de vie."
     }
   },
   "fr:platform/workspace/skills": {
@@ -670,7 +670,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Dépannage",
-      "description": "Index par symptôme pour les problèmes que les opérateurs ont réellement rencontrés sur des instances Tale — ce que l'utilisateur rapporte, ce qui est cassé et quoi faire à ce sujet."
+      "description": "Index par symptôme pour les problèmes que les opérateurs ont réellement rencontrés sur des instances Tale."
     }
   },
   "fr:self-hosted/operate/observability/prometheus-grafana": {
@@ -702,7 +702,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Alertes d’intégrité du journal d’audit",
-      "description": "Comment réagir quand le contrôle quotidien d’intégrité du journal d’audit lève une alerte — lire le constat, distinguer une falsification d’une lacune de configuration bénigne et préserver les preuves."
+      "description": "Comment réagir quand le contrôle quotidien d’intégrité du journal d’audit lève une alerte."
     }
   },
   "fr:self-hosted/operate/security/cryptography": {
@@ -710,7 +710,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Cryptographie",
-      "description": "Les algorithmes que Tale utilise pour les données au repos, les données en transit, le hachage des mots de passe et l'intégrité du journal d'audit — et leur correspondance avec BSI TR-02102-1."
+      "description": "Les algorithmes que Tale utilise pour les données au repos, les données en transit, le hachage des mots de passe et l'intégrité du journal d'audit."
     }
   },
   "fr:self-hosted/operate/security/hardening": {
@@ -758,7 +758,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Auto-hébergé",
-      "description": "Tale auto-hébergé tourne sur ton infrastructure — on-premise, dans ton VPC, ou coupé du réseau. Neuf conteneurs, tes données sur ton stockage, aucune facturation au siège.",
+      "description": "Tale auto-hébergé tourne sur ton infrastructure — on-premise, dans ton VPC, ou coupé du réseau.",
       "kind": "index"
     }
   },
@@ -799,7 +799,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Créer le premier admin",
-      "description": "Faire passer une instance auto-hébergée toute neuve par son assistant de configuration unique — le premier compte devient Owner sans clé et les nouveaux arrivent par invitation."
+      "description": "Faire passer une instance auto-hébergée toute neuve par son assistant de configuration unique."
     }
   },
   "fr:self-hosted/install/linux-server": {
@@ -872,7 +872,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Ingestion vidéo",
-      "description": "Configure comment un déploiement auto-hébergé récupère les transcriptions vidéo au-delà du mur anti-bot de YouTube — le fournisseur de PO tokens intégré, un proxy de sortie et le pool de sessions de navigateur préchauffées."
+      "description": "Configure comment un déploiement auto-hébergé récupère les transcriptions vidéo au-delà du mur anti-bot de YouTube."
     }
   },
   "fr:self-hosted/configuration/tls-and-domains": {
@@ -963,7 +963,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Démarrage rapide",
-      "description": "De rien à ta première réponse d’agent — obtiens une instance, connecte-toi et envoie ton premier message. Cinq minutes sur une instance prête, quinze si tu en montes une sur ta propre machine."
+      "description": "De rien à ta première réponse d’agent — obtiens une instance, connecte-toi et envoie ton premier message."
     }
   },
   "fr:get-started/editors": {
@@ -1077,7 +1077,7 @@
     "locale": "fr",
     "frontmatter": {
       "title": "Configuration contributeur",
-      "description": "La source unique de vérité pour mettre en place le code source de Tale en développement local — prérequis, bun install, la vérification pré-vol, ce que fait bun run dev, les conflits de port et la checklist pré-PR."
+      "description": "La source unique de vérité pour mettre en place le code source de Tale en développement local."
     }
   },
   "en:tutorials/overview": {
@@ -1133,7 +1133,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Video tutorials",
-      "description": "Short, produced walkthroughs of the platform — what Tale does, where AI helps, and where it needs your judgment. Every episode ships in English, German, and French."
+      "description": "Short, produced walkthroughs of the platform — what Tale does, where AI helps, and where it needs your judgment."
     }
   },
   "en:tutorials/videos/governance-and-trust": {
@@ -1213,7 +1213,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Chat effectively",
-      "description": "Five habits that turn a chat from \"thanks for the wall of text\" into \"exactly what I needed\" — asking instead of commissioning, picking the model, feeding Knowledge, reading the timeline, and checking the sources."
+      "description": "Five habits that turn a chat from \"thanks for the wall of text\" into \"exactly what I needed\"."
     }
   },
   "en:tutorials/member/use-projects": {
@@ -1221,7 +1221,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Use projects to bundle files and chats",
-      "description": "Turn a one-off chat into a shared workspace that keeps the same files, instructions, and conversations together — and stops you from re-uploading the same documents every time."
+      "description": "Turn a one-off chat into a shared workspace that keeps the same files, instructions, and conversations together."
     }
   },
   "en:tutorials/admin/meeting-transcription": {
@@ -1261,7 +1261,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Chat",
-      "description": "Chat is where you ask and retrieve — send a message, let Auto pick the model or pin your own, read a reply with its steps and sources visible. This overview maps the screen and draws the line between chat, task, and automation work."
+      "description": "Chat is where you ask and retrieve — send a message, let Auto pick the model or pin your own, read a reply with its steps and sources visible."
     }
   },
   "en:platform/chat/shared-threads": {
@@ -1301,7 +1301,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Platform",
-      "description": "Platform is the canonical product reference — every user-visible feature, identical for Cloud and self-hosted. Chat, projects, agents, automations, knowledge, approvals, admin.",
+      "description": "Platform is the canonical product reference — every user-visible feature, identical for Cloud and self-hosted.",
       "kind": "index"
     }
   },
@@ -1310,7 +1310,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Editor",
-      "description": "Editor is the build surface — creating agents, projects, automations, and the knowledge they reach into. The pages here are what someone with the Editor role does day to day."
+      "description": "Editor is the build surface — creating agents, projects, automations, and the knowledge they reach into."
     }
   },
   "en:platform/agents/harnesses": {
@@ -1406,7 +1406,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Projects",
-      "description": "A project is a shared workspace that bundles chats, files, instructions, and tasks around one piece of work. This overview maps the project tabs and points to the page that goes deeper on each."
+      "description": "A project is a shared workspace that bundles chats, files, instructions, and tasks around one piece of work."
     }
   },
   "en:platform/projects/manage-files": {
@@ -1454,7 +1454,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "WebDAV",
-      "description": "Mount your organisation's documents as a network drive in Finder, File Explorer, or any WebDAV client — generate an app-password under Settings > API > WebDAV and connect from your device."
+      "description": "Mount your organisation's documents as a network drive in Finder, File Explorer, or any WebDAV client."
     }
   },
   "en:platform/connectors/overview": {
@@ -1478,7 +1478,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Member",
-      "description": "Member is the end-user surface — chat, browse the knowledge base, reply in an installed automation's Inbox. The pages here are what someone with the Member role does day to day."
+      "description": "Member is the end-user surface — chat, browse the knowledge base, reply in an installed automation's Inbox."
     }
   },
   "en:platform/member/install-as-app": {
@@ -1510,7 +1510,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Approval concepts",
-      "description": "An approval is a parked step in a live automation run — a connector write waiting on the run's detail page until a person approves or rejects it. This page names what fires one, the decision it offers, and what it leaves behind."
+      "description": "An approval is a parked step in a live automation run — a connector write waiting on the run's detail page until a person approves or rejects it."
     }
   },
   "en:platform/admin/changelog": {
@@ -1526,7 +1526,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Admin",
-      "description": "Admin is the configuration plane — members, teams, providers, API keys, connectors, branding, governance. The pages here are what an Admin or Owner clicks through to set up an org and keep it running."
+      "description": "Admin is the configuration plane — members, teams, providers, API keys, connectors, branding, governance."
     }
   },
   "en:platform/admin/enterprise-sso": {
@@ -1534,7 +1534,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Enterprise SSO and provisioning",
-      "description": "Configure single sign-on (OIDC, OAuth2, SAML 2.0) and SCIM user and group provisioning for your organisation. Step-by-step setup for Microsoft Entra ID, Google, generic OIDC, and SAML, plus role mapping, group-to-team sync, and deactivation. Read this when wiring enterprise identity for the org."
+      "description": "Configure single sign-on (OIDC, OAuth2, SAML 2.0) and SCIM user and group provisioning for your organisation."
     }
   },
   "en:platform/admin/api-keys": {
@@ -1550,7 +1550,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Audit logs",
-      "description": "The chronological log of who-did-what across your organisation — sign-ins, role changes, provider edits, agent edits, run-code invocations. Admins and Owners read this when an audit asks who touched a resource and when."
+      "description": "The chronological log of who-did-what across your organisation — sign-ins, role changes, provider edits, agent edits, run-code invocations."
     }
   },
   "en:platform/admin/governance/content-models": {
@@ -1558,7 +1558,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Content and models",
-      "description": "Model-level controls — which models are allowed per role or team, and the default model each user group lands on. Admins and Owners read this when a compliance rule pins a workload to an approved model or when a team needs a cheaper default."
+      "description": "Model-level controls — which models are allowed per role or team, and the default model each user group lands on."
     }
   },
   "en:platform/admin/governance/legal-hold": {
@@ -1566,7 +1566,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Legal hold",
-      "description": "The dual-controlled freeze that pauses retention sweeps and erasure cascades for a specific user or the whole organisation during litigation. Admins and Owners read this when counsel asks them to preserve evidence."
+      "description": "The dual-controlled freeze that pauses retention sweeps and erasure cascades for a specific user or the whole organisation during litigation."
     }
   },
   "en:platform/admin/governance/trash": {
@@ -1582,7 +1582,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Policies and limits",
-      "description": "Per-org caps on token cost, request count, upload size, image generation, and feature access — scoped by user, team, role, or individual API key. Admins and Owners read this when a workload is over budget or when a feature needs a tighter blast radius."
+      "description": "Per-org caps on token cost, request count, upload size, image generation, and feature access — scoped by user, team, role, or individual API key."
     }
   },
   "en:platform/admin/governance/usage-analytics": {
@@ -1590,7 +1590,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Usage analytics",
-      "description": "The dashboard for tokens, cost, and request volume by user, team, model, and agent — with trends and a top-agent leaderboard. Admins and Owners read this when a bill is unexpected or when leadership wants the rough shape of AI spend."
+      "description": "The dashboard for tokens, cost, and request volume by user, team, model, and agent — with trends and a top-agent leaderboard."
     }
   },
   "en:platform/admin/governance/guardrails": {
@@ -1598,7 +1598,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Guardrails",
-      "description": "The three filter layers — content safety, PII detection, and a moderation provider — that screen chat inputs and outputs before and after the model. Admins and Owners read this when a regulator names a content rule or when a leak warrants a tighter policy."
+      "description": "The three filter layers — content safety, PII detection, and a moderation provider — that screen chat inputs and outputs before and after the model."
     }
   },
   "en:platform/admin/governance/data-subject-requests": {
@@ -1606,7 +1606,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Data subject requests",
-      "description": "The GDPR Article 17 workflow for erasing a person's data across chats, documents, uploads, and preferences. Admins and Owners read this when a user files a request or when an SLA deadline is closing in."
+      "description": "The GDPR Article 17 workflow for erasing a person's data across chats, documents, uploads, and preferences."
     }
   },
   "en:platform/admin/governance/feedback-analytics": {
@@ -1614,7 +1614,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Feedback analytics",
-      "description": "Aggregated thumbs-up and thumbs-down on assistant replies plus arena verdicts, broken down per assistant and per model. Admins and Owners read this when an agent regression needs a number behind it."
+      "description": "Aggregated thumbs-up and thumbs-down on assistant replies plus arena verdicts, broken down per assistant and per model."
     }
   },
   "en:platform/admin/governance/run-code-policy": {
@@ -1654,7 +1654,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Teams",
-      "description": "Teams are named groups of members that share access to documents, projects, skills, and conversations. Admins create and manage teams under Settings > Teams; the boundary they draw is the scoping layer for everything below the role layer."
+      "description": "Teams are named groups of members that share access to documents, projects, skills, and conversations."
     }
   },
   "en:platform/admin/two-factor-authentication": {
@@ -1662,7 +1662,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Two-factor authentication",
-      "description": "TOTP enrolment, passkeys, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator. Read this when wiring 2FA for the org or recovering an account."
+      "description": "TOTP enrolment, passkeys, backup codes, the org-wide enforce policy, and how an admin resets a member who lost their authenticator."
     }
   },
   "en:platform/admin/members-and-roles": {
@@ -1670,7 +1670,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Members and roles",
-      "description": "The six roles that ship with Tale and the resource-level matrix that says who can do what. Admins and Owners read this when they set up a team or when an audit asks who has access to what."
+      "description": "The six roles that ship with Tale and the resource-level matrix that says who can do what."
     }
   },
   "en:platform/admin/branding": {
@@ -1686,7 +1686,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Structured data",
-      "description": "Tale's knowledge base ships three built-in structured entities — Contacts, Products, Websites — alongside Documents. This page hands you the mental model for when to pick a typed record over a document."
+      "description": "Tale's knowledge base ships three built-in structured entities — Contacts, Products, Websites — alongside Documents."
     }
   },
   "en:platform/knowledge/overview": {
@@ -1694,7 +1694,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Knowledge",
-      "description": "Knowledge is the org's shared library — documents, small facts, crawled websites, and typed records — that agents ground their replies in. This overview names the tabs and points at the per-area pages."
+      "description": "Knowledge is the org's shared library — documents, small facts, crawled websites, and typed records — that agents ground their replies in."
     }
   },
   "en:platform/knowledge/crawling": {
@@ -1718,7 +1718,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Documents",
-      "description": "The Documents tab is where Editors upload files into the knowledge base, watch them index, and manage their lifecycle — upload sources, RAG status, team scoping, folders, and reindexing."
+      "description": "The Documents tab is where Editors upload files into the knowledge base, watch them index, and manage their lifecycle."
     }
   },
   "en:platform/workspace/skills": {
@@ -2044,7 +2044,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "Quickstart",
-      "description": "From nothing to your first agent answer — get an instance, sign in, and send your first message. Five minutes on a ready instance, fifteen if you stand one up on your own machine."
+      "description": "From nothing to your first agent answer — get an instance, sign in, and send your first message."
     }
   },
   "en:get-started/editors": {
@@ -2093,7 +2093,7 @@
     "locale": "en",
     "frontmatter": {
       "title": "API reference",
-      "description": "How to call Tale from outside — authentication, the endpoint inventory, pagination, the async run and turn loops, and the error model. The single source of truth for the REST surface.",
+      "description": "How to call Tale from outside — authentication, the endpoint inventory, pagination, the async run and turn loops, and the error model.",
       "i18nLintExclude": ""
     }
   },
@@ -2190,7 +2190,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Deinen ersten Agent bauen",
-      "description": "Bring ein frisches Projekt von „ich will einen Agent“ zu einem geprüften Aufgaben-Ergebnis — leg einen Projekt-Agenten mit Agent-Laufzeit, Modell und einem Absatz Anweisungen an, gib ihm eine echte Aufgabe und prüfe, was zurückkommt."
+      "description": "Bring ein frisches Projekt von „ich will einen Agent“ zu einem geprüften Aufgaben-Ergebnis."
     }
   },
   "de:tutorials/editor/workflow-with-approvals": {
@@ -2214,7 +2214,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Video-Tutorials",
-      "description": "Kurze, produzierte Rundgänge durch die Plattform — was Tale kann, wo KI hilft und wo dein Urteil gefragt bleibt. Jede Episode erscheint auf Deutsch, Englisch und Französisch."
+      "description": "Kurze, produzierte Rundgänge durch die Plattform — was Tale kann, wo KI hilft und wo dein Urteil gefragt bleibt."
     }
   },
   "de:tutorials/videos/governance-and-trust": {
@@ -2294,7 +2294,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Effektiv chatten",
-      "description": "Fünf Gewohnheiten, die einen Chat von „danke für die Textwand\" zu „genau, was ich brauchte\" drehen — fragen statt beauftragen, das Modell wählen, Wissen füttern, den Denkverlauf lesen und die Quellen prüfen."
+      "description": "Fünf Gewohnheiten, die einen Chat von „danke für die Textwand\" zu „genau, was ich brauchte\" drehen."
     }
   },
   "de:tutorials/member/use-projects": {
@@ -2302,7 +2302,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Projekte nutzen, um Dateien und Chats zu bündeln",
-      "description": "Verwandle einen Einmal-Chat in einen geteilten Arbeitsraum, der dieselben Dateien, Instruktionen und Konversationen zusammenhält — und hör auf, jedes Mal dieselben Dokumente erneut hochzuladen."
+      "description": "Verwandle einen Einmal-Chat in einen geteilten Arbeitsraum, der dieselben Dateien, Instruktionen und Konversationen zusammenhält."
     }
   },
   "de:tutorials/admin/meeting-transcription": {
@@ -2382,7 +2382,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Plattform",
-      "description": "Plattform ist die kanonische Produktreferenz — jedes nutzersichtbare Feature, identisch für Cloud und selbst gehostet. Chat, Projekte, Agents, Automatisierungen, Wissen, Genehmigungen, Verwaltung.",
+      "description": "Plattform ist die kanonische Produktreferenz — jedes nutzersichtbare Feature, identisch für Cloud und selbst gehostet.",
       "kind": "index"
     }
   },
@@ -2391,7 +2391,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Redakteur",
-      "description": "Redakteur ist die Bau-Oberfläche — Agents, Projekte, Automatisierungen und das Wissen erstellen, in das sie reichen. Die Seiten hier sind das, was eine Person mit Redakteurs-Rolle tagtäglich tut."
+      "description": "Redakteur ist die Bau-Oberfläche — Agents, Projekte, Automatisierungen und das Wissen erstellen, in das sie reichen."
     }
   },
   "de:platform/agents/harnesses": {
@@ -2423,7 +2423,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Automatisierungs-Assistent",
-      "description": "Einen Chat-Agent, der auf eine Automatisierung fixiert ist, gibt es in dieser Version nicht — eine Automatisierung bearbeitest du auf ihrer eigenen Seite, und ein Modell verfasst sie über den MCP-Endpoint."
+      "description": "Einen Chat-Agent, der auf eine Automatisierung fixiert ist, gibt es in dieser Version nicht."
     }
   },
   "de:platform/automations/editor": {
@@ -2487,7 +2487,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Projekte",
-      "description": "Ein Projekt ist ein geteilter Arbeitsbereich, der Chats, Dateien, Anweisungen und Aufgaben rund um ein Stück Arbeit bündelt. Diese Übersicht führt durch die Projekt-Tabs und verweist auf die Seite, die den jeweiligen Tab vertieft."
+      "description": "Ein Projekt ist ein geteilter Arbeitsbereich, der Chats, Dateien, Anweisungen und Aufgaben rund um ein Stück Arbeit bündelt."
     }
   },
   "de:platform/projects/manage-files": {
@@ -2495,7 +2495,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Projekt-Dateien verwalten",
-      "description": "Der Wissen-Tab eines Projekts hält die Dateien, aus denen jeder Chat im Projekt schöpfen kann — Ordner, Hochladen, Index-Status und wie Projekt-Dateien auf das Projekt begrenzt bleiben."
+      "description": "Der Wissen-Tab eines Projekts hält die Dateien, aus denen jeder Chat im Projekt schöpfen kann."
     }
   },
   "de:platform/projects/project-agents": {
@@ -2519,7 +2519,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Projekt-Backlog",
-      "description": "Backlog ist der Eingangsstatus des Boards für Arbeit, zu der sich noch niemand verpflichtet hat — wie eine Aufgabe dort landet und wie du sie mit denselben Steuerelementen wie in jeder anderen Spalte weiterbewegst."
+      "description": "Backlog ist der Eingangsstatus des Boards für Arbeit, zu der sich noch niemand verpflichtet hat."
     }
   },
   "de:platform/projects/concepts": {
@@ -2527,7 +2527,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Projekt-Konzepte",
-      "description": "Ein Projekt bündelt Chats, Dateien, Anweisungen und Aufgaben in einem geteilten Arbeitsbereich. Diese Seite gibt dir das mentale Modell dafür, wann ein Projekt einen Einzel-Chat schlägt."
+      "description": "Ein Projekt bündelt Chats, Dateien, Anweisungen und Aufgaben in einem geteilten Arbeitsbereich."
     }
   },
   "de:platform/connectors/webdav": {
@@ -2535,7 +2535,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "WebDAV",
-      "description": "Hänge die Dokumente deiner Organisation als Netzlaufwerk im Finder, im Datei-Explorer oder in jedem WebDAV-Client ein — erzeuge ein App-Passwort unter Einstellungen > API > WebDAV und verbinde dich von deinem Gerät."
+      "description": "Hänge die Dokumente deiner Organisation als Netzlaufwerk im Finder, im Datei-Explorer oder in jedem WebDAV-Client ein."
     }
   },
   "de:platform/connectors/overview": {
@@ -2551,7 +2551,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "MCP-Server",
-      "description": "Externe MCP-Server zu registrieren, damit Agenten sie aufrufen, gibt es in dieser Version nicht — Tales einzige MCP-Oberfläche ist der eingehende Endpoint unter Einstellungen > API > MCP."
+      "description": "Externe MCP-Server zu registrieren, damit Agenten sie aufrufen, gibt es in dieser Version nicht."
     }
   },
   "de:platform/member/overview": {
@@ -2559,7 +2559,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Mitglied",
-      "description": "Mitglied ist die Endbenutzer-Oberfläche — Chat, durch die Wissensdatenbank stöbern, in der Inbox einer installierten Automatisierung antworten. Die Seiten hier sind das, was eine Person mit Mitglieds-Rolle tagtäglich tut."
+      "description": "Mitglied ist die Endbenutzer-Oberfläche — Chat, durch die Wissensdatenbank stöbern, in der Inbox einer installierten Automatisierung antworten."
     }
   },
   "de:platform/member/install-as-app": {
@@ -2599,7 +2599,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Changelog",
-      "description": "Der In-Produkt-Release-Viewer, der zeigt, was sich in der Tale-Plattform selbst geändert hat. Admins lesen das nach einem Upgrade, um zu sehen, was gelandet ist, und um die Highlights mit der Org zu teilen."
+      "description": "Der In-Produkt-Release-Viewer, der zeigt, was sich in der Tale-Plattform selbst geändert hat."
     }
   },
   "de:platform/admin/overview": {
@@ -2607,7 +2607,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Admin",
-      "description": "Admin ist die Konfigurationsebene — Mitglieder, Teams, Anbieter, API-Schlüssel, Connectors, Branding, Richtlinien. Die Seiten hier sind das, was ein Admin oder Inhaber durchklickt, um eine Organisation aufzusetzen und am Laufen zu halten."
+      "description": "Admin ist die Konfigurationsebene — Mitglieder, Teams, Anbieter, API-Schlüssel, Connectors, Branding, Richtlinien."
     }
   },
   "de:platform/admin/enterprise-sso": {
@@ -2615,7 +2615,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Enterprise-SSO und Bereitstellung",
-      "description": "Single Sign-On (OIDC, OAuth2, SAML 2.0) und SCIM-Bereitstellung von Benutzern und Gruppen für deine Organisation konfigurieren. Schritt-für-Schritt-Einrichtung für Microsoft Entra ID, Google, generisches OIDC und SAML, plus Rollenzuordnung, Gruppe-zu-Team-Synchronisierung und Deaktivierung. Lies dies, wenn du die Unternehmensidentität für die Organisation einrichtest."
+      "description": "Single Sign-On (OIDC, OAuth2, SAML 2.0) und SCIM-Bereitstellung von Benutzern und Gruppen für deine Organisation konfigurieren."
     }
   },
   "de:platform/admin/api-keys": {
@@ -2639,7 +2639,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Inhalte und Modelle",
-      "description": "Modell-Ebenen-Kontrollen — welche Modelle pro Rolle oder Team erlaubt sind und das Default-Modell, auf dem jede Benutzergruppe landet. Admins und Inhaber lesen das, wenn eine Compliance-Regel eine Last an ein freigegebenes Modell bindet oder wenn ein Team einen günstigeren Default braucht."
+      "description": "Modell-Ebenen-Kontrollen — welche Modelle pro Rolle oder Team erlaubt sind und das Default-Modell, auf dem jede Benutzergruppe landet."
     }
   },
   "de:platform/admin/governance/legal-hold": {
@@ -2663,7 +2663,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Richtlinien und Limits",
-      "description": "Per-Org-Limits für Token-Kosten, Anzahl Anfragen, Upload-Größe, Bildgenerierung und Feature-Zugriff — eingegrenzt nach Benutzer, Team, Rolle oder einzelnem API-Schlüssel. Admins und Inhaber lesen das, wenn eine Last über Budget ist oder wenn ein Feature einen engeren Radius braucht."
+      "description": "Per-Org-Limits für Token-Kosten, Anzahl Anfragen, Upload-Größe, Bildgenerierung und Feature-Zugriff."
     }
   },
   "de:platform/admin/governance/usage-analytics": {
@@ -2671,7 +2671,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Nutzungs-Analyse",
-      "description": "Das Dashboard für Tokens, Kosten und Anfragenvolumen nach Benutzer, Team, Modell und Agent — mit Trends und einer Top-Agent-Rangliste. Admins und Inhaber lesen das, wenn eine Rechnung unerwartet ist oder wenn die Führung die grobe Form der AI-Ausgaben will."
+      "description": "Das Dashboard für Tokens, Kosten und Anfragenvolumen nach Benutzer, Team, Modell und Agent — mit Trends und einer Top-Agent-Rangliste."
     }
   },
   "de:platform/admin/governance/guardrails": {
@@ -2679,7 +2679,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Guardrails",
-      "description": "Die drei Filterebenen — Inhaltssicherheit, PII-Erkennung und ein Moderationsanbieter — die Chat-Eingaben und -Ausgaben vor und nach dem Modell prüfen. Admins und Inhaber lesen das, wenn ein Regulierer eine Inhaltsregel benennt oder wenn ein Leck eine strengere Richtlinie rechtfertigt."
+      "description": "Die drei Filterebenen — Inhaltssicherheit, PII-Erkennung und ein Moderationsanbieter — die Chat-Eingaben und -Ausgaben vor und nach dem Modell prüfen."
     }
   },
   "de:platform/admin/governance/data-subject-requests": {
@@ -2687,7 +2687,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Anfragen betroffener Personen",
-      "description": "Der Workflow nach DSGVO Artikel 17 zur Löschung der Daten einer Person über Chats, Dokumente, Uploads und Einstellungen hinweg. Admins und Inhaber lesen das, wenn ein Benutzer eine Anfrage stellt oder wenn eine SLA-Frist näher rückt."
+      "description": "Der Workflow nach DSGVO Artikel 17 zur Löschung der Daten einer Person über Chats, Dokumente, Uploads und Einstellungen hinweg."
     }
   },
   "de:platform/admin/governance/feedback-analytics": {
@@ -2695,7 +2695,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Feedback-Analyse",
-      "description": "Aggregierte Daumen-hoch- und Daumen-runter-Bewertungen auf Assistenten-Antworten plus Arena-Urteile, aufgeschlüsselt pro Assistent und pro Modell. Admins und Inhaber lesen das, wenn eine Agent-Regression eine Zahl dahinter braucht."
+      "description": "Aggregierte Daumen-hoch- und Daumen-runter-Bewertungen auf Assistenten-Antworten plus Arena-Urteile, aufgeschlüsselt pro Assistent und pro Modell."
     }
   },
   "de:platform/admin/governance/run-code-policy": {
@@ -2703,7 +2703,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Run-code-Richtlinie",
-      "description": "Die Paket-Zulassungsliste und -Sperrliste, die regeln, was sandgeboxtes Run code installieren darf. Admins und Inhaber lesen das, wenn ein Agent eine neue Bibliothek braucht oder wenn ein Audit fragt, warum ein Paket zu einem bestimmten Zeitpunkt blockiert war."
+      "description": "Die Paket-Zulassungsliste und -Sperrliste, die regeln, was sandgeboxtes Run code installieren darf."
     }
   },
   "de:platform/admin/connectors": {
@@ -2711,7 +2711,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Zugangsdaten für Connectors",
-      "description": "Unter Einstellungen > Connectors legt eine Organisation die Zugangsdaten an, mit denen sich jeder mitgelieferte Connector anmeldet — benennen, zum Standard machen, deaktivieren, neu verbinden."
+      "description": "Unter Einstellungen > Connectors legt eine Organisation die Zugangsdaten an, mit denen sich jeder mitgelieferte Connector anmeldet."
     }
   },
   "de:platform/admin/providers": {
@@ -2735,7 +2735,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Teams",
-      "description": "Teams sind benannte Gruppen von Mitgliedern, die sich Zugriff auf Dokumente, Projekte, Skills und Konversationen teilen. Admins erstellen und verwalten Teams unter Einstellungen > Teams; die Grenze, die sie ziehen, greift überall unterhalb der Rollen-Ebene."
+      "description": "Teams sind benannte Gruppen von Mitgliedern, die sich Zugriff auf Dokumente, Projekte, Skills und Konversationen teilen."
     }
   },
   "de:platform/admin/two-factor-authentication": {
@@ -2751,7 +2751,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Mitglieder und Rollen",
-      "description": "Die sechs Rollen, die Tale mitbringt, und die Berechtigungs-Matrix auf Ressourcen-Ebene, die sagt, wer was darf. Admins und Inhaber lesen das beim Aufsetzen eines Teams oder wenn ein Audit fragt, wer welchen Zugriff hat."
+      "description": "Die sechs Rollen, die Tale mitbringt, und die Berechtigungs-Matrix auf Ressourcen-Ebene, die sagt, wer was darf."
     }
   },
   "de:platform/admin/branding": {
@@ -2767,7 +2767,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Strukturierte Daten",
-      "description": "Tales Wissensdatenbank bringt drei eingebaute strukturierte Entitäten mit — Kontakte, Produkte, Websites — neben den Dokumenten. Diese Seite gibt dir das mentale Modell dafür, wann ein typisierter Datensatz ein Dokument schlägt."
+      "description": "Tales Wissensdatenbank bringt drei eingebaute strukturierte Entitäten mit — Kontakte, Produkte, Websites — neben den Dokumenten."
     }
   },
   "de:platform/knowledge/overview": {
@@ -2799,7 +2799,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Dokumente",
-      "description": "Auf dem Dokumente-Tab laden Redakteure Dateien in die Wissensdatenbank, sehen ihnen beim Indexieren zu und verwalten ihren Lebenszyklus — Upload-Quellen, RAG-Status, Team-Bindung, Ordner und Neuindexierung."
+      "description": "Auf dem Dokumente-Tab laden Redakteure Dateien in die Wissensdatenbank, sehen ihnen beim Indexieren zu und verwalten ihren Lebenszyklus."
     }
   },
   "de:platform/workspace/skills": {
@@ -2832,7 +2832,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Troubleshooting",
-      "description": "Symptomorientierter Index für die Probleme, die Operator auf Tale-Instanzen tatsächlich getroffen haben — was der Benutzer meldet, was kaputt ist und was zu tun ist."
+      "description": "Symptomorientierter Index für die Probleme, die Operator auf Tale-Instanzen tatsächlich getroffen haben."
     }
   },
   "de:self-hosted/operate/observability/prometheus-grafana": {
@@ -2864,7 +2864,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Audit-Log-Integritätswarnungen",
-      "description": "Wie du reagierst, wenn die tägliche Integritätsprüfung des Audit-Logs eine Warnung auslöst — den Befund lesen, Manipulation von einer harmlosen Konfigurationslücke unterscheiden und Beweise sichern."
+      "description": "Wie du reagierst, wenn die tägliche Integritätsprüfung des Audit-Logs eine Warnung auslöst."
     }
   },
   "de:self-hosted/operate/security/cryptography": {
@@ -2872,7 +2872,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Kryptografie",
-      "description": "Die Algorithmen, die Tale für Daten im Ruhezustand, Daten bei der Übertragung, Passwort-Hashing und Audit-Log-Integrität nutzt — und wie sie auf BSI TR-02102-1 abgebildet sind."
+      "description": "Die Algorithmen, die Tale für Daten im Ruhezustand, Daten bei der Übertragung, Passwort-Hashing und Audit-Log-Integrität nutzt."
     }
   },
   "de:self-hosted/operate/security/hardening": {
@@ -2920,7 +2920,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Selbst gehostet",
-      "description": "Selbst gehostetes Tale läuft auf deiner Infrastruktur — on-premise, in deiner VPC oder air-gapped. Neun Container, deine Daten auf deinem Storage, keine Pro-Sitz-Abrechnung.",
+      "description": "Selbst gehostetes Tale läuft auf deiner Infrastruktur — on-premise, in deiner VPC oder air-gapped.",
       "kind": "index"
     }
   },
@@ -3034,7 +3034,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Video-Ingestion",
-      "description": "Konfiguriere, wie eine selbst gehostete Bereitstellung Video-Transkripte an YouTubes Bot-Abfrage vorbei abruft — der eingebaute PO-Token-Provider, ein Egress-Proxy und der vorgewärmte Browser-Session-Pool."
+      "description": "Konfiguriere, wie eine selbst gehostete Bereitstellung Video-Transkripte an YouTubes Bot-Abfrage vorbei abruft."
     }
   },
   "de:self-hosted/configuration/tls-and-domains": {
@@ -3125,7 +3125,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Quickstart",
-      "description": "Von null zur ersten Agent-Antwort — Instanz besorgen, anmelden und die erste Nachricht senden. Fünf Minuten auf einer bereiten Instanz, fünfzehn, wenn du selbst eine aufstellst."
+      "description": "Von null zur ersten Agent-Antwort — Instanz besorgen, anmelden und die erste Nachricht senden."
     }
   },
   "de:get-started/editors": {
@@ -3174,7 +3174,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "API-Referenz",
-      "description": "Wie du Tale von außen aufrufst — Authentifizierung, das Endpoint-Inventar, Pagination, die asynchronen Lauf- und Turn-Schleifen und das Fehlermodell. Die einzige Quelle der Wahrheit für die REST-Oberfläche.",
+      "description": "Wie du Tale von außen aufrufst — Authentifizierung, das Endpoint-Inventar, Pagination, die asynchronen Lauf- und Turn-Schleifen und das Fehlermodell.",
       "i18nLintExclude": ""
     }
   },
@@ -3239,7 +3239,7 @@
     "locale": "de",
     "frontmatter": {
       "title": "Contributor-Setup",
-      "description": "Die zentrale Quelle der Wahrheit für das Aufsetzen von Tales Quellcode zur lokalen Entwicklung — Voraussetzungen, bun install, der Pre-flight-Check, was bun run dev tut, Port-Konflikte und die Pre-PR-Checkliste."
+      "description": "Die zentrale Quelle der Wahrheit für das Aufsetzen von Tales Quellcode zur lokalen Entwicklung."
     }
   }
 }

--- a/services/docs/app/pages/build-meta-title.test.ts
+++ b/services/docs/app/pages/build-meta-title.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression: the docs `<title>` was the bare frontmatter title. That name
+ * also labels the sidebar entry, the breadcrumb and the H1, so it is short
+ * on purpose — "Chat", "Admin", "Teams", "Cloud". As a title it rendered as
+ * little as 11 characters and repeated across sections, which Ahrefs reports
+ * as "Title too short".
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildMetaTitle } from './docs-page';
+
+const SITE = 'Tale documentation';
+const crumbs = (...labels: string[]) => labels.map((label) => ({ label }));
+
+describe('buildMetaTitle', () => {
+  it('trails the top-level section so short names carry context', () => {
+    expect(buildMetaTitle(crumbs('Platform', 'Chat', 'Chat'), SITE)).toBe(
+      'Chat | Platform',
+    );
+    expect(buildMetaTitle(crumbs('Cloud', 'Billing'), SITE)).toBe(
+      'Billing | Cloud',
+    );
+  });
+
+  it('gives a section landing page the site title instead', () => {
+    expect(buildMetaTitle(crumbs('Cloud'), SITE)).toBe(
+      'Cloud | Tale documentation',
+    );
+    expect(buildMetaTitle(crumbs('Develop', 'Develop'), SITE)).toBe(
+      'Develop | Tale documentation',
+    );
+  });
+
+  it('does not repeat a section the page name already carries', () => {
+    expect(
+      buildMetaTitle(
+        crumbs('Self-hosted', 'Install', 'Self-hosted quickstart'),
+        SITE,
+      ),
+    ).toBe('Self-hosted quickstart');
+  });
+
+  it('drops the section rather than overflow 60 rendered characters', () => {
+    const long = 'Pipe meeting transcripts into the Knowledge Base';
+    expect(buildMetaTitle(crumbs('Tutorials', 'Admin', long), SITE)).toBe(long);
+    // `${long} | Tutorials | Tale` would be 67.
+    expect(`${long} | Tale`.length).toBeLessThanOrEqual(60);
+  });
+
+  it('falls back to the site title at the docs root', () => {
+    expect(buildMetaTitle([], SITE)).toBe(SITE);
+  });
+});

--- a/services/docs/app/pages/docs-page.tsx
+++ b/services/docs/app/pages/docs-page.tsx
@@ -8,6 +8,7 @@ import {
   buildWebSiteJsonLd,
 } from '@tale/ui/seo/builders/json-ld';
 import { pageAsMarkdown } from '@tale/ui/seo/builders/page-as-markdown';
+import { resolveFullTitle } from '@tale/ui/seo/document-meta';
 import { useMemo } from 'react';
 
 import { DocsBreadcrumbs } from '@/app/components/docs/docs-breadcrumbs';
@@ -69,6 +70,46 @@ function buildBreadcrumbs(
   });
 }
 
+/**
+ * The `<title>` a crawler sees, before `resolveFullTitle` appends `| Tale`.
+ *
+ * A bare page name is often both too short and not unique: "Chat", "Admin",
+ * "Teams" and "Overview" each name several pages in different sections, so
+ * they render identical titles. Trailing the top-level section disambiguates
+ * them and lifts the shortest ones out of the range Ahrefs reports as
+ * "Title too short".
+ *
+ * The section is dropped when the page name already contains it, so
+ * `self-hosted/install/quickstart` stays "Self-hosted quickstart" instead of
+ * repeating itself. A section landing page has no section to add, so it takes
+ * the localized site title.
+ */
+/** Longest rendered `<title>` a search result will show in full. */
+const TITLE_MAX = 60;
+
+export function buildMetaTitle(
+  breadcrumbs: readonly { label: string }[],
+  siteTitle: string,
+): string {
+  if (breadcrumbs.length === 0) return siteTitle;
+  const page = breadcrumbs[breadcrumbs.length - 1].label;
+  const section = breadcrumbs.length > 1 ? breadcrumbs[0].label : null;
+  // Adding context is only worth it while the result still fits. A page name
+  // long enough to overflow already describes itself.
+  const withinBudget = (candidate: string) =>
+    resolveFullTitle(candidate).length <= TITLE_MAX ? candidate : page;
+  // A section landing page ("Cloud", "Platform") has no section above it, or
+  // repeats its own name as one. Neither has anything to disambiguate with,
+  // so those take the site title instead.
+  if (section === null || section.toLowerCase() === page.toLowerCase()) {
+    return withinBudget(`${page} | ${siteTitle}`);
+  }
+  // The page name already carries the section ("Self-hosted quickstart");
+  // appending it again would only repeat.
+  if (page.toLowerCase().includes(section.toLowerCase())) return page;
+  return withinBudget(`${page} | ${section}`);
+}
+
 function findPrevNext(slug: string): {
   prev: string | null;
   next: string | null;
@@ -94,6 +135,7 @@ function buildAlternates(
 
 export function DocsPage({ locale, slug }: DocsPageProps) {
   const { t } = useT('docs');
+  const { t: tSeo } = useT('seo');
   const doc = getDocPage(locale, slug);
   const breadcrumbs = useMemo(
     () => buildBreadcrumbs(locale, slug),
@@ -168,7 +210,7 @@ export function DocsPage({ locale, slug }: DocsPageProps) {
   }, [doc, url, breadcrumbs, locale, slug]);
 
   useDocumentMeta({
-    title: doc?.frontmatter.title ?? 'Tale documentation',
+    title: buildMetaTitle(breadcrumbs, tSeo('siteTitle')),
     description: doc?.frontmatter.description ?? '',
     canonicalPath: path,
     locale,

--- a/services/docs/messages/de.yml
+++ b/services/docs/messages/de.yml
@@ -1,4 +1,5 @@
 seo:
+  siteTitle: Tale-Dokumentation
   ogImageAlt: Tale — Der Orchestrator für KI-Agents
 nav:
   homeAriaLabel: Tale Dokumentation Startseite

--- a/services/docs/messages/en.yml
+++ b/services/docs/messages/en.yml
@@ -1,4 +1,5 @@
 seo:
+  siteTitle: Tale documentation
   ogImageAlt: Tale — The Orchestrator for AI Agents
 nav:
   homeAriaLabel: Tale documentation home

--- a/services/docs/messages/fr.yml
+++ b/services/docs/messages/fr.yml
@@ -1,4 +1,5 @@
 seo:
+  siteTitle: Documentation Tale
   ogImageAlt: Tale — l’orchestrateur pour agents IA
 nav:
   homeAriaLabel: Accueil de la documentation Tale

--- a/services/docs/tests/frontmatter.test.ts
+++ b/services/docs/tests/frontmatter.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { assertNoFindings, type Finding } from './lib/findings';
 import { hasFrontmatter, parseFrontmatter } from './lib/markdown';
@@ -53,5 +53,36 @@ describe('frontmatter', () => {
       }
     }
     assertNoFindings(findings, 'Frontmatter issues');
+  });
+
+  /**
+   * A description over 160 characters is cut off in a search result, so the
+   * tail is never read. 281 pages were over; 99 shortened cleanly by dropping
+   * a whole trailing sentence or a trailing clause, which leaves grammatical
+   * text in all three languages. The rest need a real rewrite per page: their
+   * commas separate subordinate clauses, not list items, so cutting at one
+   * produces a fragment.
+   *
+   * This budget is a ratchet. It may go down as pages are rewritten; a change
+   * that pushes it up is adding a description nobody will read the end of.
+   */
+  it('does not grow the backlog of over-long descriptions', () => {
+    const MAX = 160;
+    const BUDGET = 182;
+    const over: string[] = [];
+    for (const rel of walkDocs()) {
+      const raw = fs
+        .readFileSync(path.join(CONTENT_ROOT, rel), 'utf8')
+        .replaceAll('\r\n', '\n');
+      if (!hasFrontmatter(raw)) continue;
+      const { frontmatter } = parseFrontmatter(raw);
+      if (/^noindex:\s*true/m.test(frontmatter)) continue;
+      const match = /^description:\s*(.+)$/m.exec(frontmatter);
+      if (match && match[1].trim().length > MAX) over.push(rel);
+    }
+    expect(
+      over.length,
+      `over-long descriptions: ${over.length} (budget ${BUDGET})`,
+    ).toBeLessThanOrEqual(BUDGET);
   });
 });

--- a/services/docs/tests/prerender/seo.test.ts
+++ b/services/docs/tests/prerender/seo.test.ts
@@ -24,6 +24,58 @@ describe('docs prerender SEO suite', () => {
     expect(existsSync(DIST)).toBe(true);
   });
 
+  // Regression: the `<title>` was the bare frontmatter title, which also
+  // labels the sidebar, breadcrumb and H1 and is therefore short on purpose.
+  // Pages rendered as little as 11 characters ("Chat | Tale"), which Ahrefs
+  // reports as "Title too short". Titles now trail their top-level section.
+  describe('title lengths', () => {
+    // Rendered bounds. The floor sits below the docs root title
+    // ("Tale documentation", 18) and well above the 11-character titles
+    // that regressed; the ceiling is what a search result shows in full.
+    const MIN = 15;
+    const MAX = 60;
+
+    function indexablePages(): { path: string; title: string }[] {
+      const out: { path: string; title: string }[] = [];
+      const walk = (dir: string) => {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const full = join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walk(full);
+            continue;
+          }
+          if (entry.name !== 'index.html') continue;
+          const html = readFileSync(full, 'utf8');
+          // Redirect stubs and /404 are noindex; they are not results.
+          if (/name="robots"[^>]*content="[^"]*noindex/i.test(html)) continue;
+          const match = /<title>([\s\S]*?)<\/title>/.exec(html);
+          if (!match) continue;
+          out.push({
+            path: full.slice(DIST.length),
+            title: match[1]
+              .replaceAll('&amp;', '&')
+              .replaceAll('&lt;', '<')
+              .replaceAll('&gt;', '>')
+              .replaceAll('&#39;', "'")
+              .replaceAll('&quot;', '"'),
+          });
+        }
+      };
+      walk(DIST);
+      return out;
+    }
+
+    it('renders every indexable title within the bounds', () => {
+      if (!existsSync(DIST)) return;
+      const pages = indexablePages();
+      expect(pages.length).toBeGreaterThan(100);
+      const offenders = pages
+        .filter((p) => p.title.length < MIN || p.title.length > MAX)
+        .map((p) => `${p.path} (${p.title.length}): ${p.title}`);
+      expect(offenders).toEqual([]);
+    });
+  });
+
   it('prerenders /404 with noindex', () => {
     const html = readHtml('/404');
     expect(html).not.toBeNull();

--- a/services/web/lib/seo/meta-lengths.test.ts
+++ b/services/web/lib/seo/meta-lengths.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Length budgets for the marketing `seo` catalog, asserted against the
+ * strings a crawler sees: the rendered `<title>` (which only gains
+ * ` | Tale` when the title does not already name the site) and the raw
+ * meta description.
+ *
+ * Regression: 12 German and French descriptions ran past 160 characters
+ * and the three changelog descriptions sat under 110, which Ahrefs reports
+ * as "Meta description too long" and "too short"; several page titles
+ * rendered under 30.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { resolveFullTitle } from '@tale/ui/seo/document-meta';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import { SUPPORTED_LOCALES } from '../i18n/locales';
+
+const TITLE_MIN = 30;
+const TITLE_MAX = 60;
+const DESCRIPTION_MIN = 110;
+const DESCRIPTION_MAX = 160;
+
+interface SeoEntry {
+  title: string;
+  description: string;
+}
+
+function seoNamespace(locale: string): Record<string, SeoEntry> {
+  const path = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    'messages',
+    `${locale}.yml`,
+  );
+  const catalog: unknown = parse(readFileSync(path, 'utf8'));
+  const seo =
+    catalog !== null && typeof catalog === 'object' && 'seo' in catalog
+      ? catalog.seo
+      : undefined;
+  if (seo === null || typeof seo !== 'object') {
+    throw new Error(`${locale}.yml has no "seo" namespace`);
+  }
+  const out: Record<string, SeoEntry> = {};
+  for (const [key, value] of Object.entries(seo as Record<string, unknown>)) {
+    if (value === null || typeof value !== 'object') continue;
+    const { title, description } = value as Partial<SeoEntry>;
+    if (typeof title === 'string' && typeof description === 'string') {
+      out[key] = { title, description };
+    }
+  }
+  return out;
+}
+
+describe('marketing seo meta lengths', () => {
+  for (const locale of SUPPORTED_LOCALES) {
+    describe(locale, () => {
+      const entries = Object.entries(seoNamespace(locale));
+
+      it('has an seo entry for every page', () => {
+        expect(entries.length).toBeGreaterThan(0);
+      });
+
+      for (const [key, entry] of entries) {
+        it(`${key} title renders within ${TITLE_MIN}-${TITLE_MAX} characters`, () => {
+          const rendered = resolveFullTitle(entry.title);
+          expect(
+            rendered.length,
+            `${locale}.${key}: "${rendered}"`,
+          ).toBeGreaterThanOrEqual(TITLE_MIN);
+          expect(
+            rendered.length,
+            `${locale}.${key}: "${rendered}"`,
+          ).toBeLessThanOrEqual(TITLE_MAX);
+        });
+
+        it(`${key} description is within ${DESCRIPTION_MIN}-${DESCRIPTION_MAX} characters`, () => {
+          expect(
+            entry.description.length,
+            `${locale}.${key}: "${entry.description}"`,
+          ).toBeGreaterThanOrEqual(DESCRIPTION_MIN);
+          expect(
+            entry.description.length,
+            `${locale}.${key}: "${entry.description}"`,
+          ).toBeLessThanOrEqual(DESCRIPTION_MAX);
+        });
+      }
+    });
+  }
+});

--- a/services/web/messages/de.yml
+++ b/services/web/messages/de.yml
@@ -11,22 +11,23 @@ seo:
       gratis bei Jahresabrechnung. Community ist unter MIT kostenlos selbst
       gehostet.'
   contact:
-    title: Kontakt zum Tale-Team
-    description: Sprich mit dem Tale-Team über selbst gehostete KI für deine
-      Organisation — Plattform, Preise, Hardware oder eine geführte Demo.
-      Antwort innerhalb eines Werktags.
+    title: Kontakt zum Tale-Team — Vertrieb, Support, Demos
+    description: Sprich mit dem Tale-Team über selbst gehostete KI — Plattform,
+      Preise, Hardware oder eine geführte Demo. Antwort innerhalb eines
+      Werktags.
   about:
     title: Wer steht hinter Tale? — Über die Ruler GmbH
     description: Hinter Tale steht die Ruler GmbH, ein Schweizer Unternehmen aus
-      Spiez, gegründet 2020 — herstellerneutral, ISO 27001 & SOC 2 Type II
-      zertifiziert und vollständig Open Source unter MIT.
+      Spiez — herstellerneutral, ISO 27001 & SOC 2 Type II zertifiziert und Open
+      Source unter MIT.
   requestDemo:
-    title: Demo anfragen
-    description: 'Buch eine geführte Tale-Demo: selbst gehostete KI-Agents,
-      Automatisierungen und Governance in Aktion. Für datensensible
-      Organisationen in der Schweiz und der EU.'
+    title: Tale-Demo anfragen — geführter Rundgang
+    description:
+      'Buch eine geführte Tale-Demo: selbst gehostete KI-Agents,
+      Automatisierungen und Governance in Aktion — für datensensible Teams in
+      der Schweiz und der EU.'
   hardwarePricing:
-    title: Was kostet Tale-AI-Hardware?
+    title: Was kostet Tale-AI-Hardware? — mieten, leasen, kaufen
     description: Geräuscharme Inference-Hardware von einzelnen Nodes bis Racks —
       mieten, leasen oder kaufen. Vor Ort mit Remote-Wartung oder in sicheren
       Rechenzentren.
@@ -37,41 +38,43 @@ seo:
       steuert jede Aktion — selbst gehostet für datensensible Teams in der
       Schweiz und der EU.
   platformAgents:
-    title: Was sind Agents in Tale?
+    title: Was sind Agents in Tale? — Anweisungen, Tools, Modell
     description:
       Tale-Agents kombinieren Anweisungen, Wissen, Tools und ein Modell.
       Verbinde Claude Code, Codex, Hermes und OpenClaw unter einem Orchestrator,
       den du hostest.
   platformChat:
-    title: Chats in Tale
+    title: Was ist Chat in Tale? — Zitate, Tool-Aufrufe, Freigaben
     description:
       'Tale Chat ist der Alltagseinstieg: Agent wählen, Nachricht senden,
       gestreamte Antwort lesen — mit Zitaten, Tool-Aufrufen, Arena-Modus und
       Freigaben im Chat.'
   platformAutomations:
-    title: Was sind Automations in Tale?
-    description: Tale Automations bündeln Connectors, Agents und typisierte
-      Workflow-Schritte — Trigger, Bedingungen, Aktionen und menschliche
-      Freigaben auf deiner Infrastruktur.
+    title: Was sind Automations in Tale? — vom Trigger zur Freigabe
+    description:
+      'Tale Automations bündeln Connectors, Agents und typisierte
+      Workflow-Schritte: Trigger, Bedingungen, Aktionen und menschliche
+      Freigaben auf deiner Infrastruktur.'
   platformKnowledge:
-    title: Was ist Knowledge in Tale?
+    title: Was ist Knowledge in Tale? — indexiert und zitiert
     description: Tale Knowledge indexiert Dokumente, Websites und typisierte
       Datensätze, damit Agents deine Realität abrufen und zitieren — nicht nur
       Trainingsdaten.
   platformGovernance:
-    title: Was ist Governance in Tale?
+    title: Was ist Governance in Tale? — Freigaben und Audit-Log
     description: Tale Governance hält Agent-Aktionen hinter Freigabe-Karten,
       schreibt jeden Entscheid ins Audit-Log und filtert PII und unsichere
       Inhalte in beide Richtungen.
   platformProjects:
-    title: Was sind Projekte in Tale?
+    title: Was sind Projekte in Tale? — geteilte Arbeitsbereiche
     description: Tale-Projekte bündeln Chats, Dateien, Anweisungen und ein
-      Task-Board in einem geteilten Arbeitsbereich — weise eine Aufgabe einem
-      Agent zu und prüfe das Ergebnis, bevor es rausgeht.
+      Task-Board — weise eine Aufgabe einem Agent zu und prüfe das Ergebnis,
+      bevor es rausgeht.
   changelog:
     title: Was ist neu in Tale? — Changelog
-    description: Release Notes zu jeder Tale-Version, neueste zuerst —
-      veröffentlicht aus GitHub Releases.
+    description: Release Notes zu jeder Tale-Version, neueste zuerst — Features,
+      Fixes und Breaking Changes jeder Version, veröffentlicht aus GitHub
+      Releases.
 notFound:
   title: Diese Seite gibt es nicht
   body: Die Adresse ist vielleicht vertippt, oder die Seite ist umgezogen. Am

--- a/services/web/messages/en.yml
+++ b/services/web/messages/en.yml
@@ -11,7 +11,7 @@ seo:
       Tale Enterprise is CHF 12 (EUR 14) per user/month, two months free
       on yearly billing. Community is free to self-host under MIT.
   contact:
-    title: Contact the Tale team
+    title: Contact the Tale team — sales, support, demos
     description:
       Talk to the Tale team about self-hosted AI for your organization —
       platform, pricing, hardware, or a guided demo. Replies land within one
@@ -22,7 +22,7 @@ seo:
       in 2020 — vendor-neutral, ISO 27001 & SOC 2 Type II certified, and fully
       open source under MIT.
   requestDemo:
-    title: Request a demo
+    title: Request a Tale demo — a guided walkthrough
     description:
       'Book a guided Tale demo: see self-hosted AI agents, automations,
       and governance in action. Built for data-sensitive organizations in
@@ -39,44 +39,44 @@ seo:
       governs every action — self-hosted for data-sensitive teams in Switzerland
       and the EU.
   platformAgents:
-    title: What are agents in Tale?
+    title: What are agents in Tale? — instructions, tools, models
     description:
       Tale agents combine instructions, knowledge, tools, and a model.
       Connect Claude Code, Codex, Hermes, and OpenClaw under one orchestrator
       you host.
   platformChat:
-    title: Chats in Tale
+    title: What is Chat in Tale? — agents, citations, approvals
     description: 'Tale Chat is the everyday entry point: pick an agent, send a
       message, and read a streamed reply with citations, tool calls, Arena mode,
       and in-chat approvals.'
   platformAutomations:
-    title: What are Automations in Tale?
+    title: What are Automations in Tale? — triggers to approvals
     description: Tale Automations bundle connectors, agents, and typed workflow
       steps — triggers, conditions, actions, and human approvals on
       infrastructure you run.
   platformKnowledge:
-    title: What is Knowledge in Tale?
+    title: What is Knowledge in Tale? — indexed and cited sources
     description:
       Tale Knowledge indexes documents, websites, and typed records so
       agents retrieve and cite your reality instead of model training data
       alone.
   platformGovernance:
-    title: What is Governance in Tale?
+    title: What is Governance in Tale? — approvals and audit trail
     description:
       Tale Governance holds agent actions behind approval cards, writes
       every decision to the audit log, and filters PII and unsafe content in
       both directions.
   platformProjects:
-    title: What are Projects in Tale?
+    title: What are Projects in Tale? — shared agent workspaces
     description:
       Tale Projects bundle chats, files, instructions, and a task board
       into one shared workspace — assign a task to an agent and review the
       result before it ships.
   changelog:
     title: What's new in Tale? — Changelog
-    description:
-      Release notes for every Tale version, newest first — published from
-      GitHub Releases.
+    description: Release notes for every Tale version, newest first — the
+      features, fixes, and breaking changes in each one, published from GitHub
+      Releases.
 notFound:
   title: This page doesn't exist
   body: The address may be mistyped, or the page has moved. The homepage is the

--- a/services/web/messages/fr.yml
+++ b/services/web/messages/fr.yml
@@ -11,33 +11,33 @@ seo:
       'Tale Enterprise : CHF 12 (EUR 14) par utilisateur/mois, deux mois
       offerts en annuel. Community est gratuite en auto-hébergement sous MIT.'
   contact:
-    title: Contacter l’équipe Tale
+    title: Contacter l’équipe Tale — ventes, support, démos
     description:
       Parle à l’équipe Tale de l’IA auto-hébergée pour ton organisation —
       plateforme, tarifs, matériel ou une démo guidée. Réponse sous un jour
       ouvrable.
   about:
     title: Qui est derrière Tale ? — À propos de Ruler GmbH
-    description: Tale est construit par Ruler GmbH, une entreprise suisse de
-      Spiez fondée en 2020 — neutre vis-à-vis des fournisseurs, certifiée ISO
-      27001 & SOC 2 Type II et entièrement open source sous MIT.
+    description: Tale est construit par Ruler GmbH, entreprise suisse de Spiez —
+      neutre vis-à-vis des fournisseurs, certifiée ISO 27001 & SOC 2 Type II,
+      open source sous MIT.
   requestDemo:
-    title: Demander une démo
-    description: 'Réserve une démo guidée de Tale : agents IA auto-hébergés,
-      automatisations et gouvernance en action. Pour les organisations sensibles
-      aux données, en Suisse et dans l’UE.'
+    title: Demander une démo Tale — visite guidée
+    description:
+      'Réserve une démo guidée de Tale : agents IA auto-hébergés,
+      automatisations et gouvernance en action, pour les équipes sensibles aux
+      données.'
   hardwarePricing:
     title: Combien coûte le hardware AI Tale ?
     description:
-      Hardware d’inférence silencieux, du nœud unique au rack — location,
-      leasing ou achat. Déployé sur site avec maintenance à distance, ou hébergé
-      en centres de données sécurisés.
+      'Hardware d’inférence silencieux, du nœud unique au rack : location,
+      leasing ou achat. Sur site avec maintenance à distance, ou en centres de
+      données sécurisés.'
   platform:
     title: Comment fonctionne la plateforme Tale ?
-    description:
-      Tale connecte les agents, regroupe les connaissances, exécute les
-      automations et gouverne chaque action — auto-hébergé pour les équipes
-      sensibles aux données en Suisse et dans l’UE.
+    description: Tale connecte les agents, regroupe les connaissances, exécute
+      les automations et gouverne chaque action — auto-hébergé, en Suisse et
+      dans l’UE.
   platformAgents:
     title: Que sont les agents dans Tale ?
     description:
@@ -45,15 +45,15 @@ seo:
       modèle. Connecte Claude Code, Codex, Hermes et OpenClaw sous un
       orchestrateur que tu héberges.
   platformChat:
-    title: Chats dans Tale
+    title: Qu’est-ce que Chat dans Tale ? — citations et outils
     description: 'Tale Chat, l’entrée du quotidien : choisis un agent, envoie un
       message, lis la réponse — citations, appels d’outils, Arena et
       approbations dans le fil.'
   platformAutomations:
     title: Que sont les Automations dans Tale ?
-    description: Les Automations Tale regroupent connectors, agents et étapes de
-      workflow typées — déclencheurs, conditions, actions et approbations
-      humaines sur ton infrastructure.
+    description:
+      'Les Automations Tale regroupent connectors, agents et étapes de workflow
+      typées : déclencheurs, conditions, actions et approbations humaines.'
   platformKnowledge:
     title: Qu’est-ce que Knowledge dans Tale ?
     description: Tale Knowledge indexe documents, sites et enregistrements typés
@@ -62,18 +62,18 @@ seo:
   platformGovernance:
     title: Qu’est-ce que la gouvernance dans Tale ?
     description: Tale Governance retient les actions des agents sur des cartes
-      d’approbation, écrit chaque décision au journal d’audit et filtre PII et
-      contenus à risque dans les deux sens.
+      d’approbation, journalise chaque décision et filtre PII et contenus à
+      risque.
   platformProjects:
     title: Que sont les Projets dans Tale ?
     description: Les Projets Tale réunissent chats, fichiers, instructions et
-      tableau de tâches dans un espace de travail partagé — assigne une tâche à
-      un agent et relis le résultat avant qu’il parte.
+      tableau de tâches — assigne une tâche à un agent et relis le résultat
+      avant qu’il parte.
   changelog:
     title: Quoi de neuf dans Tale ? — Changelog
-    description:
-      Les notes de version de Tale, de la plus récente à la plus ancienne
-      — publiées depuis GitHub Releases.
+    description: Les notes de version de Tale, de la plus récente à la plus
+      ancienne — fonctionnalités, correctifs et changements de rupture, publiés
+      depuis GitHub Releases.
 notFound:
   title: Cette page n’existe pas
   body:


### PR DESCRIPTION
99 docs page descriptions no longer run past 160 characters, so a search result shows them whole instead of cutting mid-clause. A ratchet holds the remaining backlog at 182 and lets it only shrink.

> Stacked on #3237, which is stacked on #3234. Review those first.

## Why

281 indexable pages carry a description over 160 characters; the longest is 377. Everything past 160 is written but never read.

They split into two shapes. 99 end with something separable: a whole trailing sentence naming the audience ("Admins und Inhaber lesen das, wenn ..."), or a trailing clause after an em-dash. Dropping that leaves a complete sentence that still describes the page.

```
- Der In-Produkt-Release-Viewer, der zeigt, was sich in der Tale-Plattform selbst
  geändert hat. Admins lesen das nach einem Upgrade, um zu sehen, was gelandet
  ist, und um die Highlights mit der Org zu teilen.                        [206]

+ Der In-Produkt-Release-Viewer, der zeigt, was sich in der Tale-Plattform selbst
  geändert hat.                                                             [93]
```

The other 182 do not. Their commas separate subordinate clauses, not list items, so cutting at one leaves a fragment. Two results from an earlier pass that tried:

```
Admins und Entwickler erstellen.
Les connecteurs livrés avec Tale, les identifiants que ton organisation enregistre en face.
```

Those need a rewrite per page, in each language, and are out of scope here.

## What changed

99 `description:` lines under `docs/{en,de,fr}/`, one line per file. Two rules produced all of them, and both keep the text grammatical because they cut at a sentence or clause boundary that already existed:

| Rule | Count |
| --- | --- |
| dropped a whole trailing sentence | 66 |
| dropped the clause after an em-dash | 31 |
| both | 2 |

Nothing was reworded. Every shortened description is a prefix of what the author wrote.

`services/docs/app/content/frontmatter.json` is generated and committed. This commit patches the 99 matching entries in place; a full regeneration reorders all 2,017 of them and would bury the change.

## Risk

Shortening drops detail. The dropped text was always one of two things: an audience line, which is not page content, or an enumeration whose lead sentence already names the subject. The page body still carries all of it.

The rules that could produce a fragment were removed rather than guarded. An earlier version also split enumerations on commas and rebuilt them with the conjunction. It broke German subordinate clauses and mangled digits, so it is not in this branch.

## Tests

`tests/frontmatter.test.ts` counts descriptions over 160 characters on indexable pages and fails above 182.

| Mutation | Result |
| --- | --- |
| restore one of the 99 long descriptions | red, `over-long descriptions: 183 (budget 182)` |

## Scope

Does not close the Ahrefs finding. 182 pages remain over 160 characters, roughly 60 English, 60 German, 62 French, and each needs its own rewrite rather than a cut. The ratchet keeps that number from growing while they are worked down.

Gate: `bun run format`, `lint`, `typecheck`, `lint:sast` clean; docs suite 200 passing.
