### PR TITLE
fix(platform): never let a PII window cut fall inside an identifier

### DIFF
--- a/services/platform/backend/core/knowledge/pii_gate.test.ts
+++ b/services/platform/backend/core/knowledge/pii_gate.test.ts
@@ -135,6 +135,34 @@ describe('applyPiiPolicyForIndexing', () => {
     expect(masked.text).not.toContain('4111 1111 1111 1111');
   });
 
+  // An identifier straddling the window cut: the head is one unbroken word
+  // as long as a window, so the only separators in the cut's range are the
+  // spaces inside the card number itself — the shape of a single-line CSV
+  // export. Pre-fix neither window saw the number: block passed, mask
+  // indexed it raw.
+  const WINDOW_CHARS = 12_500;
+  const STRADDLE = `${'a'.repeat(WINDOW_CHARS - 10)} 4111 1111 1111 1111 rest of the line`;
+
+  it('refuses an identifier that straddles the window cut', () => {
+    const decision = applyPiiPolicyForIndexing(
+      STRADDLE,
+      policy({ mode: 'block', enabledPatterns: ['creditCard'] }),
+    );
+    expect(decision).toEqual({ kind: 'refuse', categoryIds: ['creditCard'] });
+  });
+
+  it('masks an identifier that straddles the window cut', () => {
+    const decision = applyPiiPolicyForIndexing(
+      STRADDLE,
+      policy({ enabledPatterns: ['creditCard'] }),
+    );
+    expect(decision.kind).toBe('index');
+    if (decision.kind !== 'index') return;
+    expect(decision.text).toContain('a [CREDIT_CARD] rest of the line');
+    expect(decision.text).not.toContain('4111');
+    expect(decision.text).not.toContain('1111');
+  });
+
   it('indexes clean text unchanged', () => {
     const clean = 'The handbook covers refunds within 30 days.';
     expect(applyPiiPolicyForIndexing(clean, policy())).toEqual({

--- a/services/platform/backend/core/knowledge/pii_gate.test.ts
+++ b/services/platform/backend/core/knowledge/pii_gate.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
+import { MAX_MESSAGE_BYTES } from '../../../lib/pii';
 import {
   applyPiiPolicyForIndexing,
   parsePiiConfig,
@@ -139,9 +140,11 @@ describe('applyPiiPolicyForIndexing', () => {
   // as long as a window, so the only separators in the cut's range are the
   // spaces inside the card number itself — the shape of a single-line CSV
   // export. Pre-fix neither window saw the number: block passed, mask
-  // indexed it raw.
-  const WINDOW_CHARS = 12_500;
-  const STRADDLE = `${'a'.repeat(WINDOW_CHARS - 10)} 4111 1111 1111 1111 rest of the line`;
+  // indexed it raw. The filler sits outside every pattern's character
+  // classes: on a letter run the email regex backtracks quadratically, and a
+  // policy that enables it would push this file past the test timeout.
+  const WINDOW_CHARS = Math.floor(MAX_MESSAGE_BYTES / 4);
+  const STRADDLE = `${'#'.repeat(WINDOW_CHARS - 10)} 4111 1111 1111 1111 rest of the line`;
 
   it('refuses an identifier that straddles the window cut', () => {
     const decision = applyPiiPolicyForIndexing(
@@ -158,7 +161,7 @@ describe('applyPiiPolicyForIndexing', () => {
     );
     expect(decision.kind).toBe('index');
     if (decision.kind !== 'index') return;
-    expect(decision.text).toContain('a [CREDIT_CARD] rest of the line');
+    expect(decision.text).toContain('# [CREDIT_CARD] rest of the line');
     expect(decision.text).not.toContain('4111');
     expect(decision.text).not.toContain('1111');
   });

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -6878,7 +6878,9 @@ async function checkKnowledge(
         20_000,
       );
       const maskedRow = await ragRow(masked.fileId);
-      const chunkRows = await sql<{ content: string }[]>`
+      // The corpus lives in the organization's knowledge database, not
+      // the app database.
+      const chunkRows = await corpusPool<{ content: string }[]>`
         SELECT c.chunk_content AS content
         FROM private_knowledge.chunks c
         JOIN private_knowledge.documents d ON d.id = c.document_id

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -6827,6 +6827,78 @@ async function checkKnowledge(
         !connectionWritten,
       `probe(verify-ca)=${probeVerifyCa.status}/200 ok=${probeBody.success ? probeBody.data.ok : 'ERR'}/false error=${JSON.stringify(probeBody.success ? (probeBody.data.error ?? '').slice(0, 60) : 'ERR')}, save(blocked host)=${saveBlocked.status}/400 code=${saveBody.success ? saveBody.data.error : 'ERR'}/BLOCKED_HOST written=${connectionWritten}(want false)`,
     );
+
+    // ---- the organization's PII policy at the indexing gate -------------
+    // A `pii_config` policy is applied to every document before it is
+    // chunked or embedded. Driven end to end here — policy file → upload →
+    // rag.index_file on the live worker → `applyPiiPolicyForIndexing` →
+    // rag_status — because no unit test sees the worker read the policy.
+    // The identifier straddles the engine's window cut on purpose: the head
+    // is one word as long as a window (a single-line export), so the only
+    // separators in the cut's range are the card number's own spaces. Pre-
+    // fix neither window saw it — a block policy passed and a mask policy
+    // indexed the raw number.
+    const orgConfig = await import('./lib/org-config.ts');
+    const governanceDir = path.join(configRoot, orgSlug, 'governance');
+    await mkdir(governanceDir, { recursive: true });
+    const piiPolicyPath = path.join(governanceDir, 'pii-config.yml');
+    const straddling = `${'a'.repeat(12_490)} 4111 1111 1111 1111 rest of the export line`;
+    const writePiiPolicy = async (mode: 'block' | 'mask'): Promise<void> => {
+      await writeFile(
+        piiPolicyPath,
+        [
+          'enabled: true',
+          `mode: ${mode}`,
+          'enabledPatterns:',
+          '  - creditCard',
+        ].join('\n'),
+      );
+      orgConfig.clearOrgConfigCaches();
+    };
+    try {
+      await writePiiPolicy('block');
+      const refused = await uploadTextDocument('cards-block.txt', straddling);
+      const refusedFailed = await waitFor(
+        async () => (await ragRow(refused.fileId)).status === 'failed',
+        20_000,
+      );
+      const refusedRow = await ragRow(refused.fileId);
+      record(
+        'knowledge: a block pii_config refuses a document whose identifier straddles the window cut',
+        refusedFailed &&
+          (refusedRow.error ?? '').includes('PII policy') &&
+          (refusedRow.error ?? '').includes('creditCard'),
+        `status=${refusedRow.status}/failed error=${JSON.stringify((refusedRow.error ?? '').slice(0, 90))}`,
+      );
+
+      await writePiiPolicy('mask');
+      const masked = await uploadTextDocument('cards-mask.txt', straddling);
+      const maskedIndexed = await waitFor(
+        async () => (await ragRow(masked.fileId)).status === 'completed',
+        20_000,
+      );
+      const maskedRow = await ragRow(masked.fileId);
+      const chunkRows = await sql<{ content: string }[]>`
+        SELECT c.chunk_content AS content
+        FROM private_knowledge.chunks c
+        JOIN private_knowledge.documents d ON d.id = c.document_id
+        WHERE d.org_slug = ${orgSlug} AND d.file_id = ${masked.storageRef}
+      `;
+      const indexedText = chunkRows.map((row) => row.content).join('\n');
+      record(
+        'knowledge: a mask pii_config indexes the masked text, never the raw identifier',
+        maskedIndexed &&
+          chunkRows.length > 0 &&
+          !indexedText.includes('4111') &&
+          !indexedText.includes('1111 1111') &&
+          indexedText.includes('[CREDIT_CARD]'),
+        `status=${maskedRow.status}/completed chunks=${chunkRows.length} raw=${indexedText.includes('4111')}(want false) token=${indexedText.includes('[CREDIT_CARD]')}(want true)`,
+      );
+    } finally {
+      // Later lanes index under no policy, as before.
+      await rm(piiPolicyPath, { force: true });
+      orgConfig.clearOrgConfigCaches();
+    }
   } finally {
     await new Promise<void>((resolve) => {
       embedServer.close(() => resolve());

--- a/services/platform/lib/pii/engine/document.ts
+++ b/services/platform/lib/pii/engine/document.ts
@@ -9,31 +9,61 @@
  * never be seen. `scrubDocument` keeps the engine's clamp exactly as it is
  * and scans in windows instead.
  *
- * Windowing: the text is cut into pieces of at most `windowBytes / 4`
- * UTF-16 code units — one code unit encodes to at most four UTF-8 bytes,
- * so every piece is under the clamp as cut (`clampMessage`'s own fast
- * path). A cut prefers a paragraph break, then a line break, then a space,
- * searched back over the second half of the window, so a match is only
- * ever split when a single paragraph is longer than the window and has no
- * break to cut at.
+ * Normalization happens once, up front: the whole text goes through
+ * `normalizeForDetection` before it is windowed. The engine normalizes
+ * again inside `scrub`, but the function is idempotent, so a window comes
+ * back exactly as cut and the rewritten pieces join back offset for offset.
+ * It also closes the clamp for good: NFC can grow text (U+0958 becomes
+ * U+0915 U+093C), but it has already grown here, so a window of at most
+ * `windowBytes / 4` UTF-16 code units — one code unit encodes to at most
+ * four UTF-8 bytes — is under the clamp by `clampMessage`'s own fast path.
+ * A `modified` document is therefore the normalized text with the engine's
+ * rewrites; a `pass` says nothing about the text and the caller keeps its
+ * original.
  *
- * Normalization can still grow a piece past the clamp: the engine runs NFC
- * before it clamps, and a composition-excluded code point decomposes under
- * NFC (U+0958 becomes U+0915 U+093C — three UTF-8 bytes become six), so a
- * window of them is clamped inside `scrub` after all. The engine's
- * `truncated` flag is therefore the authority, on every verdict kind
- * including `pass` — a clamped window with no match in its prefix says
- * nothing about its tail. A window that comes back truncated is halved and
- * rescanned; no text is ever indexed from a truncated scan.
+ * Windowing: a cut prefers a paragraph break, then a line break, then a
+ * space, searched back over the second half of the window, then falls back
+ * to a hard cut — and no cut is accepted until it is checked. A space or a
+ * hard cut lands inside any identifier that contains spaces or straddles
+ * the boundary (`4111 1111 1111 1111`, a spaced IBAN or phone number, an
+ * email at a hard cut), and an identifier split across two windows is seen
+ * whole by neither: a block policy is walked past, a mask policy indexes
+ * it raw. So every candidate cut is checked by the engine's own detector
+ * over a window-sized neighbourhood centred on it, and a cut that a match
+ * crosses moves to the match's start (nudged back to a preferred separator
+ * when one sits in range). The neighbourhood is exactly one window long on
+ * purpose: the detectors' size gates and budgets are calibrated to a window
+ * (the phone detector drops its library pass past a cluster count that
+ * grows with the text; the exec budgets are per window), so a longer region
+ * would go blind exactly where the window scan still sees. The guarantee
+ * that follows: no identifier shorter than half a window — 6,250 code units
+ * at the default clamp, against patterns that top out in the low hundreds
+ * and JWTs of a few thousand — is ever split by a cut. An identifier longer
+ * than a whole window cannot be scanned whole by the engine at all and is
+ * cut like any text.
+ *
+ * The check costs one extra window-sized detection per window (twice the
+ * engine's own work) and more only when a cut actually moves, which is
+ * rare: the first candidate already sits at a separator.
+ *
+ * The engine's `truncated` flag stays the authority on every verdict kind,
+ * a `pass` included, as a guard: a scrubber built with a smaller `maxBytes`
+ * than `windowBytes` says, or a scrubber that is not this engine, can still
+ * clamp a window, and a clamped window with no match in its prefix says
+ * nothing about its tail. Such a window is halved (with the same checked
+ * cut) and rescanned; no text is ever indexed from a truncated scan.
  *
  * Aggregation follows the strongest verdict: any `blocked` window blocks
  * the document; any `step_error` (a window the engine could not scan)
- * surfaces so the caller decides fail-open or fail-closed; otherwise the
- * windows' texts are joined back in order — rewritten where the engine
- * rewrote, verbatim where it passed — and the categories and match counts
- * are unioned.
+ * surfaces so the caller decides fail-open or fail-closed — deliberately
+ * ahead of `modified`, because a partially masked text would present an
+ * unscanned window as scanned; a caller that fails open indexes its own
+ * original text and says so. Otherwise the windows' texts are joined back
+ * in order — rewritten where the engine rewrote, verbatim where it passed
+ * — and the categories and match counts are unioned.
  */
 
+import { normalizeForDetection } from '../core/normalize';
 import {
   blocked,
   flagged,
@@ -43,6 +73,8 @@ import {
   type FilterStepErrorOutcome,
 } from '../core/outcome';
 import { MAX_MESSAGE_BYTES } from '../core/regex-safety';
+import type { PiiMatch, PiiPattern } from '../core/types';
+import { detectPii } from './detector';
 import type { Scrubber } from './scrubber';
 
 export interface ScrubDocumentOptions {
@@ -57,17 +89,25 @@ export interface ScrubDocumentOptions {
 /** Cut boundaries, most preferred first. */
 const CUT_SEPARATORS = ['\n\n', '\n', ' '] as const;
 
+/**
+ * How many times a cut may move before it is placed exactly at the start
+ * of the match crossing it. Each move re-checks a fresh neighbourhood; a
+ * cut moves at all only when a separator sits inside an identifier, and
+ * twice only in text dense with them.
+ */
+const MAX_CUT_MOVES = 4;
+
 function isHighSurrogate(code: number): boolean {
   return code >= 0xd800 && code <= 0xdbff;
 }
 
 /**
- * Where to end the piece that starts at `start` and may not run past
- * `hardEnd`: after the last preferred separator in `[minEnd, hardEnd)`, or
- * at `hardEnd` itself — nudged back one unit when that would split a
- * surrogate pair.
+ * The preferred place to end the piece that starts at `start` and may not
+ * run past `hardEnd`: after the last preferred separator in
+ * `[minEnd, hardEnd)`, or at `hardEnd` itself — nudged back one unit when
+ * that would split a surrogate pair. Unchecked: see `safeCutPoint`.
  */
-function cutPoint(
+function preferredCutPoint(
   text: string,
   start: number,
   hardEnd: number,
@@ -83,14 +123,100 @@ function cutPoint(
   return hardEnd;
 }
 
-/** Split `text` into consecutive pieces of at most `windowChars` units. */
-export function splitIntoWindows(text: string, windowChars: number): string[] {
+/**
+ * The cut to use when `limit` is the start of an identifier: after the
+ * last preferred separator that ends in `[minEnd, limit]`, or `limit`
+ * itself.
+ */
+function cutBeforeMatch(text: string, limit: number, minEnd: number): number {
+  for (const separator of CUT_SEPARATORS) {
+    const at = text.lastIndexOf(separator, limit - separator.length);
+    if (at >= 0 && at + separator.length >= minEnd)
+      return at + separator.length;
+  }
+  return limit;
+}
+
+/**
+ * The detector's matches over the window-sized neighbourhood centred on
+ * `cut`, in absolute offsets. `detectPii` returns disjoint spans, so at
+ * most one of them can cross any given position.
+ */
+function matchesAround(
+  text: string,
+  cut: number,
+  halfWindow: number,
+  patterns: ReadonlyArray<PiiPattern>,
+): PiiMatch[] {
+  const from = Math.max(0, cut - halfWindow);
+  const to = Math.min(text.length, cut + halfWindow);
+  return detectPii(text.slice(from, to), patterns).map((m) => ({
+    patternName: m.patternName,
+    replacement: m.replacement,
+    matchedText: m.matchedText,
+    start: m.start + from,
+    end: m.end + from,
+  }));
+}
+
+function crossing(matches: readonly PiiMatch[], cut: number): PiiMatch | null {
+  return matches.find((m) => m.start < cut && m.end > cut) ?? null;
+}
+
+/**
+ * Where to end the piece that starts at `start` and may not run past
+ * `hardEnd`, such that no identifier the engine detects straddles the cut.
+ * Starts from the preferred cut and moves it back to the start of any
+ * match crossing it (see the header for the guarantee and its bound).
+ * Always returns a position in `(start, hardEnd]`.
+ */
+function safeCutPoint(
+  text: string,
+  start: number,
+  hardEnd: number,
+  minEnd: number,
+  patterns: ReadonlyArray<PiiPattern>,
+): number {
+  let cut = preferredCutPoint(text, start, hardEnd, minEnd);
+  if (patterns.length === 0) return cut;
+  const halfWindow = Math.ceil((hardEnd - start) / 2);
+
+  for (let move = 0; ; move += 1) {
+    const match = crossing(matchesAround(text, cut, halfWindow, patterns), cut);
+    if (match === null) return cut;
+    if (match.start <= start) {
+      // The identifier covers the head of the window. It fits: cut right
+      // after it — no other match in this neighbourhood crosses that point.
+      // It does not fit: it is longer than a window, and the engine cannot
+      // see it whole anywhere; the cut stands.
+      return match.end <= hardEnd ? match.end : cut;
+    }
+    if (move === MAX_CUT_MOVES) return match.start;
+    cut = cutBeforeMatch(text, match.start, minEnd);
+  }
+}
+
+/**
+ * Split `text` into consecutive pieces of at most `windowChars` units,
+ * never cutting inside an identifier `patterns` would detect.
+ */
+export function splitIntoWindows(
+  text: string,
+  windowChars: number,
+  patterns: ReadonlyArray<PiiPattern> = [],
+): string[] {
   const size = Math.max(2, Math.floor(windowChars));
   const pieces: string[] = [];
   let start = 0;
   while (text.length - start > size) {
     const hardEnd = start + size;
-    const end = cutPoint(text, start, hardEnd, start + Math.ceil(size / 2));
+    const end = safeCutPoint(
+      text,
+      start,
+      hardEnd,
+      start + Math.ceil(size / 2),
+      patterns,
+    );
     pieces.push(text.slice(start, end));
     start = end;
   }
@@ -123,7 +249,13 @@ function scanPiece(scrubber: Scrubber, piece: string): Scanned[] {
   const truncated = outcome.kind !== 'step_error' && outcome.truncated === true;
   if (!truncated) return [{ piece, outcome }];
   if (piece.length <= 1) return [{ piece, outcome: truncatedStepError() }];
-  const mid = cutPoint(piece, 0, Math.ceil(piece.length / 2), 1);
+  const mid = safeCutPoint(
+    piece,
+    0,
+    Math.ceil(piece.length / 2),
+    1,
+    scrubber.patterns,
+  );
   return [
     ...scanPiece(scrubber, piece.slice(0, mid)),
     ...scanPiece(scrubber, piece.slice(mid)),
@@ -160,9 +292,14 @@ export function scrubDocument(
   if (text.length === 0) return pass();
   const windowBytes = options.windowBytes ?? MAX_MESSAGE_BYTES;
   const windowChars = Math.floor(windowBytes / 4);
+  const normalized = normalizeForDetection(text);
 
   const scanned: Scanned[] = [];
-  for (const piece of splitIntoWindows(text, windowChars)) {
+  for (const piece of splitIntoWindows(
+    normalized,
+    windowChars,
+    scrubber.patterns,
+  )) {
     scanned.push(...scanPiece(scrubber, piece));
   }
 

--- a/services/platform/lib/pii/engine/document.ts
+++ b/services/platform/lib/pii/engine/document.ts
@@ -44,7 +44,15 @@
  *
  * The check costs one extra window-sized detection per window (twice the
  * engine's own work) and more only when a cut actually moves, which is
- * rare: the first candidate already sits at a separator.
+ * rare: the first candidate already sits at a separator. Doubling the
+ * detector execs also doubles the cost of a pattern that is super-linear on
+ * a pathological window: the email regex, unanchored at its start, retries
+ * at every position of an unbroken run of its own class and backtracks the
+ * rest of the run each time — tens of milliseconds per exec on a
+ * 12,500-letter word here, seconds across a test on a saturated CI worker.
+ * The exec budget bounds the scan between execs, not inside one; a fixture
+ * that needs a long unbroken head uses a character outside every pattern's
+ * classes.
  *
  * The engine's `truncated` flag stays the authority on every verdict kind,
  * a `pass` included, as a guard: a scrubber built with a smaller `maxBytes`

--- a/services/platform/lib/pii/engine/scrubber.ts
+++ b/services/platform/lib/pii/engine/scrubber.ts
@@ -35,7 +35,11 @@ import { applyTokenization } from './tokenizer';
 export interface Scrubber {
   /** Detect + rewrite/block `text`, returning a filter outcome. */
   scrub(text: string): FilterOutcome;
-  /** The compiled pattern list — exposed for tests, not production code. */
+  /**
+   * The compiled pattern list — what `scrubDocument` checks its window
+   * cuts against, so a cut never lands inside an identifier this scrubber
+   * would detect; also exposed for tests.
+   */
   readonly patterns: ReadonlyArray<PiiPattern>;
   /** The locale union the patterns were composed over. */
   readonly locales: ReadonlyArray<LocaleConfig>;

--- a/services/platform/tests/integration/container-smoke-test.ts
+++ b/services/platform/tests/integration/container-smoke-test.ts
@@ -281,6 +281,33 @@ async function main(): Promise<number> {
     r.fail('Backend api /ping');
   }
 
+  // The PII data tree is baked into the backend image at
+  // TALE_CONFIG_SYSTEM_DIR (/app/system/pii); an image built without it
+  // cannot enforce any organization's `pii_config` policy and only says so
+  // in a boot log line. Load the registry inside the built image exactly as
+  // the backend does — the same node flags and loader — so a packaging
+  // regression fails this job rather than a customer's governance policy.
+  if (
+    await dockerExecOk(backendContainer, [
+      'node',
+      '--experimental-transform-types',
+      '--disable-warning=ExperimentalWarning',
+      '--import',
+      '/app/backend/node-loader.mjs',
+      '--input-type=module',
+      '-e',
+      "const { PatternRegistry } = await import('/app/lib/pii/index.ts'); PatternRegistry.fromDefaults();",
+    ])
+  ) {
+    r.pass(
+      'Backend image loads the PII data tree (PatternRegistry.fromDefaults)',
+    );
+  } else {
+    r.fail(
+      'Backend image loads the PII data tree (PatternRegistry.fromDefaults)',
+    );
+  }
+
   // Platform: Vite server with platform-ready marker.
   const platformContainer = await compose.containerName('platform');
   const viteCode = await httpStatus('http://localhost:13000/api/health', 10);

--- a/services/platform/tests/integration/container-smoke-test.ts
+++ b/services/platform/tests/integration/container-smoke-test.ts
@@ -287,6 +287,9 @@ async function main(): Promise<number> {
   // in a boot log line. Load the registry inside the built image exactly as
   // the backend does — the same node flags and loader — so a packaging
   // regression fails this job rather than a customer's governance policy.
+  // The flags and loader path mirror the `backend)` launch line in
+  // docker-entrypoint.sh by hand: change them together, or this probe fails
+  // for the wrong reason.
   if (
     await dockerExecOk(backendContainer, [
       'node',

--- a/services/platform/tests/pii/document.test.ts
+++ b/services/platform/tests/pii/document.test.ts
@@ -3,7 +3,8 @@
  *
  * The properties: every window stays under the engine clamp, the pieces
  * join back to the input exactly, a match past the clamp is found in every
- * mode, a rewritten document keeps its length, and a truncated window —
+ * mode, a rewritten document keeps its length, no window cut ever falls
+ * inside an identifier the engine would detect, and a truncated window —
  * whatever verdict it came back with, a `pass` included — is rescanned in
  * halves rather than returned.
  */
@@ -21,6 +22,7 @@ import {
   pass,
   scrubDocument,
   splitIntoWindows,
+  type PiiPattern,
   type Scrubber,
 } from '../../lib/pii';
 
@@ -42,9 +44,29 @@ function longText(head: string, tail: string): string {
   return [head, FILLER.repeat(2_500), tail].join('\n');
 }
 
-function fakeScrubber(scrub: Scrubber['scrub']): Scrubber {
-  return { scrub, patterns: [], locales: [] };
+function fakeScrubber(
+  scrub: Scrubber['scrub'],
+  patterns: PiiPattern[] = [],
+): Scrubber {
+  return { scrub, patterns, locales: [] };
 }
+
+/**
+ * Identifiers placed so that the preferred cut — the last space in the
+ * second half of the first window — falls inside them: the head is one
+ * unbroken word, so the only separators in range are the identifier's own.
+ * A single-line CSV export or minified text has exactly this shape.
+ */
+const STRADDLE_HEAD = 'a'.repeat(WINDOW_CHARS - 10);
+const STRADDLE_CARD = `${STRADDLE_HEAD} 4111 1111 1111 1111 rest of the line`;
+const STRADDLE_IBAN = `${STRADDLE_HEAD} DE89 3704 0044 0532 0130 00 rest`;
+const STRADDLE_PHONE = `${STRADDLE_HEAD} +49 30 12345678 rest of the line`;
+/**
+ * No separator at all: the hard cut lands inside the address. The filler
+ * is a character the email pattern's classes exclude — a letter head would
+ * be swallowed into the local part and make the whole text one match.
+ */
+const STRADDLE_EMAIL = `${'#'.repeat(WINDOW_CHARS - 10)}ada.lovelace@example.com${'#'.repeat(50)}`;
 
 describe('splitIntoWindows', () => {
   it('keeps every window under the size and joins back to the input', () => {
@@ -78,6 +100,90 @@ describe('splitIntoWindows', () => {
 
   it('returns one window for a short text', () => {
     expect(splitIntoWindows('short', WINDOW_CHARS)).toEqual(['short']);
+  });
+
+  describe('with the patterns to keep whole', () => {
+    const { patterns } = createScrubber({
+      mode: 'mask',
+      registry: REGISTRY,
+      patterns: { email: true, creditCard: true, iban: true, phone: true },
+    });
+
+    it('cuts inside a spaced identifier when it has no patterns to check', () => {
+      // The defect, pinned as the baseline the checked cut is measured
+      // against: the space inside the card number is the preferred cut.
+      const [first, second] = splitIntoWindows(STRADDLE_CARD, WINDOW_CHARS);
+      expect(first?.endsWith(' 4111 ')).toBe(true);
+      expect(second?.startsWith('1111 1111 1111 ')).toBe(true);
+    });
+
+    it.each([
+      ['card number', STRADDLE_CARD, '4111 1111 1111 1111'],
+      ['IBAN', STRADDLE_IBAN, 'DE89 3704 0044 0532 0130 00'],
+      ['phone number', STRADDLE_PHONE, '+49 30 12345678'],
+      ['email at a hard cut', STRADDLE_EMAIL, 'ada.lovelace@example.com'],
+    ])('keeps a straddling %s whole in one window', (_, text, identifier) => {
+      const windows = splitIntoWindows(text, WINDOW_CHARS, patterns);
+      expect(windows.join('')).toBe(text);
+      for (const w of windows) {
+        expect(w.length).toBeLessThanOrEqual(WINDOW_CHARS);
+      }
+      expect(windows.filter((w) => w.includes(identifier))).toHaveLength(1);
+    });
+
+    it('moves the cut back to the separator before the identifier', () => {
+      const [first, second] = splitIntoWindows(
+        STRADDLE_CARD,
+        WINDOW_CHARS,
+        patterns,
+      );
+      expect(first).toBe(`${STRADDLE_HEAD} `);
+      expect(second).toBe('4111 1111 1111 1111 rest of the line');
+    });
+
+    it('never ends a window inside a digit group of a dense single line', () => {
+      // A CSV export without line breaks: every second-half separator sits
+      // next to or inside an identifier, so cuts move on most windows.
+      const row =
+        'Ada Lovelace,4111 1111 1111 1111,DE89 3704 0044 0532 0130 00,+49 30 12345678,ada@example.com,';
+      const text = row.repeat(Math.ceil((WINDOW_CHARS * 6) / row.length));
+      const windows = splitIntoWindows(text, WINDOW_CHARS, patterns);
+      expect(windows.length).toBeGreaterThan(5);
+      expect(windows.join('')).toBe(text);
+      for (const w of windows) {
+        expect(w.length).toBeLessThanOrEqual(WINDOW_CHARS);
+      }
+      // Every identifier survives whole in some window: the windows hold
+      // exactly as many copies as the text does.
+      const count = (haystack: string, needle: string): number =>
+        haystack.split(needle).length - 1;
+      for (const identifier of [
+        '4111 1111 1111 1111',
+        'DE89 3704 0044 0532 0130 00',
+        '+49 30 12345678',
+      ]) {
+        expect(windows.reduce((n, w) => n + count(w, identifier), 0)).toBe(
+          count(text, identifier),
+        );
+      }
+    });
+
+    it('cuts an identifier longer than a window like any text, and ends', () => {
+      // A JWT-shaped run longer than the window: the engine cannot see it
+      // whole anywhere, so the split is unavoidable — the cut stands.
+      const { patterns: jwt } = createScrubber({
+        mode: 'mask',
+        registry: REGISTRY,
+        patterns: { jwt: true },
+      });
+      const token = `eyJ${'a'.repeat(WINDOW_CHARS)}.eyJ${'b'.repeat(40)}.sig`;
+      const windows = splitIntoWindows(`head ${token} tail`, WINDOW_CHARS, jwt);
+      expect(windows.join('')).toBe(`head ${token} tail`);
+      expect(windows.length).toBeGreaterThan(1);
+      for (const w of windows) {
+        expect(w.length).toBeLessThanOrEqual(WINDOW_CHARS);
+      }
+    });
   });
 });
 
@@ -119,6 +225,66 @@ describe('scrubDocument over the engine', () => {
     expect(scrubDocument(mask, longText('clean', 'also clean'))).toEqual(
       pass(),
     );
+  });
+
+  describe('an identifier straddling the window cut', () => {
+    const straddle = createScrubber({
+      mode: 'block',
+      registry: REGISTRY,
+      patterns: { email: true, creditCard: true, iban: true, phone: true },
+    });
+    const straddleMask = createScrubber({
+      mode: 'mask',
+      registry: REGISTRY,
+      patterns: { email: true, creditCard: true, iban: true, phone: true },
+    });
+
+    it.each([
+      ['card number', STRADDLE_CARD, 'creditCard', '4111 1111 1111 1111'],
+      ['IBAN', STRADDLE_IBAN, 'iban', 'DE89 3704 0044 0532 0130 00'],
+      ['phone number', STRADDLE_PHONE, 'phone', '+49 30 12345678'],
+      [
+        'email at a hard cut',
+        STRADDLE_EMAIL,
+        'email',
+        'ada.lovelace@example.com',
+      ],
+    ])('is blocked and masked: %s', (_, text, category, identifier) => {
+      // The engine sees the identifier in a message; the document scan
+      // must not lose it to the cut.
+      expect(straddle.scrub(`x ${identifier} y`).kind).toBe('blocked');
+      expect(scrubDocument(straddle, text)).toEqual(blocked([category], 1));
+
+      const o = scrubDocument(straddleMask, text);
+      expect(o.kind).toBe('modified');
+      if (o.kind !== 'modified') return;
+      expect(o.text).not.toContain(identifier);
+      expect(o.categoryIds).toEqual([category]);
+      expect(o.matchCount).toBe(1);
+      // Neither half of the identifier survives raw around the token.
+      expect(o.text).toMatch(/a \[(CREDIT_CARD|IBAN|PHONE)\] rest|#\[EMAIL\]#/);
+    });
+  });
+
+  it('normalizes once, so a window is never clamped inside the engine', () => {
+    // The NFC-growing head is normalized before it is windowed: it arrives
+    // at the engine already grown and cut under the clamp, so every window
+    // is scanned exactly once — no truncated verdict, no halving.
+    const calls: number[] = [];
+    const counting: Scrubber = {
+      ...block,
+      scrub: (piece) => {
+        const outcome = block.scrub(piece);
+        calls.push(piece.length);
+        expect(outcome.kind === 'step_error' || !outcome.truncated).toBe(true);
+        return outcome;
+      },
+    };
+    const text = `${NFC_GROWING_HEAD} ${CARD}`;
+    expect(scrubDocument(counting, text)).toEqual(blocked(['creditCard'], 1));
+    const normalizedLength = normalizeForDetection(text).length;
+    expect(normalizedLength).toBeGreaterThan(WINDOW_CHARS);
+    expect(calls).toHaveLength(Math.ceil(normalizedLength / WINDOW_CHARS));
   });
 
   it('blocks an identifier behind a head that doubles under NFC', () => {
@@ -185,9 +351,50 @@ describe('scrubDocument aggregation', () => {
     expect(seen.join('')).toBe('abcdefgh ijkl!mnop qrstuvwx');
   });
 
+  it('halves a truncated window without cutting inside an identifier', () => {
+    // The engine's flag, forced on anything 16 units or longer. The
+    // midpoint cut would fall on the space inside `1234 5678`; the checked
+    // cut moves it back to the space before the identifier.
+    const spaced: PiiPattern = {
+      name: 'x',
+      regex: /\d{4} \d{4}/g,
+      replacement: '[X]',
+    };
+    const seen: string[] = [];
+    const scrubber = fakeScrubber(
+      (text) => {
+        if (text.length >= 16) return pass(true);
+        seen.push(text);
+        return /\d{4} \d{4}/.test(text)
+          ? modified(text.replace(/\d{4} \d{4}/, '[X]'), ['x'], 1)
+          : pass();
+      },
+      [spaced],
+    );
+    const text = 'abcdefghij 1234 5678 klmnopqrstuv';
+    const o = scrubDocument(scrubber, text, { windowBytes: 4 * 40 });
+    expect(seen).toEqual(['abcdefghij ', '1234 5678 ', 'klmnopqrstuv']);
+    expect(o).toEqual(modified('abcdefghij [X] klmnopqrstuv', ['x'], 1));
+  });
+
   it('surfaces a step error instead of indexing an unscanned window', () => {
     const scrubber = fakeScrubber(() => modified('', [], 0, true));
     const o = scrubDocument(scrubber, 'abcd', { windowBytes: 16 });
+    expect(o.kind).toBe('step_error');
+  });
+
+  it('lets a step error outrank a modified window elsewhere', () => {
+    // Deliberate: a partially masked text would present the unscanned
+    // window as scanned. The caller decides fail-open or fail-closed on its
+    // own original text.
+    let calls = 0;
+    const scrubber = fakeScrubber(() => {
+      calls += 1;
+      return calls === 1
+        ? modified('[X]', ['x'], 1)
+        : { kind: 'step_error', filterName: 'pii', reason: 'forced' };
+    });
+    const o = scrubDocument(scrubber, 'one two', { windowBytes: 16 });
     expect(o.kind).toBe('step_error');
   });
 

--- a/services/platform/tests/pii/document.test.ts
+++ b/services/platform/tests/pii/document.test.ts
@@ -55,18 +55,22 @@ function fakeScrubber(
  * Identifiers placed so that the preferred cut — the last space in the
  * second half of the first window — falls inside them: the head is one
  * unbroken word, so the only separators in range are the identifier's own.
- * A single-line CSV export or minified text has exactly this shape.
+ * A single-line CSV export or minified text has exactly this shape. The
+ * filler is a character outside every enabled pattern's classes: on a
+ * letter run the email regex backtracks quadratically (hundreds of
+ * milliseconds per scan here, past the test timeout on a saturated CI
+ * worker) without changing any verdict.
  */
-const STRADDLE_HEAD = 'a'.repeat(WINDOW_CHARS - 10);
+const STRADDLE_HEAD = '#'.repeat(WINDOW_CHARS - 10);
 const STRADDLE_CARD = `${STRADDLE_HEAD} 4111 1111 1111 1111 rest of the line`;
 const STRADDLE_IBAN = `${STRADDLE_HEAD} DE89 3704 0044 0532 0130 00 rest`;
 const STRADDLE_PHONE = `${STRADDLE_HEAD} +49 30 12345678 rest of the line`;
 /**
- * No separator at all: the hard cut lands inside the address. The filler
- * is a character the email pattern's classes exclude — a letter head would
- * be swallowed into the local part and make the whole text one match.
+ * No separator at all: the hard cut lands inside the address. A letter head
+ * would also be swallowed into the local part and make the whole text one
+ * match.
  */
-const STRADDLE_EMAIL = `${'#'.repeat(WINDOW_CHARS - 10)}ada.lovelace@example.com${'#'.repeat(50)}`;
+const STRADDLE_EMAIL = `${STRADDLE_HEAD}ada.lovelace@example.com${'#'.repeat(50)}`;
 
 describe('splitIntoWindows', () => {
   it('keeps every window under the size and joins back to the input', () => {
@@ -102,19 +106,22 @@ describe('splitIntoWindows', () => {
     expect(splitIntoWindows('short', WINDOW_CHARS)).toEqual(['short']);
   });
 
+  it('baseline: cuts inside a spaced identifier when given no patterns to check', () => {
+    // The pre-fix defect, pinned as the baseline the checked cut below is
+    // measured against, not as desired behaviour: without patterns the
+    // space inside the card number is the preferred cut. The only
+    // production caller (`scrubDocument`) always passes the scrubber's
+    // patterns.
+    const [first, second] = splitIntoWindows(STRADDLE_CARD, WINDOW_CHARS);
+    expect(first?.endsWith(' 4111 ')).toBe(true);
+    expect(second?.startsWith('1111 1111 1111 ')).toBe(true);
+  });
+
   describe('with the patterns to keep whole', () => {
     const { patterns } = createScrubber({
       mode: 'mask',
       registry: REGISTRY,
       patterns: { email: true, creditCard: true, iban: true, phone: true },
-    });
-
-    it('cuts inside a spaced identifier when it has no patterns to check', () => {
-      // The defect, pinned as the baseline the checked cut is measured
-      // against: the space inside the card number is the preferred cut.
-      const [first, second] = splitIntoWindows(STRADDLE_CARD, WINDOW_CHARS);
-      expect(first?.endsWith(' 4111 ')).toBe(true);
-      expect(second?.startsWith('1111 1111 1111 ')).toBe(true);
     });
 
     it.each([
@@ -262,7 +269,7 @@ describe('scrubDocument over the engine', () => {
       expect(o.categoryIds).toEqual([category]);
       expect(o.matchCount).toBe(1);
       // Neither half of the identifier survives raw around the token.
-      expect(o.text).toMatch(/a \[(CREDIT_CARD|IBAN|PHONE)\] rest|#\[EMAIL\]#/);
+      expect(o.text).toMatch(/# \[(CREDIT_CARD|IBAN|PHONE)\] rest|#\[EMAIL\]#/);
     });
   });
 

--- a/services/platform/vitest.config.ts
+++ b/services/platform/vitest.config.ts
@@ -59,6 +59,10 @@ export default defineConfig({
           name: 'pii',
           environment: 'node',
           include: ['tests/pii/**/*.test.ts', 'lib/pii/**/*.test.ts'],
+          // A per-TEST ceiling, not added wall-clock: under the fully parallel
+          // suite the 5s vitest default starves whichever file lands on a
+          // saturated worker.
+          testTimeout: 30_000,
           // The data-driven suite fans out to 67k+ cases — per-test
           // isolation would rebuild the shared scrubbers constantly. The
           // engine is pure; tests share no mutable state.


### PR DESCRIPTION
## Summary

Follow-up to #3229 (round-2 review, blocking item 2). `scrubDocument` cut its scan windows at the last paragraph break, line break or space in the second half of a window, or hard at the size limit — so an identifier that contains spaces or straddles the boundary (`4111 1111 1111 1111`, a spaced IBAN or phone number, an email at a hard cut) was seen whole by neither window whenever a stretch of text had no line break (single-line CSV/JSON exports, minified content). A `block` policy was walked past and a `mask` policy indexed the identifier raw. Reproduced on main with the real engine for a card number, an IBAN and a phone number.

Now the text is normalized once up front (`normalizeForDetection` is idempotent, so offsets stay stable and a window can no longer grow past the clamp inside the engine), and every candidate cut is checked by the engine's own detector over a window-sized neighbourhood centred on it; a cut that a match crosses moves back to the match's start (nudged to a preferred separator when one is in range). The neighbourhood is exactly one window long so the detectors' size gates and exec budgets behave as in a window scan. Guarantee: no identifier shorter than half a window (6,250 code units) is ever split. Cost: one extra window-sized detection per window.

Also closes the cheap round-2 notes: the `step_error`-over-`modified` aggregation order is stated as deliberate and pinned; an itest lane drives a real `pii_config` (block and mask) through the worker and `applyPiiPolicyForIndexing`; the compose-stack smoke test loads `PatternRegistry.fromDefaults()` inside the built backend image.

## Findings fixed

- pii-round2-1 — checked window cuts (`safeCutPoint`) over the once-normalized text; regression tests for card / IBAN / phone / hard-cut email under block and mask, a dense single-line CSV, an identifier longer than a window, the halving path, normalization-once; `pii_gate.test.ts` through `applyPiiPolicyForIndexing` (refuse + mask).
- pii-round2-nb-document.ts — `step_error` outranking `modified` documented as deliberate in the header and pinned by a test (unreachable through the real engine; the caller fails open on its own original text).
- pii-round2-nb-pii_gate.ts — itest lane in `checkKnowledge`: writes `governance/pii-config.yml`, uploads a document whose card number straddles the window cut; `block` → `rag_status=failed` with the PII-policy prose naming `creditCard`; `mask` → `completed` with `[CREDIT_CARD]` in the stored chunks and never the raw digits; policy file removed afterwards.
- pii-round2-nb-main.ts — `container-smoke-test.ts` runs `PatternRegistry.fromDefaults()` inside the `backend-api` container with the backend's own node flags and loader (observable only in the smoke-test CI job; no local backend image).

## Skipped

- pii-round2-nb-folder-tree.ts — moot: the 74-char header lives on an already-merged squash (PR title ≤72 chars is what reached main); rewriting pushed history is out of scope.
- pii-round2-nb-tokenizer.ts — the `createTokenizer`/`detokenize` consumer is `fix/chat-guardrails-policy-wiring`, not this theme.

## Tests & gates observed

Round-1 review repair (`4e4405b57`, `test(platform): keep straddle fixtures off the email regex letter run`): the PR's own straddle tests timed out on CI (`Unit`: `Test timed out in 5000ms` for the card and IBAN cases, `tests/pii/document.test.ts` 18,575 ms). Root cause: the fixture head was 12,490 letters, and the email data regex (`[a-zA-Z0-9._%+-]+@…`, unanchored at its start) retries at every position of an unbroken letter run and backtracks the rest of the run each time — quadratic per exec (≈44 ms per window here in Bun, ≈2 ms with the fix; several seconds per test on a saturated CI worker), and the checked cut doubles the execs. The `execWithBudget` 50 ms budget only applies between execs. Fix: the straddle heads are `#` (outside every enabled pattern's classes — every verdict unchanged) in `tests/pii/document.test.ts` and `pii_gate.test.ts`; the `pii` vitest project gets the same 30 s per-test ceiling the `server` project has (a ceiling, not added wall-clock); `pii_gate.test.ts` derives `WINDOW_CHARS` from `MAX_MESSAGE_BYTES`; the `document.ts` header states the doubled-exec cost honestly; the smoke probe notes its node flags mirror `docker-entrypoint.sh` by hand. `tests/pii/document.test.ts` now runs its 31 tests in ≈50 ms of test time (222 ms under the full parallel suite).

Observed on `4e4405b57` inside the worktree:

- `bunx tsc --noEmit` — TSC_OK
- `bunx oxlint --type-aware` — exit 0
- `bunx vitest --run --project pii tests/pii/document.test.ts` — `Test Files  1 passed (1)` / `Tests  31 passed (31)` / `Duration  442ms (… tests 50ms …)`
- `bunx vitest --run --project server backend/core/knowledge/pii_gate.test.ts` — `Test Files  1 passed (1)` / `Tests  18 passed (18)`
- `bun run check` — exit 0: `@tale/platform:test: Test Files 527 passed (527) / Tests 73357 passed (73357)`; `@tale/platform:test:ui: Test Files 456 passed (456) / Tests 3512 passed (3512)`; shared 22/22 files, ui 124/124, docs 31/31, web 23/23; every `lint: Found 0 warnings and 0 errors`
- `bun run knip:check` — exit 0 (same pre-existing `cron-parser` configuration hint)
- `git merge-tree --write-tree origin/main HEAD` — CLEAN (main = 3997f6a2a)
- itest not rerun for this commit: it touches tests, a comment and the vitest config only; the lanes below were observed on `50da3cdab`, whose runtime code is unchanged.

Observed on the previous tip (`50da3cdab`):

- `bunx tsc --noEmit` — clean (TSC_OK)
- `bunx oxlint --type-aware` — exit 0, no findings
- `bunx vitest --run --project pii` — `Test Files  8 passed (8)` / `Tests  67254 passed (67254)`
- `bunx vitest --run --project server` — `Test Files  519 passed (519)` / `Tests  6103 passed (6103)`
- `bun run check` — format:check, lint, typecheck green; `@tale/platform:test: Test Files 527 passed (527) / Tests 73357 passed (73357)`; shared 22/22, ui 124/124, docs 31/31, web 23/23 files. `@tale/platform:test:ui` reported `5 failed | 451 passed (456)` files — all 5 were 5 s timeouts / `Timed out in waitFor` in `app/**` component tests (chat-surface, connectors-settings, data-residency-settings, enterprise-sso-form, automation-detail) while the itest ran concurrently; none of the five files or their subjects are touched here. Rerun alone: `Test Files  4 passed (4) / Tests  117 passed (117)` and `Test Files  1 passed (1) / Tests  27 passed (27)`.
- `bun run knip:check` — exit 0 (one pre-existing configuration hint: `cron-parser … Remove from ignoreDependencies`, not touched here)
- `run-itest.sh` (real Postgres + MinIO) — `[itest] 477/478 checks passed across 134/134 lanes`; the single failure is the known pre-existing `webdav re-home` lane. New lanes: `PASS knowledge: a block pii_config refuses a document whose identifier straddles the window cut — status=failed/failed error="Indexing refused by the organization's PII policy (creditCard)."` and `PASS knowledge: a mask pii_config indexes the masked text, never the raw identifier — status=completed/completed chunks=7 raw=false(want false) token=true(want true)`.
- `git merge-tree --write-tree origin/main HEAD` — CLEAN (main = 3997f6a2a).

## Notes for the reviewer

- `Scrubber.patterns` is now a production consumer (was "tests only").
- `splitIntoWindows` gained an optional `patterns` argument; with no patterns it behaves exactly as before (the baseline defect is pinned as a test so the checked cut is measured against it).
- The smoke-test step can only be observed in this PR's compose-stack CI job.
- `serializable retry` in the itest is a timing race (50 ms overlap) and failed once while `bun run check` ran concurrently; it passed in the isolated rerun. The `test:ui` timeouts under that same load were rerun alone — see the gate lines.

