### PR TITLE
fix(platform): complete deferred sends and memories, prune dead chat doors

### DIFF
--- a/docs/de/platform/member/preferences.md
+++ b/docs/de/platform/member/preferences.md
@@ -41,6 +41,8 @@ Nichts wandert in deinem Namen in einen Prompt. Eine gespeicherte Erinnerung err
 
 Gespeicherte Erinnerungen stehen auf derselben Seite, jede mit einem Knopf zum Löschen. Eine Erinnerung zu löschen nimmt sie aus dem heraus, was eine Suche zurückgeben kann — mehr Wirkung hat sie nicht, denn es fährt keine zweite Kopie in irgendeinem anderen Prompt mit.
 
+Der Schalter **Erinnerungen** über den Listen gilt für die ganze Funktion, nicht nur für die Seite: Ist er aus, kann der Assistent weder eine Erinnerung vorschlagen noch eine lesen — ein Vorschlag in dieser Zeit wird sofort abgewiesen, nicht für später aufgehoben — und was du schon gespeichert hast, bleibt unangetastet liegen, bis du ihn wieder einschaltest.
+
 ## Abmelden
 
 Die Zeile **Abmelden** unten im Profilmenü bestätigt mit einem Dialog, bevor sie die Session löscht. Nach der Bestätigung lädt Tale die Seite zur Anmeldeseite hart neu, damit kein veralteter Zustand im Tab hängenbleibt. Das Abmelden ist pro Gerät — dich auf dem Laptop abzumelden, meldet dich nicht auf dem Handy ab, und umgekehrt.

--- a/docs/en/platform/member/preferences.md
+++ b/docs/en/platform/member/preferences.md
@@ -41,6 +41,8 @@ Nothing is added to a prompt on your behalf. A saved memory reaches a reply only
 
 Saved memories are listed on the same page with a control to delete each one. Deleting a memory takes it out of what a search can return, which is the whole of its effect — no second copy is riding along in some other prompt.
 
+The **Memories** switch above the lists is the whole feature's gate, not just the page's: with it off, the assistant can neither propose a memory nor read one back — a proposal made while it is off is refused on the spot, not queued for later — and what you already saved waits untouched until you switch it back on.
+
 ## Signing out
 
 The **Log out** row at the bottom of the profile menu confirms with a dialog before clearing the session. After confirming, Tale does a full page reload to the sign-in page so no stale state lingers in the tab. Sign-out is per-device — signing out on your laptop does not log you out on your phone, and vice versa.

--- a/docs/fr/platform/member/preferences.md
+++ b/docs/fr/platform/member/preferences.md
@@ -41,6 +41,8 @@ Rien n’est ajouté à un prompt en ton nom. Une mémoire enregistrée n’atte
 
 Les mémoires enregistrées figurent sur la même page, chacune avec un bouton pour la supprimer. Supprimer une mémoire la retire de ce qu’une recherche peut renvoyer, et c’est tout son effet — aucune seconde copie ne voyage dans un autre prompt.
 
+L’interrupteur **Souvenirs** au-dessus des listes commande toute la fonction, pas seulement la page : quand il est coupé, l’assistant ne peut ni proposer une mémoire ni en relire une — une proposition faite pendant ce temps est refusée sur-le-champ, pas mise de côté — et ce que tu as déjà enregistré attend, intact, que tu le rallumes.
+
 ## Se déconnecter
 
 La ligne **Se déconnecter** en bas du menu de profil confirme via une boîte de dialogue avant de purger la session. Après confirmation, Tale fait un rechargement complet vers la page de connexion pour qu’aucun état périmé ne traîne dans l’onglet. La déconnexion est par appareil — te déconnecter sur ton laptop ne te déconnecte pas sur ton téléphone, et réciproquement.

--- a/services/platform/app/features/settings/personalization/components/preferences-settings.test.tsx
+++ b/services/platform/app/features/settings/personalization/components/preferences-settings.test.tsx
@@ -34,6 +34,8 @@ vi.mock('@/app/features/settings/governance/hooks/queries', () => ({
 const setCustomInstructionsEnabled = vi.fn().mockResolvedValue(undefined);
 const setMemoriesEnabled = vi.fn().mockResolvedValue(undefined);
 const upsert = vi.fn().mockResolvedValue(undefined);
+const reviewMemory = vi.fn().mockResolvedValue(true);
+const deleteMemory = vi.fn().mockResolvedValue(true);
 
 vi.mock('../hooks/mutations', () => ({
   useSetCustomInstructionsEnabled: () => ({
@@ -45,6 +47,18 @@ vi.mock('../hooks/mutations', () => ({
     isPending: false,
   }),
   useUpsertMyPreferences: () => ({ mutateAsync: upsert, isPending: false }),
+  useReviewMemory: () => ({ mutateAsync: reviewMemory, isPending: false }),
+  useDeleteMemory: () => ({ mutateAsync: deleteMemory, isPending: false }),
+}));
+
+// The memories read: a proposal waiting and a memory already saved.
+let memories: {
+  pending: { id: string; content: string }[];
+  approved: { id: string; content: string }[];
+} = { pending: [], approved: [] };
+
+vi.mock('@/app/features/chat/data/chat-backend', () => ({
+  useChatMemories: () => ({ status: 'ready', data: memories }),
 }));
 
 import { PreferencesSettings } from './preferences-settings';
@@ -56,6 +70,7 @@ function renderPage() {
 beforeEach(() => {
   preferences = null;
   policyEnabled = false;
+  memories = { pending: [], approved: [] };
   vi.clearAllMocks();
 });
 
@@ -175,8 +190,60 @@ describe('PreferencesSettings', () => {
     expect(screen.getAllByText('Saved memories').length).toBeGreaterThan(0);
   });
 
+  it('saves or discards a pending suggestion — the person decides', async () => {
+    preferences = { memoriesEnabled: true };
+    memories = {
+      pending: [{ id: 'mem_1', content: 'Prefers metric units' }],
+      approved: [],
+    };
+    const { user } = renderPage();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Save suggestion: Prefers metric units',
+      }),
+    );
+    expect(reviewMemory).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      memoryId: 'mem_1',
+      decision: 'approved',
+    });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Discard suggestion: Prefers metric units',
+      }),
+    );
+    expect(reviewMemory).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      memoryId: 'mem_1',
+      decision: 'rejected',
+    });
+  });
+
+  it('deletes a saved memory from its row', async () => {
+    preferences = { memoriesEnabled: true };
+    memories = {
+      pending: [],
+      approved: [{ id: 'mem_2', content: 'Works in Berlin' }],
+    };
+    const { user } = renderPage();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Delete memory: Works in Berlin' }),
+    );
+    expect(deleteMemory).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      memoryId: 'mem_2',
+    });
+  });
+
   it('passes an axe audit', async () => {
     preferences = { customInstructionsEnabled: true, memoriesEnabled: true };
+    memories = {
+      pending: [{ id: 'mem_1', content: 'Prefers metric units' }],
+      approved: [{ id: 'mem_2', content: 'Works in Berlin' }],
+    };
     const { container } = renderPage();
     await waitFor(() => checkAccessibility(container));
   });

--- a/services/platform/app/features/settings/personalization/components/preferences-settings.tsx
+++ b/services/platform/app/features/settings/personalization/components/preferences-settings.tsx
@@ -17,6 +17,7 @@
  * preference would give the same behaviour two sources of truth.
  */
 
+import { Button } from '@tale/ui/button';
 import { Stack } from '@tale/ui/layout';
 import { Skeletonize } from '@tale/ui/skeleton-context';
 import { Text } from '@tale/ui/text';
@@ -39,6 +40,8 @@ import { useT } from '@/lib/i18n/client';
 import { isRecord } from '@/lib/utils/type-utils';
 
 import {
+  useDeleteMemory,
+  useReviewMemory,
   useSetCustomInstructionsEnabled,
   useSetMemoriesEnabled,
   useUpsertMyPreferences,
@@ -263,6 +266,35 @@ function MemoriesSection({
   const { toast } = useToast();
   const { mutateAsync: setEnabled, isPending } = useSetMemoriesEnabled();
   const memories = useChatMemories(organizationId);
+  const { mutateAsync: review, isPending: reviewing } = useReviewMemory();
+  const { mutateAsync: remove, isPending: removing } = useDeleteMemory();
+
+  const settle = async (
+    memoryId: string,
+    decision: 'approved' | 'rejected',
+  ): Promise<void> => {
+    try {
+      await review({ organizationId, memoryId, decision });
+      toast({
+        title:
+          decision === 'approved'
+            ? t('toasts.memorySaved')
+            : t('toasts.memoryDiscarded'),
+      });
+    } catch (error) {
+      console.error('[personalization] memory review failed', error);
+      toast({ title: t('errors.saveFailed'), variant: 'destructive' });
+    }
+  };
+  const forget = async (memoryId: string): Promise<void> => {
+    try {
+      await remove({ organizationId, memoryId });
+      toast({ title: t('toasts.memoryDeleted') });
+    } catch (error) {
+      console.error('[personalization] memory delete failed', error);
+      toast({ title: t('errors.saveFailed'), variant: 'destructive' });
+    }
+  };
 
   const description = useGateHint(gate, t('page.memoriesToggle.description'));
 
@@ -296,6 +328,34 @@ function MemoriesSection({
             entries={
               memories.status === 'ready' ? memories.data.pending : undefined
             }
+            actions={(entry) => (
+              <>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  disabled={reviewing}
+                  aria-label={t('page.pending.saveLabel', {
+                    content: entry.content,
+                  })}
+                  onClick={() => settle(entry.id, 'approved')}
+                >
+                  {t('page.pending.save')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={reviewing}
+                  aria-label={t('page.pending.discardLabel', {
+                    content: entry.content,
+                  })}
+                  onClick={() => settle(entry.id, 'rejected')}
+                >
+                  {t('page.pending.discard')}
+                </Button>
+              </>
+            )}
           />
           <MemoryList
             title={t('page.memories.title')}
@@ -303,6 +363,20 @@ function MemoriesSection({
             entries={
               memories.status === 'ready' ? memories.data.approved : undefined
             }
+            actions={(entry) => (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={removing}
+                aria-label={t('page.memories.deleteLabel', {
+                  content: entry.content,
+                })}
+                onClick={() => forget(entry.id)}
+              >
+                {t('page.memories.delete')}
+              </Button>
+            )}
           />
         </Stack>
       )}
@@ -313,18 +387,20 @@ function MemoriesSection({
 /**
  * One memory list under a plain label. `entries` is `undefined` while the
  * memories backend has not answered — the list says nothing has loaded rather
- * than claiming the user has no memories. The lists are read-only until the
- * memory mutations exist behind the same seam that feeds them; a review
- * control that silently did nothing would be worse than none.
+ * than claiming the user has no memories. Each row carries the controls that
+ * settle it (`actions`): a suggestion is saved or discarded, a saved memory
+ * deleted — the person decides, the model only proposes.
  */
 function MemoryList({
   title,
   empty,
   entries,
+  actions,
 }: {
   title: string;
   empty: string;
   entries?: readonly { id: string; content: string }[];
+  actions: (entry: { id: string; content: string }) => ReactNode;
 }) {
   const { t: tChat } = useT('chat');
 
@@ -344,6 +420,9 @@ function MemoryList({
           {entries.map((entry) => (
             <li key={entry.id} className="flex items-start gap-3 py-2">
               <Text className="flex-1">{entry.content}</Text>
+              <div className="flex shrink-0 items-center gap-1">
+                {actions(entry)}
+              </div>
             </li>
           ))}
         </ul>

--- a/services/platform/app/features/settings/personalization/hooks/mutations.ts
+++ b/services/platform/app/features/settings/personalization/hooks/mutations.ts
@@ -21,3 +21,18 @@ export function useUpsertMyPreferences() {
     errorToast: false,
   });
 }
+
+/** Settle a suggestion the model made: save it (approved) or discard it
+ * (rejected). Only a saved memory can ever be read back. */
+export function useReviewMemory() {
+  return useBackendMutation('chat/memories:reviewMemory', {
+    errorToast: false,
+  });
+}
+
+/** Delete a saved memory — it leaves what a search can return. */
+export function useDeleteMemory() {
+  return useBackendMutation('chat/memories:deleteMemory', {
+    errorToast: false,
+  });
+}

--- a/services/platform/app/lib/backend/chat.ts
+++ b/services/platform/app/lib/backend/chat.ts
@@ -162,8 +162,6 @@ export interface CreateChatThreadArgs {
   kind?: string;
   title?: string;
   agentSlug?: string;
-  harness?: string;
-  capabilities?: unknown;
   projectId?: string;
   reasoningEffort?: string;
 }

--- a/services/platform/app/lib/backend/contract/chat.ts
+++ b/services/platform/app/lib/backend/contract/chat.ts
@@ -121,6 +121,20 @@ export interface ChatContract {
       approved: Array<{ id: string; content: string }>;
     };
   };
+  'chat/memories:reviewMemory': {
+    kind: 'mutation';
+    args: {
+      organizationId: string;
+      memoryId: string;
+      decision: 'approved' | 'rejected';
+    };
+    returns: boolean;
+  };
+  'chat/memories:deleteMemory': {
+    kind: 'mutation';
+    args: { organizationId: string; memoryId: string };
+    returns: boolean;
+  };
   'chat/messages:getOrgChatHealth': {
     kind: 'query';
     args: { organizationId: string; periodDays: 1 | 7 | 30 };

--- a/services/platform/app/lib/backend/settings.ts
+++ b/services/platform/app/lib/backend/settings.ts
@@ -845,6 +845,18 @@ function invalidateMembers(
   });
 }
 
+function invalidateChatMemories(
+  client: Parameters<NonNullable<WriteAdapter['invalidate']>>[0],
+  args: Record<string, unknown>,
+  ctx: AdapterContext,
+): void {
+  const orgId = orgOf(args, ctx);
+  if (orgId === undefined) return;
+  void client.invalidateQueries({
+    queryKey: backendEntityPrefix(orgId, 'chat_memory'),
+  });
+}
+
 function invalidateUserPrefs(
   client: Parameters<NonNullable<WriteAdapter['invalidate']>>[0],
   args: Record<string, unknown>,
@@ -1060,6 +1072,28 @@ export const settingsWriteAdapters: Record<string, WriteAdapter> = {
         body: { enabled: args.enabled === true },
       }).then(() => null),
     invalidate: invalidateUserPrefs,
+  },
+  // The memories the preferences page reviews: the model proposes, the
+  // person settles — save (approve) or discard (reject) a suggestion, and
+  // delete a saved memory. Both refresh the page's memory lists.
+  'chat/memories:reviewMemory': {
+    run: (args, ctx) =>
+      backendFetch<{ ok: boolean }>(
+        `/chat/memories/${encodeURIComponent(String(args.memoryId))}/review`,
+        {
+          orgId: requireOrg(args, ctx),
+          body: { decision: args.decision },
+        },
+      ).then((body) => body.ok),
+    invalidate: invalidateChatMemories,
+  },
+  'chat/memories:deleteMemory': {
+    run: (args, ctx) =>
+      backendFetch<{ ok: boolean }>(
+        `/chat/memories/${encodeURIComponent(String(args.memoryId))}`,
+        { method: 'DELETE', orgId: requireOrg(args, ctx) },
+      ).then((body) => body.ok),
+    invalidate: invalidateChatMemories,
   },
   'user_preferences/mutations:setCustomInstructionsEnabled': {
     run: (args, ctx) =>

--- a/services/platform/backend/domains/chat/deferred-sends.test.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment node
+
+/**
+ * The parked send's ordering contract: the video claim, the row and its
+ * readiness poll commit TOGETHER, claim first and poll last — the poll wakes
+ * on the commit (pg-boss LISTEN/NOTIFY) and must find the whole row, never a
+ * video-only send whose ids a post-commit claim was still about to write.
+ * The real-Postgres run rides `integration-check.ts`; this locks the
+ * statement order and what the row carries.
+ */
+
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { addJobInTx, loadOwnedThread, runChatTurn, isBackendDraining } =
+  vi.hoisted(() => ({
+    addJobInTx: vi.fn(),
+    loadOwnedThread: vi.fn(),
+    runChatTurn: vi.fn(),
+    isBackendDraining: vi.fn(),
+  }));
+
+vi.mock('../../jobs/enqueue.ts', () => ({ addJobInTx }));
+vi.mock('./threads.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./threads.ts')>()),
+  loadOwnedThread,
+}));
+vi.mock('./service.ts', () => ({ runChatTurn }));
+vi.mock('../control/service.ts', () => ({ isBackendDraining }));
+
+import { enqueueDeferredSend, pollDeferredSend } from './deferred-sends.ts';
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+/**
+ * A transaction-aware fake `sql`. Every statement — pool or transaction —
+ * and every job send lands on ONE timeline, so a test can prove not just
+ * what ran but in which order and on which connection.
+ */
+function fakeSql(answer: (statement: Statement) => unknown[] | undefined): {
+  sql: Sql;
+  timeline: Array<{
+    lane: 'pool' | 'tx' | 'job';
+    text: string;
+    values: unknown[];
+  }>;
+} {
+  const timeline: Array<{
+    lane: 'pool' | 'tx' | 'job';
+    text: string;
+    values: unknown[];
+  }> = [];
+  const makeTag = (lane: 'pool' | 'tx') => {
+    const tag = (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const text = strings.join('?');
+      timeline.push({ lane, text, values });
+      return Promise.resolve(answer({ text, values }) ?? []);
+    };
+    tag.json = (value: unknown) => ({ json: value });
+    tag.unsafe = (text: string) => text;
+    return tag;
+  };
+  const pooled = Object.assign(makeTag('pool'), {
+    begin: (fn: (tx: unknown) => Promise<unknown>) => fn(makeTag('tx')),
+  });
+  addJobInTx.mockImplementation(
+    (_sql: unknown, name: string, data: Record<string, unknown>) => {
+      timeline.push({ lane: 'job', text: name, values: [data] });
+      return Promise.resolve('job-id');
+    },
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the deferred-send lane exercises exactly the tag, json, unsafe and begin surfaces faked here
+  return { sql: pooled as unknown as Sql, timeline };
+}
+
+const PARK = {
+  organizationId: 'org_1',
+  userId: 'user_1',
+  threadId: 'thread_1',
+  modelId: 'z-ai/glm-5.1',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadOwnedThread.mockResolvedValue({ id: 'thread_1' });
+  isBackendDraining.mockResolvedValue(false);
+});
+
+describe('enqueueDeferredSend', () => {
+  it('claims the videos inside the park transaction, writes them on the row, and enqueues the poll last', async () => {
+    const f = fakeSql(({ text, values }) => {
+      if (text.includes('UPDATE app.video_link_jobs')) {
+        return values.includes('job_1') ? [{ id: 'job_1' }] : [];
+      }
+      if (text.includes('INSERT INTO app.deferred_sends'))
+        return [{ id: 'ds_1' }];
+      if (text.includes('count(*)')) return [{ count: '0' }];
+      return undefined;
+    });
+
+    await expect(
+      enqueueDeferredSend(f.sql, {
+        ...PARK,
+        userText: '',
+        videoJobIds: ['job_1', 'job_foreign'],
+      }),
+    ).resolves.toEqual({ deferredSendId: 'ds_1' });
+
+    // Nothing ran on the pool: claim, insert and poll all rode the tx.
+    expect(f.timeline.every((entry) => entry.lane !== 'pool')).toBe(true);
+    const order = f.timeline.map((entry) =>
+      entry.lane === 'job'
+        ? `job:${entry.text}`
+        : entry.text.includes('UPDATE app.video_link_jobs')
+          ? 'claim'
+          : entry.text.includes('INSERT INTO app.deferred_sends')
+            ? 'insert'
+            : 'other',
+    );
+    expect(order).toEqual([
+      'other',
+      'claim',
+      'claim',
+      'insert',
+      'job:chat.deferred_send_poll',
+    ]);
+    // The row carries exactly the CLAIMED set — the foreign id was dropped.
+    const insert = f.timeline.find((entry) =>
+      entry.text.includes('INSERT INTO app.deferred_sends'),
+    );
+    expect(insert?.values).toContainEqual(['job_1']);
+    const poll = f.timeline.find((entry) => entry.lane === 'job');
+    expect(poll?.values[0]).toEqual({ deferredSendId: 'ds_1' });
+  });
+
+  it('refuses a video-only send whose ids were all unclaimable instead of parking an empty message', async () => {
+    const f = fakeSql(({ text }) => {
+      if (text.includes('count(*)')) return [{ count: '0' }];
+      return [];
+    });
+
+    await expect(
+      enqueueDeferredSend(f.sql, {
+        ...PARK,
+        userText: '',
+        videoJobIds: ['job_gone'],
+      }),
+    ).rejects.toMatchObject({ code: 'EMPTY_MESSAGE' });
+    expect(
+      f.timeline.some((entry) =>
+        entry.text.includes('INSERT INTO app.deferred_sends'),
+      ),
+    ).toBe(false);
+    expect(addJobInTx).not.toHaveBeenCalled();
+  });
+});
+
+describe('pollDeferredSend', () => {
+  it('keeps a video-only row parked while its claimed job is still ingesting', async () => {
+    const f = fakeSql(({ text }) => {
+      if (text.includes('FROM app.deferred_sends')) {
+        return [
+          {
+            id: 'ds_1',
+            organizationId: 'org_1',
+            userId: 'user_1',
+            threadId: 'thread_1',
+            userText: '',
+            attachments: null,
+            modelId: 'z-ai/glm-5.1',
+            modelSelection: null,
+            providerSlug: null,
+            reasoningEffort: null,
+            locale: 'en',
+            status: 'waiting',
+            createdAt: 1,
+            waitingSince: Date.now(),
+            videoJobIds: ['job_1'],
+          },
+        ];
+      }
+      if (text.includes('FROM app.video_link_jobs')) {
+        return [{ status: 'ingesting', transcriptionStatus: null }];
+      }
+      return undefined;
+    });
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).resolves.toBe('waiting');
+    expect(runChatTurn).not.toHaveBeenCalled();
+    expect(addJobInTx).toHaveBeenCalledWith(
+      f.sql,
+      'chat.deferred_send_poll',
+      { deferredSendId: 'ds_1' },
+      expect.objectContaining({ singletonKey: 'ds_1' }),
+    );
+  });
+});

--- a/services/platform/backend/domains/chat/deferred-sends.test.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.test.ts
@@ -1,12 +1,19 @@
 // @vitest-environment node
 
 /**
- * The parked send's ordering contract: the video claim, the row and its
- * readiness poll commit TOGETHER, claim first and poll last — the poll wakes
- * on the commit (pg-boss LISTEN/NOTIFY) and must find the whole row, never a
- * video-only send whose ids a post-commit claim was still about to write.
+ * The parked send's contracts, on a fake `sql`:
+ *
+ *  - park: the video claim, the row and its readiness poll commit TOGETHER,
+ *    claim first and poll last — the poll wakes on the commit (pg-boss
+ *    LISTEN/NOTIFY) and must find the whole row, never a video-only send
+ *    whose ids a post-commit claim was still about to write;
+ *  - fire: the tray row settles the moment the turn persists the user
+ *    message (never bubble + "sending" row together), and a send the turn
+ *    refused or dropped BEFORE that write leaves its trace in the thread
+ *    instead of vanishing.
+ *
  * The real-Postgres run rides `integration-check.ts`; this locks the
- * statement order and what the row carries.
+ * statement order and what the rows carry.
  */
 
 import type { Sql } from 'postgres';
@@ -196,5 +203,144 @@ describe('pollDeferredSend', () => {
       { deferredSendId: 'ds_1' },
       expect.objectContaining({ singletonKey: 'ds_1' }),
     );
+  });
+});
+
+describe('pollDeferredSend — settle at user append, trace on failure', () => {
+  const READY_ROW = {
+    id: 'ds_1',
+    organizationId: 'org_1',
+    userId: 'user_1',
+    threadId: 'thread_1',
+    userText: 'Summarize this',
+    attachments: null,
+    modelId: 'z-ai/glm-5.1',
+    modelSelection: null,
+    providerSlug: null,
+    reasoningEffort: null,
+    locale: 'en',
+    status: 'waiting',
+    createdAt: 1,
+    waitingSince: Date.now(),
+    videoJobIds: null,
+  };
+
+  function readySql() {
+    let order = 0;
+    return fakeSql(({ text }) => {
+      if (text.includes('FROM app.deferred_sends')) return [READY_ROW];
+      if (text.includes('UPDATE app.deferred_sends')) return [{ id: 'ds_1' }];
+      if (text.includes('INSERT INTO app.messages')) {
+        order += 1;
+        return [{ id: `m_${order}`, order }];
+      }
+      return [];
+    });
+  }
+
+  const messageInserts = (timeline: ReturnType<typeof fakeSql>['timeline']) =>
+    timeline.filter((entry) => entry.text.includes('INSERT INTO app.messages'));
+  const settleIndex = (timeline: ReturnType<typeof fakeSql>['timeline']) =>
+    timeline.findIndex((entry) =>
+      entry.text.includes('DELETE FROM app.deferred_sends'),
+    );
+
+  it('settles the tray row the moment the user message is durable, before the turn settles', async () => {
+    const f = readySql();
+    let settledBeforeTurnEnd = false;
+    runChatTurn.mockImplementation(
+      async (
+        _sql: unknown,
+        request: { onUserMessageAppended?: () => Promise<void> },
+      ) => {
+        await request.onUserMessageAppended?.();
+        settledBeforeTurnEnd = settleIndex(f.timeline) !== -1;
+        return { status: 'completed', steps: ['done'], text: 'ok' };
+      },
+    );
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).resolves.toBe('ran');
+    expect(settledBeforeTurnEnd).toBe(true);
+    // A completed turn wrote its own rows through the store — no trace.
+    expect(messageInserts(f.timeline)).toHaveLength(0);
+  });
+
+  it('leaves the user row and an assistant error row when the turn is refused before the pipeline opened', async () => {
+    runChatTurn.mockResolvedValue({
+      status: 'refused',
+      steps: [],
+      step: 'input-guardrails',
+      reason: 'Model "z-ai/glm-5.1" is not available for your account.',
+    });
+    const f = readySql();
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).resolves.toBe('ran');
+    const inserts = messageInserts(f.timeline);
+    expect(inserts).toHaveLength(2);
+    // values: thread, org, role, parts, text, model, provider, usage,
+    // blockedReason, truncation, error, status, now, thread
+    expect(inserts[0]?.values[2]).toBe('user');
+    expect(inserts[0]?.values[3]).toEqual({
+      json: [{ type: 'text', text: 'Summarize this' }],
+    });
+    expect(inserts[0]?.values[4]).toBe('Summarize this');
+    expect(inserts[1]?.values[2]).toBe('assistant');
+    expect(inserts[1]?.values[5]).toBe('z-ai/glm-5.1');
+    expect(String(inserts[1]?.values[10])).toMatch(/^TALE_ERR1 /);
+    expect(String(inserts[1]?.values[10])).toContain(
+      'is not available for your account',
+    );
+    // The trace lands BEFORE the tray row settles: no window with neither.
+    const settleAt = settleIndex(f.timeline);
+    expect(settleAt).toBeGreaterThan(f.timeline.indexOf(inserts[1]!));
+  });
+
+  it('leaves no second trace for a guardrail refusal — the pipeline appended its blocked row', async () => {
+    runChatTurn.mockResolvedValue({
+      status: 'refused',
+      steps: ['input-guardrails'],
+      step: 'input-guardrails',
+      reason: 'Blocked by the input filter.',
+    });
+    const f = readySql();
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).resolves.toBe('ran');
+    expect(messageInserts(f.timeline)).toHaveLength(0);
+    expect(settleIndex(f.timeline)).not.toBe(-1);
+  });
+
+  it('traces a turn that threw before the user message was appended, settles the row, then rethrows', async () => {
+    runChatTurn.mockRejectedValue(new Error('Unknown model "z-ai/glm-5.1"'));
+    const f = readySql();
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).rejects.toThrow(
+      'Unknown model',
+    );
+    const inserts = messageInserts(f.timeline);
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0]?.values[2]).toBe('user');
+    expect(inserts[1]?.values[2]).toBe('assistant');
+    expect(String(inserts[1]?.values[10])).toContain('Unknown model');
+    expect(settleIndex(f.timeline)).toBeGreaterThan(
+      f.timeline.indexOf(inserts[1]!),
+    );
+  });
+
+  it('adds no trace for a failure the placeholder already carries', async () => {
+    runChatTurn.mockImplementation(
+      async (
+        _sql: unknown,
+        request: { onUserMessageAppended?: () => Promise<void> },
+      ) => {
+        await request.onUserMessageAppended?.();
+        throw new Error('stream died');
+      },
+    );
+    const f = readySql();
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).rejects.toThrow(
+      'stream died',
+    );
+    expect(messageInserts(f.timeline)).toHaveLength(0);
   });
 });

--- a/services/platform/backend/domains/chat/deferred-sends.test.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.test.ts
@@ -19,15 +19,25 @@
 import type { Sql } from 'postgres';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { addJobInTx, loadOwnedThread, runChatTurn, isBackendDraining } =
-  vi.hoisted(() => ({
-    addJobInTx: vi.fn(),
-    loadOwnedThread: vi.fn(),
-    runChatTurn: vi.fn(),
-    isBackendDraining: vi.fn(),
-  }));
+const {
+  addJobInTx,
+  loadOwnedThread,
+  runChatTurn,
+  isBackendDraining,
+  cancelDeferredJobs,
+} = vi.hoisted(() => ({
+  addJobInTx: vi.fn(),
+  loadOwnedThread: vi.fn(),
+  runChatTurn: vi.fn(),
+  isBackendDraining: vi.fn(),
+  cancelDeferredJobs: vi.fn(),
+}));
 
 vi.mock('../../jobs/enqueue.ts', () => ({ addJobInTx }));
+vi.mock('../video_links/service.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../video_links/service.ts')>()),
+  cancelDeferredJobs,
+}));
 vi.mock('./threads.ts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./threads.ts')>()),
   loadOwnedThread,
@@ -35,7 +45,11 @@ vi.mock('./threads.ts', async (importOriginal) => ({
 vi.mock('./service.ts', () => ({ runChatTurn }));
 vi.mock('../control/service.ts', () => ({ isBackendDraining }));
 
-import { enqueueDeferredSend, pollDeferredSend } from './deferred-sends.ts';
+import {
+  cancelDeferredSendsForThread,
+  enqueueDeferredSend,
+  pollDeferredSend,
+} from './deferred-sends.ts';
 
 interface Statement {
   text: string;
@@ -90,10 +104,44 @@ const PARK = {
   modelId: 'z-ai/glm-5.1',
 };
 
+/** A parked row the poll finds ready: no attachments, no videos unless
+ * overridden, its thread idle. */
+function readyRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'ds_1',
+    organizationId: 'org_1',
+    userId: 'user_1',
+    threadId: 'thread_1',
+    userText: 'Summarize this',
+    attachments: null,
+    modelId: 'z-ai/glm-5.1',
+    modelSelection: null,
+    providerSlug: null,
+    reasoningEffort: null,
+    locale: 'en',
+    status: 'waiting',
+    createdAt: 1,
+    waitingSince: Date.now(),
+    videoJobIds: null,
+    ...overrides,
+  };
+}
+
+type Timeline = ReturnType<typeof fakeSql>['timeline'];
+const messageInserts = (timeline: Timeline) =>
+  timeline.filter((entry) => entry.text.includes('INSERT INTO app.messages'));
+const settleIndex = (timeline: Timeline) =>
+  timeline.findIndex((entry) =>
+    entry.text.includes('DELETE FROM app.deferred_sends'),
+  );
+const releaseStatement = (timeline: Timeline) =>
+  timeline.find((entry) => entry.text.includes('message_bound_at_ms = NULL'));
+
 beforeEach(() => {
   vi.clearAllMocks();
   loadOwnedThread.mockResolvedValue({ id: 'thread_1' });
   isBackendDraining.mockResolvedValue(false);
+  cancelDeferredJobs.mockResolvedValue(undefined);
 });
 
 describe('enqueueDeferredSend', () => {
@@ -207,28 +255,10 @@ describe('pollDeferredSend', () => {
 });
 
 describe('pollDeferredSend — settle at user append, trace on failure', () => {
-  const READY_ROW = {
-    id: 'ds_1',
-    organizationId: 'org_1',
-    userId: 'user_1',
-    threadId: 'thread_1',
-    userText: 'Summarize this',
-    attachments: null,
-    modelId: 'z-ai/glm-5.1',
-    modelSelection: null,
-    providerSlug: null,
-    reasoningEffort: null,
-    locale: 'en',
-    status: 'waiting',
-    createdAt: 1,
-    waitingSince: Date.now(),
-    videoJobIds: null,
-  };
-
   function readySql() {
     let order = 0;
     return fakeSql(({ text }) => {
-      if (text.includes('FROM app.deferred_sends')) return [READY_ROW];
+      if (text.includes('FROM app.deferred_sends')) return [readyRow()];
       if (text.includes('UPDATE app.deferred_sends')) return [{ id: 'ds_1' }];
       if (text.includes('INSERT INTO app.messages')) {
         order += 1;
@@ -237,13 +267,6 @@ describe('pollDeferredSend — settle at user append, trace on failure', () => {
       return [];
     });
   }
-
-  const messageInserts = (timeline: ReturnType<typeof fakeSql>['timeline']) =>
-    timeline.filter((entry) => entry.text.includes('INSERT INTO app.messages'));
-  const settleIndex = (timeline: ReturnType<typeof fakeSql>['timeline']) =>
-    timeline.findIndex((entry) =>
-      entry.text.includes('DELETE FROM app.deferred_sends'),
-    );
 
   it('settles the tray row the moment the user message is durable, before the turn settles', async () => {
     const f = readySql();
@@ -342,5 +365,130 @@ describe('pollDeferredSend — settle at user append, trace on failure', () => {
       'stream died',
     );
     expect(messageInserts(f.timeline)).toHaveLength(0);
+  });
+});
+
+describe('pollDeferredSend — the thread and the claimed videos at fire time', () => {
+  it("drops a parked send whose thread is no longer the owner's active thread and releases its videos", async () => {
+    loadOwnedThread.mockResolvedValue(null);
+    const f = fakeSql(({ text }) =>
+      text.includes('FROM app.deferred_sends')
+        ? [readyRow({ videoJobIds: ['job_1'] })]
+        : [],
+    );
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).resolves.toBe('gone');
+    expect(runChatTurn).not.toHaveBeenCalled();
+    expect(addJobInTx).not.toHaveBeenCalled();
+    expect(settleIndex(f.timeline)).not.toBe(-1);
+    // The claim is undone for the jobs no message carries — the predicate
+    // rides the statement; here it is the set that matters.
+    expect(releaseStatement(f.timeline)?.values[0]).toEqual(['job_1']);
+  });
+
+  it('sends the transcripts that are ready and releases the claimed videos the send did not carry', async () => {
+    runChatTurn.mockResolvedValue({
+      status: 'completed',
+      steps: ['done'],
+      text: 'ok',
+    });
+    const f = fakeSql(({ text, values }) => {
+      if (text.includes('FROM app.deferred_sends')) {
+        return [readyRow({ videoJobIds: ['job_ready', 'job_late'] })];
+      }
+      if (text.includes('UPDATE app.deferred_sends')) return [{ id: 'ds_1' }];
+      if (text.includes('j.storage_ref')) {
+        // buildBoundJobAttachments: one transcript landed, one did not.
+        return values.includes('job_ready')
+          ? [
+              {
+                storageRef: 'blob_ready',
+                videoTitle: 'Clip',
+                status: 'completed',
+                transcriptionStatus: null,
+                size: 10,
+              },
+            ]
+          : [
+              {
+                storageRef: 'blob_late',
+                videoTitle: 'Late clip',
+                status: 'transcribing_handoff',
+                transcriptionStatus: 'failed',
+                size: 5,
+              },
+            ];
+      }
+      if (text.includes('FROM app.video_link_jobs j')) {
+        // readiness: terminal either way (failed proceeds degraded)
+        return values.includes('job_ready')
+          ? [{ status: 'completed', transcriptionStatus: null }]
+          : [{ status: 'transcribing_handoff', transcriptionStatus: 'failed' }];
+      }
+      return [];
+    });
+
+    await expect(pollDeferredSend(f.sql, 'ds_1')).resolves.toBe('ran');
+    expect(runChatTurn).toHaveBeenCalledWith(
+      f.sql,
+      expect.objectContaining({
+        attachments: [
+          {
+            fileId: 'blob_ready',
+            fileName: 'Clip',
+            fileType: 'video/mp4',
+            fileSize: 10,
+          },
+        ],
+      }),
+    );
+    // Both claimed ids go through the release; the SQL predicate keeps the
+    // one the user row now carries and frees the other.
+    const release = releaseStatement(f.timeline);
+    expect(release?.values[0]).toEqual(['job_ready', 'job_late']);
+    expect(f.timeline.indexOf(release!)).toBeGreaterThan(
+      settleIndex(f.timeline),
+    );
+  });
+});
+
+describe('cancelDeferredSendsForThread', () => {
+  it("deletes the thread's waiting rows and cancels their claimed media", async () => {
+    const f = fakeSql(({ text }) =>
+      text.includes('DELETE FROM app.deferred_sends')
+        ? [
+            { id: 'ds_1', videoJobIds: ['job_1'] },
+            { id: 'ds_2', videoJobIds: null },
+          ]
+        : [],
+    );
+
+    await expect(
+      cancelDeferredSendsForThread(f.sql, {
+        organizationId: 'org_1',
+        userId: 'user_1',
+        threadId: 'thread_1',
+      }),
+    ).resolves.toBe(2);
+    const deletion = f.timeline.find((entry) =>
+      entry.text.includes('DELETE FROM app.deferred_sends'),
+    );
+    // Waiting rows only — a claimed one is running and settles itself.
+    expect(deletion?.text).toContain("status = 'waiting'");
+    expect(deletion?.values).toEqual(['thread_1', 'org_1', 'user_1']);
+    expect(cancelDeferredJobs).toHaveBeenNthCalledWith(
+      1,
+      f.sql,
+      'org_1',
+      ['job_1'],
+      'user_1',
+    );
+    expect(cancelDeferredJobs).toHaveBeenNthCalledWith(
+      2,
+      f.sql,
+      'org_1',
+      [],
+      'user_1',
+    );
   });
 });

--- a/services/platform/backend/domains/chat/deferred-sends.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.ts
@@ -1,6 +1,15 @@
 import type { Sql } from 'postgres';
 
-import { ThreadBusyError } from '../../../lib/chat/turn.ts';
+import {
+  ThreadBusyError,
+  userTurnParts,
+  type TurnOutcome,
+} from '../../../lib/chat/turn.ts';
+import {
+  classifyChatErrorCode,
+  encodeChatError,
+  type ChatErrorCode,
+} from '../../../lib/shared/chat-errors.ts';
 import { toJson } from '../../db/sql.ts';
 import { addJobInTx } from '../../jobs/enqueue.ts';
 import { isBackendDraining } from '../control/service.ts';
@@ -10,6 +19,7 @@ import {
   cancelDeferredJobs,
 } from '../video_links/service.ts';
 import { runChatTurn } from './service.ts';
+import { appendAssistantErrorMessage, appendMessageRow } from './store.ts';
 import { ChatThreadError, loadOwnedThread } from './threads.ts';
 
 /**
@@ -358,9 +368,48 @@ export async function isDeferredSendReady(
 }
 
 /**
+ * The failure trace for a parked send that never reached the pipeline —
+ * refused at a pre-flight gate (model access, attachment ownership, no
+ * model) or thrown before the turn-open write. The direct lane hands such a
+ * refusal back to the composer and the REST lane appends an assistant error
+ * row; this lane has nobody waiting, so the parked message lands as its
+ * user row (the text plus the attachments it carried) followed by the error
+ * row, where the reply would have been. The tray row settles in the caller's
+ * `finally`. A failure INSIDE the pipeline needs none of this: the turn-open
+ * write persisted the user row and the placeholder carries the error.
+ */
+async function leaveFailureTrace(
+  sql: Sql,
+  row: DeferredSendRow,
+  attachments: readonly DeferredAttachment[],
+  failure: { code: ChatErrorCode; raw: string },
+): Promise<void> {
+  await appendMessageRow(sql, {
+    organizationId: row.organizationId,
+    threadId: row.threadId,
+    role: 'user',
+    parts: userTurnParts(row.userText, attachments),
+    text: row.userText,
+  });
+  await appendAssistantErrorMessage(sql, {
+    organizationId: row.organizationId,
+    threadId: row.threadId,
+    ...(row.modelId !== null ? { model: row.modelId } : {}),
+    error: encodeChatError({
+      code: failure.code,
+      ...(row.modelId !== null ? { model: row.modelId } : {}),
+      raw: failure.raw,
+    }),
+  });
+}
+
+/**
  * One poll step: not ready (or the thread busy) → re-enqueue with the aged
- * backoff; ready + idle → claim and run the turn under the stored identity,
- * settling (deleting) the row in a `finally` — the 0.4 mop-up posture. A
+ * backoff; ready + idle → claim and run the turn under the stored identity.
+ * The row settles the moment the turn persists the user message (the tray
+ * row and the bubble must never show together) and, as the mop-up for a
+ * turn that refused or threw before that, in a `finally` — the 0.4 posture,
+ * plus a trace in the thread for a message that would otherwise vanish. A
  * deleted row (user cancelled) ends the chain silently. Returns what it did
  * for the integration run's observability.
  */
@@ -413,7 +462,14 @@ export async function pollDeferredSend(
   `;
   if (claimed.length === 0) return 'gone';
 
+  const settle = async (): Promise<void> => {
+    await sql`DELETE FROM app.deferred_sends WHERE id = ${row.id}`;
+  };
   let parkedAgain = false;
+  // Flipped by the turn's own store hook once the user row is durable: from
+  // there the thread shows the bubble and the tray row is redundant; before
+  // it, a refusal or a throw has left NOTHING of the message behind.
+  let userAppended = false;
   try {
     // The claimed videos' transcripts join the send now (the 0.4
     // `buildBoundJobAttachments` semantics — a job without a completed
@@ -427,52 +483,85 @@ export async function pollDeferredSend(
           )
         : [];
     const attachments = [...row.attachments, ...videoAttachments];
-    const outcome = await runChatTurn(sql, {
-      organizationId: row.organizationId,
-      userId: row.userId,
-      threadId: row.threadId,
-      userText: row.userText,
-      ...(attachments.length > 0 ? { attachments } : {}),
-      ...(row.modelId !== null ? { modelId: row.modelId } : {}),
-      ...(row.modelSelection === 'auto'
-        ? { modelSelection: 'auto' as const }
-        : {}),
-      ...(row.providerSlug !== null ? { providerSlug: row.providerSlug } : {}),
-      ...(row.reasoningEffort !== null
-        ? {
-            // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column CHECK admits exactly the effort union
-            reasoningEffort: row.reasoningEffort as never,
-          }
-        : {}),
-      locale: row.locale,
-    });
+    let outcome: TurnOutcome;
+    try {
+      outcome = await runChatTurn(sql, {
+        organizationId: row.organizationId,
+        userId: row.userId,
+        threadId: row.threadId,
+        userText: row.userText,
+        ...(attachments.length > 0 ? { attachments } : {}),
+        ...(row.modelId !== null ? { modelId: row.modelId } : {}),
+        ...(row.modelSelection === 'auto'
+          ? { modelSelection: 'auto' as const }
+          : {}),
+        ...(row.providerSlug !== null
+          ? { providerSlug: row.providerSlug }
+          : {}),
+        ...(row.reasoningEffort !== null
+          ? {
+              // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the column CHECK admits exactly the effort union
+              reasoningEffort: row.reasoningEffort as never,
+            }
+          : {}),
+        locale: row.locale,
+        // The turn-open write persisted the user message: settle the tray
+        // row NOW (the 0.4 `settleDeferredSendOnUserAppend` wiring), not at
+        // the end of a generation that may run for minutes. Idempotent with
+        // the finally below.
+        onUserMessageAppended: async () => {
+          userAppended = true;
+          await settle();
+        },
+      });
+    } catch (error) {
+      // Lost the thread to a send that slipped in between the busy read
+      // above and the turn's atomic open. Nothing was appended, so this is
+      // the same "wait our turn" as the read — park the row again rather
+      // than drop the message into a deleted tray row.
+      if (error instanceof ThreadBusyError) {
+        await sql`
+          UPDATE app.deferred_sends
+          SET status = 'waiting', waiting_since_ms = ${Date.now()}
+          WHERE id = ${row.id} AND status = 'claimed'
+        `;
+        await reschedule(READY_POLL_MS);
+        parkedAgain = true;
+        return 'busy';
+      }
+      if (!userAppended) {
+        // Threw before the turn-open write (an unknown model, an unusable
+        // credential): the thread would show nothing of the message.
+        await leaveFailureTrace(sql, row, attachments, {
+          code: classifyChatErrorCode(error),
+          raw:
+            error instanceof Error
+              ? error.message
+              : 'The turn could not be started.',
+        });
+      }
+      throw error;
+    }
     if (outcome.status === 'refused') {
       console.warn(
         `[deferred-send] turn refused for ${row.id}: ${outcome.reason}`,
       );
+      // `steps` is empty exactly for the pre-flight refusals (`executeTurn`
+      // refuses before the pipeline runs); a guardrail refusal inside the
+      // pipeline already appended its blocked assistant row.
+      if (outcome.steps.length === 0) {
+        await leaveFailureTrace(sql, row, attachments, {
+          code: 'generic',
+          raw: outcome.reason,
+        });
+      }
     }
-  } catch (error) {
-    // Lost the thread to a send that slipped in between the busy read above
-    // and the turn's atomic open. Nothing was appended, so this is the same
-    // "wait our turn" as the read — park the row again rather than drop the
-    // message into a deleted tray row.
-    if (error instanceof ThreadBusyError) {
-      await sql`
-        UPDATE app.deferred_sends
-        SET status = 'waiting', waiting_since_ms = ${Date.now()}
-        WHERE id = ${row.id} AND status = 'claimed'
-      `;
-      await reschedule(READY_POLL_MS);
-      parkedAgain = true;
-      return 'busy';
-    }
-    throw error;
   } finally {
     // The terminal mop-up: the row settles whether the turn completed,
-    // refused, or threw — the thread shows the bubble (or nothing), and the
-    // tray row would only double-display or wedge.
+    // refused, or threw — the thread shows the bubble (or the trace), and
+    // the tray row would only double-display or wedge.
     if (!parkedAgain) {
-      await sql`DELETE FROM app.deferred_sends WHERE id = ${row.id}`;
+      await settle();
     }
   }
   return 'ran';

--- a/services/platform/backend/domains/chat/deferred-sends.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.ts
@@ -121,7 +121,8 @@ async function loadRow(
   };
 }
 
-/** Park a send; the poller job rides the insert's transaction. */
+/** Park a send; the video claim and the poller job ride the insert's
+ * transaction, in that order. */
 export async function enqueueDeferredSend(
   sql: Sql,
   args: {
@@ -152,11 +153,8 @@ export async function enqueueDeferredSend(
     throw new ChatThreadError('THREAD_NOT_FOUND', 'Thread not found', 404);
   }
   const trimmed = args.userText.trim();
-  if (
-    trimmed.length === 0 &&
-    (args.attachments?.length ?? 0) === 0 &&
-    (args.videoJobIds?.length ?? 0) === 0
-  ) {
+  const hasBody = trimmed.length > 0 || (args.attachments?.length ?? 0) > 0;
+  if (!hasBody && (args.videoJobIds?.length ?? 0) === 0) {
     throw new ChatThreadError('EMPTY_MESSAGE', 'Nothing to send');
   }
   if (
@@ -173,12 +171,30 @@ export async function enqueueDeferredSend(
     if (Number(pending[0]?.count ?? '0') >= MAX_DEFERRED_PER_THREAD) {
       throw new ChatThreadError('QUEUE_FULL', 'Too many parked sends', 409);
     }
+    // The video claim rides the insert's transaction, BEFORE the row and
+    // its poll exist: the claim releases the composer chips and stamps the
+    // row's set in the same commit the first poll wakes on, so a video-only
+    // send can never fire clip-less because the poll read the row a few ms
+    // before a post-commit claim wrote its ids. An unclaimable id (foreign,
+    // already bound, cancelled) is dropped — the 0.4 posture.
+    const claimedVideos =
+      args.videoJobIds !== undefined && args.videoJobIds.length > 0
+        ? await bindJobsForDeferredSend(tx, {
+            jobIds: args.videoJobIds,
+            userId: args.userId,
+            threadId: args.threadId,
+            organizationId: args.organizationId,
+          })
+        : [];
+    if (!hasBody && claimedVideos.length === 0) {
+      throw new ChatThreadError('EMPTY_MESSAGE', 'Nothing to send');
+    }
     const now = Date.now();
     const rows = await tx<{ id: string }[]>`
       INSERT INTO app.deferred_sends (
-        org_id, user_id, thread_id, user_text, attachments, model_id,
-        model_selection, provider_slug, reasoning_effort, locale, status,
-        created_at_ms, waiting_since_ms
+        org_id, user_id, thread_id, user_text, attachments, video_job_ids,
+        model_id, model_selection, provider_slug, reasoning_effort, locale,
+        status, created_at_ms, waiting_since_ms
       ) VALUES (
         ${args.organizationId}, ${args.userId}, ${args.threadId}, ${trimmed},
         ${
@@ -186,6 +202,7 @@ export async function enqueueDeferredSend(
             ? tx.json(toJson(args.attachments))
             : null
         },
+        ${claimedVideos.length > 0 ? claimedVideos : null},
         ${args.modelId ?? null}, ${args.modelSelection ?? null},
         ${args.providerSlug ?? null}, ${args.reasoningEffort ?? null},
         ${args.locale ?? 'en'}, 'waiting', ${now}, ${now}
@@ -196,6 +213,7 @@ export async function enqueueDeferredSend(
     // The per-send singletonKey (queue policy 'short') collapses the poll
     // self-chain to at most one queued hop, so the watchdog can blindly
     // re-enqueue a poll for a stalled row without doubling a live chain.
+    // Enqueued LAST: the poll wakes on this commit and finds the whole row.
     await addJobInTx(
       tx,
       'chat.deferred_send_poll',
@@ -204,36 +222,6 @@ export async function enqueueDeferredSend(
     );
     return { deferredSendId };
   });
-}
-
-/** The enqueue's video half, OUTSIDE the insert tx: claim the jobs, then
- * stamp the claimed set on the row (the claim releases the composer chips;
- * an unclaimable id — foreign, already bound, cancelled — is dropped, the
- * 0.4 posture). */
-export async function claimDeferredSendVideos(
-  sql: Sql,
-  args: {
-    organizationId: string;
-    userId: string;
-    threadId: string;
-    deferredSendId: string;
-    videoJobIds: readonly string[];
-  },
-): Promise<string[]> {
-  const claimed = await bindJobsForDeferredSend(sql, {
-    jobIds: args.videoJobIds,
-    userId: args.userId,
-    threadId: args.threadId,
-    organizationId: args.organizationId,
-  });
-  if (claimed.length > 0) {
-    await sql`
-      UPDATE app.deferred_sends
-      SET video_job_ids = ${claimed}
-      WHERE id = ${args.deferredSendId} AND org_id = ${args.organizationId}
-    `;
-  }
-  return claimed;
 }
 
 /** Abandon a waiting send. A `claimed` row is already running — too late,

--- a/services/platform/backend/domains/chat/deferred-sends.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.ts
@@ -17,6 +17,7 @@ import {
   bindJobsForDeferredSend,
   buildBoundJobAttachments,
   cancelDeferredJobs,
+  unbindJobsWithoutMessage,
 } from '../video_links/service.ts';
 import { runChatTurn } from './service.ts';
 import { appendAssistantErrorMessage, appendMessageRow } from './store.ts';
@@ -259,6 +260,31 @@ export async function cancelDeferredSend(
   return true;
 }
 
+/** Trashing a conversation abandons every send still parked on it — the
+ * same cascade as cancelling each by hand (a `claimed` row is already
+ * running and settles itself). Called by the trash door after the thread
+ * flipped; a poll that fires in between is re-gated at fire time. */
+export async function cancelDeferredSendsForThread(
+  sql: Sql,
+  args: { organizationId: string; userId: string; threadId: string },
+): Promise<number> {
+  const rows = await sql<{ id: string; videoJobIds: unknown }[]>`
+    DELETE FROM app.deferred_sends
+    WHERE thread_id = ${args.threadId} AND org_id = ${args.organizationId}
+      AND user_id = ${args.userId} AND status = 'waiting'
+    RETURNING id, video_job_ids AS "videoJobIds"
+  `;
+  for (const row of rows) {
+    await cancelDeferredJobs(
+      sql,
+      args.organizationId,
+      readVideoJobIds(row.videoJobIds),
+      args.userId,
+    );
+  }
+  return rows.length;
+}
+
 /** The thread's parked sends, oldest first — the tray above the composer. */
 export async function listDeferredSends(
   sql: Sql,
@@ -420,6 +446,24 @@ export async function pollDeferredSend(
   const row = await loadRow(sql, deferredSendId);
   if (!row || row.status !== 'waiting') return 'gone';
 
+  // Re-gated against the thread's lifecycle at FIRE time, not only at park:
+  // a conversation trashed (or lost) while the send waited must not receive
+  // a reply — LLM spend into a thread the user cannot see, racing the
+  // retention purge. The row is dropped and its claimed videos go back to
+  // the composer.
+  if (
+    (await loadOwnedThread(
+      sql,
+      row.organizationId,
+      row.userId,
+      row.threadId,
+    )) === null
+  ) {
+    await sql`DELETE FROM app.deferred_sends WHERE id = ${row.id}`;
+    await releaseUnsentVideos(sql, row.organizationId, row.videoJobIds);
+    return 'gone';
+  }
+
   const reschedule = async (delayMs: number): Promise<void> => {
     await addJobInTx(
       sql,
@@ -559,12 +603,35 @@ export async function pollDeferredSend(
   } finally {
     // The terminal mop-up: the row settles whether the turn completed,
     // refused, or threw — the thread shows the bubble (or the trace), and
-    // the tray row would only double-display or wedge.
+    // the tray row would only double-display or wedge. The claimed videos
+    // the send did NOT carry (no transcript in time, or no message at all)
+    // are released, or they would stay hidden and unreapable forever.
     if (!parkedAgain) {
       await settle();
+      await releaseUnsentVideos(sql, row.organizationId, row.videoJobIds);
     }
   }
   return 'ran';
+}
+
+/** The bind is what a deferred send holds on its videos; once the send is
+ * over, only a job a SENT message carries keeps it (the predicate lives in
+ * the video-links domain). Best-effort: the row is already settled, and a
+ * failed release is the unbound-GC's loss, not the user's. */
+async function releaseUnsentVideos(
+  sql: Sql,
+  organizationId: string,
+  jobIds: readonly string[],
+): Promise<void> {
+  if (jobIds.length === 0) return;
+  try {
+    await unbindJobsWithoutMessage(sql, { organizationId, jobIds });
+  } catch (error) {
+    console.warn(
+      `[deferred-send] could not release ${jobIds.length} claimed video(s):`,
+      error,
+    );
+  }
 }
 
 /** A waiting row is re-polled once it is older than this — a floor to skip a
@@ -586,8 +653,8 @@ const CLAIMED_STALE_MS = 15 * 60 * 1000;
  *    chain is revived, so this never doubles the healthy fast-poll cadence.
  *  - a CLAIMED row wedged by a crash between the claim and the finally-DELETE
  *    is uncancellable (cancel needs 'waiting') and a permanent tray chip.
- *    Clear it. The chat-generation watchdog owns the thread's composer; this
- *    only removes the tray row. At-most-once LLM spend: the turn is never
+ *    Clear it and release its unsent videos. The chat-generation watchdog
+ *    owns the thread's composer; this only removes the tray row. At-most-once LLM spend: the turn is never
  *    re-run (a crash surfaces through the generation watchdog, not a rerun).
  *
  * `waiting_since_ms` is stamped at both park and claim, so it dates the
@@ -616,11 +683,22 @@ export async function recoverStuckDeferredSends(
     );
     repolled += 1;
   }
-  const cleared = await sql<{ id: string }[]>`
+  const cleared = await sql<
+    { id: string; organizationId: string; videoJobIds: unknown }[]
+  >`
     DELETE FROM app.deferred_sends
     WHERE status = 'claimed' AND waiting_since_ms < ${claimedCutoff}
-    RETURNING id
+    RETURNING id, org_id AS "organizationId", video_job_ids AS "videoJobIds"
   `;
+  // A wedged row's videos: the ones its (crashed) turn never sent go back
+  // to the composer; a job a persisted user row carries stays bound.
+  for (const row of cleared) {
+    await releaseUnsentVideos(
+      sql,
+      row.organizationId,
+      readVideoJobIds(row.videoJobIds),
+    );
+  }
   if (repolled > 0 || cleared.length > 0) {
     console.warn(
       `[deferred-send-watchdog] re-polled ${repolled} waiting, cleared ${cleared.length} wedged claimed`,

--- a/services/platform/backend/domains/chat/deferred-sends.watchdog.test.ts
+++ b/services/platform/backend/domains/chat/deferred-sends.watchdog.test.ts
@@ -10,12 +10,27 @@ import { recoverStuckDeferredSends } from './deferred-sends.ts';
  * scan rides the real-Postgres probe in `integration-check.ts`.
  */
 
-// oxlint-disable-next-line typescript/no-explicit-any -- test double for the postgres.js tag
-function scriptedSql(script: unknown[][]): any {
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+/** A scripted postgres.js tag: answers the statements in order and records
+ * what each one asked, so a test can assert on the follow-up writes too. */
+function scriptedSql(script: unknown[][]): {
+  // oxlint-disable-next-line typescript/no-explicit-any -- test double for the postgres.js tag
+  sql: any;
+  statements: Statement[];
+} {
   let i = 0;
+  const statements: Statement[] = [];
   const nextRows = (): unknown[] =>
     i < script.length ? (script[i++] ?? []) : [];
-  return () => Promise.resolve(nextRows());
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    statements.push({ text: strings.join('?'), values });
+    return Promise.resolve(nextRows());
+  };
+  return { sql, statements };
 }
 
 interface SentJob {
@@ -43,16 +58,25 @@ describe('recoverStuckDeferredSends', () => {
       },
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- only `send` is exercised
     } as never);
-    const sql = scriptedSql([
+    const { sql, statements } = scriptedSql([
       // waiting rows the sever-recovery re-polls
       [{ id: 'wait_1' }, { id: 'wait_2' }],
       // claimed rows the wedge-recovery deletes
-      [{ id: 'claim_1' }],
+      [{ id: 'claim_1', organizationId: 'org_1', videoJobIds: ['job_1'] }],
+      // the release of the cleared row's videos
+      [],
     ]);
 
     const result = await recoverStuckDeferredSends(sql);
 
     expect(result).toEqual({ repolled: 2, cleared: 1 });
+    // The wedged row's claimed videos go back to unbound (a job a persisted
+    // user row carries is kept by the statement's own predicate) — bound to
+    // a row that no longer exists they would stay hidden and unreapable.
+    const release = statements.find((statement) =>
+      statement.text.includes('message_bound_at_ms = NULL'),
+    );
+    expect(release?.values.slice(0, 2)).toEqual([['job_1'], 'org_1']);
     expect(sent).toHaveLength(2);
     expect(sent.every((job) => job.name === 'chat.deferred_send_poll')).toBe(
       true,
@@ -72,7 +96,7 @@ describe('recoverStuckDeferredSends', () => {
       },
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- only `send` is exercised
     } as never);
-    const sql = scriptedSql([[], []]);
+    const { sql } = scriptedSql([[], []]);
 
     const result = await recoverStuckDeferredSends(sql);
 

--- a/services/platform/backend/domains/chat/memories.test.ts
+++ b/services/platform/backend/domains/chat/memories.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment node
+
+/**
+ * The memories feature gate and the bounded reads, on a fake `sql`: the
+ * person's preference beats the org policy default, and with neither set
+ * the feature is OFF — a proposal is refused, retrieval answers nothing.
+ * The real-Postgres pass rides `integration-check.ts`.
+ */
+
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getMyPreferences, readGovernancePolicyForOrg, createAuditLog } =
+  vi.hoisted(() => ({
+    getMyPreferences: vi.fn(),
+    readGovernancePolicyForOrg: vi.fn(),
+    createAuditLog: vi.fn(),
+  }));
+
+vi.mock('../user_preferences/service.ts', () => ({ getMyPreferences }));
+vi.mock('../../lib/org-config.ts', () => ({ readGovernancePolicyForOrg }));
+vi.mock('../audit_logs/service.ts', () => ({ createAuditLog }));
+
+import {
+  deleteMemory,
+  isMemoriesEnabled,
+  saveMemory,
+  searchApprovedMemories,
+} from './memories.ts';
+
+interface Statement {
+  text: string;
+  values: unknown[];
+}
+
+function fakeSql(answer: (statement: Statement) => unknown[] | undefined): {
+  sql: Sql;
+  statements: Statement[];
+} {
+  const statements: Statement[] = [];
+  const tag = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join('?');
+    statements.push({ text, values });
+    return Promise.resolve(answer({ text, values }) ?? []);
+  };
+  const pooled = Object.assign(tag, {
+    begin: (fn: (tx: unknown) => Promise<unknown>) => fn(tag),
+  });
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the memories lane exercises exactly the tag and begin surfaces faked here
+  return { sql: pooled as unknown as Sql, statements };
+}
+
+const SCOPE = { organizationId: 'org_1', userId: 'user_1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getMyPreferences.mockResolvedValue(null);
+  readGovernancePolicyForOrg.mockResolvedValue(null);
+  createAuditLog.mockResolvedValue(undefined);
+});
+
+describe('isMemoriesEnabled', () => {
+  it('is OFF with neither a preference nor a policy row', async () => {
+    const { sql } = fakeSql(() => []);
+    await expect(isMemoriesEnabled(sql, SCOPE)).resolves.toBe(false);
+  });
+
+  it('follows the org policy default when the person has not chosen', async () => {
+    readGovernancePolicyForOrg.mockResolvedValue({ enabled: true });
+    const { sql } = fakeSql(() => []);
+    await expect(isMemoriesEnabled(sql, SCOPE)).resolves.toBe(true);
+    expect(readGovernancePolicyForOrg).toHaveBeenCalledWith(
+      sql,
+      'org_1',
+      'user_memories',
+    );
+  });
+
+  it("lets the person's explicit choice override the policy either way", async () => {
+    readGovernancePolicyForOrg.mockResolvedValue({ enabled: true });
+    getMyPreferences.mockResolvedValue({ memoriesEnabled: false });
+    const { sql } = fakeSql(() => []);
+    await expect(isMemoriesEnabled(sql, SCOPE)).resolves.toBe(false);
+
+    readGovernancePolicyForOrg.mockResolvedValue({ enabled: false });
+    getMyPreferences.mockResolvedValue({ memoriesEnabled: true });
+    await expect(isMemoriesEnabled(sql, SCOPE)).resolves.toBe(true);
+  });
+});
+
+describe('saveMemory', () => {
+  it('refuses a proposal while the feature is off and writes nothing', async () => {
+    const { sql, statements } = fakeSql(() => []);
+
+    await expect(
+      saveMemory(sql, { ...SCOPE, content: 'Prefers metric units' }),
+    ).rejects.toMatchObject({ code: 'MEMORIES_DISABLED', status: 403 });
+    expect(
+      statements.some((s) => s.text.includes('INSERT INTO app.memories')),
+    ).toBe(false);
+    expect(createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('lands the proposal pending, with its audit line, while the feature is on', async () => {
+    getMyPreferences.mockResolvedValue({ memoriesEnabled: true });
+    const { sql, statements } = fakeSql(({ text }) =>
+      text.includes('INSERT INTO app.memories') ? [{ id: 'mem_1' }] : [],
+    );
+
+    await expect(
+      saveMemory(sql, { ...SCOPE, content: '  Prefers metric units ' }),
+    ).resolves.toBe('mem_1');
+    const insert = statements.find((s) =>
+      s.text.includes('INSERT INTO app.memories'),
+    );
+    expect(insert?.values.slice(0, 3)).toEqual([
+      'org_1',
+      'user_1',
+      'Prefers metric units',
+    ]);
+    expect(insert?.text).toContain("'pending'");
+    expect(createAuditLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'memory.save', resourceId: 'mem_1' }),
+    );
+  });
+});
+
+describe('searchApprovedMemories', () => {
+  it('answers nothing while the feature is off, without touching the table', async () => {
+    const { sql, statements } = fakeSql(() => [
+      { id: 'mem_1', content: 'Prefers metric units', status: 'approved' },
+    ]);
+
+    await expect(
+      searchApprovedMemories(sql, { ...SCOPE, query: 'metric' }),
+    ).resolves.toEqual([]);
+    expect(statements).toHaveLength(0);
+  });
+
+  it('pushes the approved-only filter, the query and a bounded limit into the statement', async () => {
+    getMyPreferences.mockResolvedValue({ memoriesEnabled: true });
+    const { sql, statements } = fakeSql(() => []);
+
+    await searchApprovedMemories(sql, {
+      ...SCOPE,
+      query: 'me_tric%',
+      limit: 500,
+    });
+    const select = statements[0];
+    expect(select?.text).toContain("status = 'approved'");
+    expect(select?.text).toContain('ILIKE');
+    expect(select?.text).toContain('LIMIT');
+    // The query matches as literal text (LIKE metacharacters escaped) and
+    // the limit is capped at the retrieval ceiling.
+    expect(select?.values).toContain('%me\\_tric\\%%');
+    expect(select?.values.at(-1)).toBe(50);
+  });
+
+  it('binds no pattern for an empty query and the default limit', async () => {
+    getMyPreferences.mockResolvedValue({ memoriesEnabled: true });
+    const { sql, statements } = fakeSql(() => []);
+
+    await searchApprovedMemories(sql, { ...SCOPE, query: '  ' });
+    expect(statements[0]?.values).toContain(null);
+    expect(statements[0]?.values.at(-1)).toBe(20);
+  });
+});
+
+describe('deleteMemory', () => {
+  it("deletes only the caller's own row and reports whether one went", async () => {
+    const { sql, statements } = fakeSql(({ values }) =>
+      values.includes('mem_mine') ? [{ id: 'mem_mine' }] : [],
+    );
+
+    await expect(
+      deleteMemory(sql, { ...SCOPE, memoryId: 'mem_mine' }),
+    ).resolves.toBe(true);
+    await expect(
+      deleteMemory(sql, { ...SCOPE, memoryId: 'mem_theirs' }),
+    ).resolves.toBe(false);
+    for (const statement of statements) {
+      expect(statement.text).toContain('DELETE FROM app.memories');
+      expect(statement.values.slice(1)).toEqual(['org_1', 'user_1']);
+    }
+  });
+});

--- a/services/platform/backend/domains/chat/memories.ts
+++ b/services/platform/backend/domains/chat/memories.ts
@@ -1,6 +1,8 @@
 import type { Sql } from 'postgres';
 
+import { readGovernancePolicyForOrg } from '../../lib/org-config.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
+import { getMyPreferences } from '../user_preferences/service.ts';
 
 /**
  * Memories — durable facts about a person, gated behind approval; the 0.5
@@ -9,6 +11,13 @@ import { createAuditLog } from '../audit_logs/service.ts';
  * OWNER approves it. Every read and write scopes by BOTH organization and
  * user, and retrieval additionally filters to `approved`. Proposing is an
  * auditable act independent of any later approval.
+ *
+ * The feature itself is a knob the person and the org hold: the user's
+ * `memories_enabled` preference overrides the org's `user_memories` policy
+ * default, and with neither set it is OFF (the governance schema's
+ * posture). A proposal while it is off is refused, not queued; retrieval
+ * while it is off answers nothing. The listing and review doors are not
+ * gated — a person may always see and settle what was proposed about them.
  */
 
 export interface MemoryRecord {
@@ -20,7 +29,51 @@ export interface MemoryRecord {
   createdAt: number;
 }
 
-/** Save a pending memory and record the proposal in the audit trail. */
+export class MemoryError extends Error {
+  readonly code: string;
+  readonly status: 400 | 403;
+
+  constructor(code: string, message: string, status: 400 | 403 = 400) {
+    super(message);
+    this.name = 'MemoryError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/** The retrieval cap (`memory.search` asks for at most this many). */
+const SEARCH_LIMIT_MAX = 50;
+const SEARCH_LIMIT_DEFAULT = 20;
+/** More rows than the preferences page can review at once — a bound, not
+ * pagination: a person accrues proposals one conversation at a time. */
+const LIST_LIMIT = 200;
+
+/**
+ * Is the memories feature on for this (org, user)? The person's explicit
+ * preference wins; otherwise the org policy's default; otherwise OFF. The
+ * same cascade the preferences page renders (`resolveGate`).
+ */
+export async function isMemoriesEnabled(
+  sql: Sql,
+  scope: { organizationId: string; userId: string },
+): Promise<boolean> {
+  const preferences = await getMyPreferences(sql, {
+    userId: scope.userId,
+    orgId: scope.organizationId,
+  });
+  if (preferences?.memoriesEnabled !== undefined) {
+    return preferences.memoriesEnabled;
+  }
+  const policy = await readGovernancePolicyForOrg(
+    sql,
+    scope.organizationId,
+    'user_memories',
+  );
+  return policy?.enabled === true;
+}
+
+/** Save a pending memory and record the proposal in the audit trail.
+ * Refused (`MEMORIES_DISABLED`) while the feature is off for the person. */
 export async function saveMemory(
   sql: Sql,
   args: {
@@ -34,7 +87,14 @@ export async function saveMemory(
 ): Promise<string> {
   const content = args.content.trim();
   if (content.length === 0) {
-    throw new Error('A memory cannot be empty.');
+    throw new MemoryError('EMPTY_MEMORY', 'A memory cannot be empty.');
+  }
+  if (!(await isMemoriesEnabled(sql, args))) {
+    throw new MemoryError(
+      'MEMORIES_DISABLED',
+      'Memories are turned off for this account — nothing was saved.',
+      403,
+    );
   }
   return sql.begin(async (tx) => {
     const rows = await tx<{ id: string }[]>`
@@ -67,8 +127,15 @@ export async function saveMemory(
   });
 }
 
+/** A LIKE pattern that matches the query as literal text. */
+function containsPattern(query: string): string {
+  return `%${query.replace(/[\\%_]/g, (char) => `\\${char}`)}%`;
+}
+
 /** The approved memories the model may read — approved-only, (org, user)
- * scoped, so retrieval can never surface a proposal or another person's. */
+ * scoped, so retrieval can never surface a proposal or another person's;
+ * nothing at all while the feature is off for the person. The filter and
+ * the cap ride the query. */
 export async function searchApprovedMemories(
   sql: Sql,
   args: {
@@ -78,22 +145,24 @@ export async function searchApprovedMemories(
     limit?: number;
   },
 ): Promise<MemoryRecord[]> {
-  const rows = await sql<MemoryRecord[]>`
+  if (!(await isMemoriesEnabled(sql, args))) return [];
+  const limit = Math.min(
+    Math.max(Math.trunc(args.limit ?? SEARCH_LIMIT_DEFAULT), 1),
+    SEARCH_LIMIT_MAX,
+  );
+  const query = args.query?.trim();
+  const pattern =
+    query !== undefined && query.length > 0 ? containsPattern(query) : null;
+  return sql<MemoryRecord[]>`
     SELECT id, org_id AS "organizationId", user_id AS "userId", content,
            status, created_at_ms::float8 AS "createdAt"
     FROM app.memories
     WHERE org_id = ${args.organizationId} AND user_id = ${args.userId}
       AND status = 'approved'
+      AND (${pattern}::text IS NULL OR content ILIKE ${pattern})
     ORDER BY created_at_ms DESC
+    LIMIT ${limit}
   `;
-  const queryText = args.query?.toLowerCase();
-  return rows
-    .filter(
-      (memory) =>
-        queryText === undefined ||
-        memory.content.toLowerCase().includes(queryText),
-    )
-    .slice(0, args.limit ?? 20);
 }
 
 /** The pending proposals and approved memories the preferences page reviews. */
@@ -108,7 +177,9 @@ export async function listMemories(
   const rows = await sql<{ id: string; content: string; status: string }[]>`
     SELECT id, content, status FROM app.memories
     WHERE org_id = ${organizationId} AND user_id = ${userId}
+      AND status IN ('pending', 'approved')
     ORDER BY created_at_ms DESC
+    LIMIT ${LIST_LIMIT}
   `;
   return {
     pending: rows
@@ -121,7 +192,7 @@ export async function listMemories(
 }
 
 /** Approve or reject a pending memory — the model proposes, the person
- * decides. False when the memory is not the caller's. */
+ * decides. False when the memory is not the caller's or is not pending. */
 export async function reviewMemory(
   sql: Sql,
   args: {
@@ -135,6 +206,22 @@ export async function reviewMemory(
     UPDATE app.memories SET
       status = ${args.decision}, reviewed_by = ${args.userId},
       reviewed_at_ms = ${Date.now()}
+    WHERE id = ${args.memoryId} AND org_id = ${args.organizationId}
+      AND user_id = ${args.userId} AND status = 'pending'
+    RETURNING id
+  `;
+  return rows.length > 0;
+}
+
+/** Delete a memory of the caller's — a saved one is taken out of what a
+ * search can return, which is the whole of its effect. False when the
+ * memory is not the caller's. */
+export async function deleteMemory(
+  sql: Sql,
+  args: { organizationId: string; userId: string; memoryId: string },
+): Promise<boolean> {
+  const rows = await sql<{ id: string }[]>`
+    DELETE FROM app.memories
     WHERE id = ${args.memoryId} AND org_id = ${args.organizationId}
       AND user_id = ${args.userId}
     RETURNING id

--- a/services/platform/backend/domains/chat/routes.test.ts
+++ b/services/platform/backend/domains/chat/routes.test.ts
@@ -15,12 +15,16 @@ const {
   trashThread,
   listArchivedThreads,
   searchApprovedMemories,
+  saveMemory,
+  deleteMemory,
   cancelDeferredSendsForThread,
   emitHintInTx,
 } = vi.hoisted(() => ({
   trashThread: vi.fn(),
   listArchivedThreads: vi.fn(),
   searchApprovedMemories: vi.fn(),
+  saveMemory: vi.fn(),
+  deleteMemory: vi.fn(),
   cancelDeferredSendsForThread: vi.fn(),
   emitHintInTx: vi.fn(),
 }));
@@ -33,6 +37,8 @@ vi.mock('./threads.ts', async (importOriginal) => ({
 vi.mock('./memories.ts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./memories.ts')>()),
   searchApprovedMemories,
+  saveMemory,
+  deleteMemory,
 }));
 vi.mock('./deferred-sends.ts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./deferred-sends.ts')>()),
@@ -64,6 +70,7 @@ vi.mock('../../auth/org.ts', async (importOriginal) => {
 });
 
 import { endAllEventStreams } from '../../realtime/sse.ts';
+import { MemoryError } from './memories.ts';
 import { createChatRoutes } from './routes.ts';
 
 function makeApp(sql: unknown = {}) {
@@ -208,5 +215,41 @@ describe('GET /threads/:threadId/stream — enrolled in the shutdown drain', () 
     ).resolves.toBe('ended');
     // Unregistered on the way out: nothing left to drain.
     expect(endAllEventStreams()).toBe(0);
+  });
+});
+
+describe('the memory doors', () => {
+  it('answers a refused proposal with its code and status, not a 500', async () => {
+    saveMemory.mockRejectedValue(
+      new MemoryError('MEMORIES_DISABLED', 'Memories are turned off.', 403),
+    );
+
+    const res = await makeApp().request('/memories?orgId=o1', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'Prefers metric units' }),
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: 'MEMORIES_DISABLED',
+      message: 'Memories are turned off.',
+    });
+  });
+
+  it('deletes a memory of the caller through DELETE /memories/:id', async () => {
+    deleteMemory.mockResolvedValue(true);
+
+    const res = await makeApp().request('/memories/mem_1?orgId=o1', {
+      method: 'DELETE',
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(deleteMemory).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: 'o1',
+      userId: 'u1',
+      memoryId: 'mem_1',
+    });
   });
 });

--- a/services/platform/backend/domains/chat/routes.test.ts
+++ b/services/platform/backend/domains/chat/routes.test.ts
@@ -11,17 +11,28 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { OrgEnv } from '../../auth/org.ts';
 
-const { trashThread, cancelDeferredSendsForThread, emitHintInTx } = vi.hoisted(
-  () => ({
-    trashThread: vi.fn(),
-    cancelDeferredSendsForThread: vi.fn(),
-    emitHintInTx: vi.fn(),
-  }),
-);
+const {
+  trashThread,
+  listArchivedThreads,
+  searchApprovedMemories,
+  cancelDeferredSendsForThread,
+  emitHintInTx,
+} = vi.hoisted(() => ({
+  trashThread: vi.fn(),
+  listArchivedThreads: vi.fn(),
+  searchApprovedMemories: vi.fn(),
+  cancelDeferredSendsForThread: vi.fn(),
+  emitHintInTx: vi.fn(),
+}));
 
 vi.mock('./threads.ts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./threads.ts')>()),
   trashThread,
+  listArchivedThreads,
+}));
+vi.mock('./memories.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./memories.ts')>()),
+  searchApprovedMemories,
 }));
 vi.mock('./deferred-sends.ts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./deferred-sends.ts')>()),
@@ -90,5 +101,70 @@ describe('POST /threads/:threadId/trash', () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ ok: false });
     expect(cancelDeferredSendsForThread).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /threads/archived — the numeric query params are a boundary', () => {
+  beforeEach(() => {
+    listArchivedThreads.mockResolvedValue({ rows: [], nextCursor: null });
+  });
+
+  it('coerces well-formed cursor and limit', async () => {
+    const res = await makeApp().request(
+      '/threads/archived?orgId=o1&cursor=1700000000000&limit=10',
+    );
+
+    expect(res.status).toBe(200);
+    expect(listArchivedThreads).toHaveBeenCalledWith(
+      expect.anything(),
+      'o1',
+      'u1',
+      { cursor: 1_700_000_000_000, limit: 10 },
+    );
+  });
+
+  it('answers 400 to a malformed cursor instead of binding NaN', async () => {
+    const res = await makeApp().request(
+      '/threads/archived?orgId=o1&cursor=abc',
+    );
+
+    expect(res.status).toBe(400);
+    expect(listArchivedThreads).not.toHaveBeenCalled();
+  });
+
+  it('answers 400 to a limit outside the page ceiling', async () => {
+    const res = await makeApp().request('/threads/archived?orgId=o1&limit=500');
+
+    expect(res.status).toBe(400);
+    expect(listArchivedThreads).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /memories/search — the limit is a boundary', () => {
+  beforeEach(() => {
+    searchApprovedMemories.mockResolvedValue([]);
+  });
+
+  it('passes a well-formed query and limit through', async () => {
+    const res = await makeApp().request(
+      '/memories/search?orgId=o1&q=metric&limit=5',
+    );
+
+    expect(res.status).toBe(200);
+    expect(searchApprovedMemories).toHaveBeenCalledWith(expect.anything(), {
+      organizationId: 'o1',
+      userId: 'u1',
+      query: 'metric',
+      limit: 5,
+    });
+  });
+
+  it('answers 400 to a malformed limit instead of silently returning nothing', async () => {
+    const res = await makeApp().request(
+      '/memories/search?orgId=o1&q=metric&limit=abc',
+    );
+
+    expect(res.status).toBe(400);
+    expect(searchApprovedMemories).not.toHaveBeenCalled();
   });
 });

--- a/services/platform/backend/domains/chat/routes.test.ts
+++ b/services/platform/backend/domains/chat/routes.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+
+/**
+ * The chat routes' boundary behaviours, on a fake `sql` and stubbed session
+ * + membership: what a door validates before the domain sees the call, and
+ * which domain cascades a door triggers.
+ */
+
+import type { Context } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrgEnv } from '../../auth/org.ts';
+
+const { trashThread, cancelDeferredSendsForThread, emitHintInTx } = vi.hoisted(
+  () => ({
+    trashThread: vi.fn(),
+    cancelDeferredSendsForThread: vi.fn(),
+    emitHintInTx: vi.fn(),
+  }),
+);
+
+vi.mock('./threads.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./threads.ts')>()),
+  trashThread,
+}));
+vi.mock('./deferred-sends.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./deferred-sends.ts')>()),
+  cancelDeferredSendsForThread,
+}));
+vi.mock('../../realtime/outbox.ts', () => ({ emitHintInTx }));
+
+vi.mock('../../auth/session.ts', () => ({
+  requireSession:
+    () => async (c: Context<OrgEnv>, next: () => Promise<void>) => {
+      c.set('sessionBundle', {
+        user: { id: 'u1', email: 'u@example.test' },
+      } as never);
+      await next();
+    },
+}));
+
+vi.mock('../../auth/org.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../auth/org.ts')>();
+  return {
+    ...actual,
+    requireOrgMember:
+      () => async (c: Context<OrgEnv>, next: () => Promise<void>) => {
+        c.set('orgId', 'o1');
+        c.set('orgMember', { role: 'member' } as never);
+        await next();
+      },
+  };
+});
+
+import { createChatRoutes } from './routes.ts';
+
+function makeApp() {
+  return createChatRoutes({ sql: {} as never, auth: {} as never });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  emitHintInTx.mockResolvedValue(undefined);
+  cancelDeferredSendsForThread.mockResolvedValue(0);
+});
+
+describe('POST /threads/:threadId/trash', () => {
+  it('cancels the parked sends of a thread it trashed', async () => {
+    trashThread.mockResolvedValue(true);
+
+    const res = await makeApp().request('/threads/t1/trash?orgId=o1', {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(cancelDeferredSendsForThread).toHaveBeenCalledWith(
+      expect.anything(),
+      { organizationId: 'o1', userId: 'u1', threadId: 't1' },
+    );
+  });
+
+  it('leaves the parked sends alone when the thread did not trash', async () => {
+    trashThread.mockResolvedValue(false);
+
+    const res = await makeApp().request('/threads/t1/trash?orgId=o1', {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: false });
+    expect(cancelDeferredSendsForThread).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/domains/chat/routes.test.ts
+++ b/services/platform/backend/domains/chat/routes.test.ts
@@ -63,10 +63,15 @@ vi.mock('../../auth/org.ts', async (importOriginal) => {
   };
 });
 
+import { endAllEventStreams } from '../../realtime/sse.ts';
 import { createChatRoutes } from './routes.ts';
 
-function makeApp() {
-  return createChatRoutes({ sql: {} as never, auth: {} as never });
+function makeApp(sql: unknown = {}) {
+  return createChatRoutes({ sql: sql as never, auth: {} as never });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 beforeEach(() => {
@@ -166,5 +171,42 @@ describe('GET /memories/search — the limit is a boundary', () => {
 
     expect(res.status).toBe(400);
     expect(searchApprovedMemories).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /threads/:threadId/stream — enrolled in the shutdown drain', () => {
+  it('ends with every other SSE stream when the process drains', async () => {
+    // A tagged-template `sql` stub: the owned-thread read answers a thread,
+    // the generation read answers idle, everything else is empty.
+    const sql = (strings: TemplateStringsArray): Promise<unknown[]> => {
+      const text = strings.join('?');
+      if (text.includes('FROM app.threads t')) {
+        return Promise.resolve([{ id: 't1', title: null }]);
+      }
+      return Promise.resolve([]);
+    };
+
+    const res = await makeApp(sql).request('/threads/t1/stream?orgId=o1');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error('no body');
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toContain('event: idle');
+
+    // The chat lane is in the same registry as `/events`: draining ends it,
+    // and its loop — which otherwise runs until the client leaves — exits.
+    expect(endAllEventStreams()).toBe(1);
+    await expect(
+      Promise.race([
+        reader
+          .read()
+          .then((chunk) => (chunk.done ? 'ended' : 'data'))
+          .catch(() => 'ended'),
+        sleep(2_000).then(() => 'timeout'),
+      ]),
+    ).resolves.toBe('ended');
+    // Unregistered on the way out: nothing left to drain.
+    expect(endAllEventStreams()).toBe(0);
   });
 });

--- a/services/platform/backend/domains/chat/routes.ts
+++ b/services/platform/backend/domains/chat/routes.ts
@@ -1371,9 +1371,9 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   // The per-thread progress lane. Emits `progress` while a generation row
   // exists (whenever its updated_at_ms moves) and `settled` with the final
   // message when it disappears; stays open for the thread's next turn.
-  // Polling AT the store's 250ms write throttle: pushing (the NOTIFY the
-  // store already sends) cannot beat the throttle, so a listener hub would
-  // add a connection without adding freshness.
+  // Polling AT the store's 250ms write throttle: a push (LISTEN/NOTIFY)
+  // could not beat the throttle, so a listener hub would add a connection
+  // without adding freshness.
   app.get('/threads/:threadId/stream', async (c) => {
     const { organizationId, userId } = caller(c);
     const thread = await ownedThread(

--- a/services/platform/backend/domains/chat/routes.ts
+++ b/services/platform/backend/domains/chat/routes.ts
@@ -29,7 +29,6 @@ import {
   listProjectCapabilities,
 } from './composer.ts';
 import {
-  claimDeferredSendVideos,
   cancelDeferredSend,
   enqueueDeferredSend,
   listDeferredSends,
@@ -944,20 +943,6 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
           : {}),
         ...(body.data.locale !== undefined ? { locale: body.data.locale } : {}),
       });
-      // The claim releases the composer chips + stamps the row's set — an
-      // unclaimable id (foreign, bound, cancelled) is dropped, 0.4 posture.
-      if (
-        body.data.videoJobIds !== undefined &&
-        body.data.videoJobIds.length > 0
-      ) {
-        await claimDeferredSendVideos(deps.sql, {
-          organizationId,
-          userId,
-          threadId: c.req.param('threadId'),
-          deferredSendId: enqueued.deferredSendId,
-          videoJobIds: body.data.videoJobIds,
-        });
-      }
       return c.json(enqueued, 201);
     } catch (error) {
       return handleThreadError(c, error);

--- a/services/platform/backend/domains/chat/routes.ts
+++ b/services/platform/backend/domains/chat/routes.ts
@@ -95,7 +95,6 @@ import {
   searchChats,
   setBranchSelection,
   setThreadArchived,
-  setThreadCapabilities,
   setThreadPinned,
   setThreadReasoningEffort,
   setThreadSharedWithProject,
@@ -115,18 +114,11 @@ import {
  * turns interleave on one thread.
  */
 
-const capabilitiesSchema = z.object({
-  skills: z.array(z.string().max(200)).max(50),
-  connectors: z.array(z.string().max(200)).max(50),
-});
-
 const createThreadSchema = z.object({
   title: z.string().max(200).optional(),
   projectId: z.string().max(128).optional(),
   kind: z.string().max(50).optional(),
   agentSlug: z.string().max(200).optional(),
-  harness: z.string().max(100).optional(),
-  capabilities: capabilitiesSchema.optional(),
   reasoningEffort: z.enum(['low', 'medium', 'high', 'extra', 'max']).optional(),
 });
 
@@ -382,12 +374,6 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
         ...(body.data.agentSlug !== undefined
           ? { agentSlug: body.data.agentSlug }
           : {}),
-        ...(body.data.harness !== undefined
-          ? { harness: body.data.harness }
-          : {}),
-        ...(body.data.capabilities !== undefined
-          ? { capabilities: body.data.capabilities }
-          : {}),
         ...(body.data.projectId !== undefined
           ? { projectId: body.data.projectId }
           : {}),
@@ -473,25 +459,6 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
     return status === null
       ? c.json({ error: 'thread not found' }, 404)
       : c.json(status);
-  });
-
-  app.post('/threads/:threadId/capabilities', async (c) => {
-    const body = capabilitiesSchema.safeParse(await c.req.json());
-    if (!body.success) return c.json({ error: 'invalid body' }, 400);
-    const { organizationId, userId } = caller(c);
-    try {
-      const ok = await setThreadCapabilities(
-        deps.sql,
-        organizationId,
-        userId,
-        c.req.param('threadId'),
-        body.data,
-      );
-      if (ok) await hintThread(c, c.req.param('threadId'));
-      return c.json({ ok });
-    } catch (error) {
-      return handleThreadError(c, error);
-    }
   });
 
   app.post('/threads/:threadId/reasoning-effort', async (c) => {

--- a/services/platform/backend/domains/chat/routes.ts
+++ b/services/platform/backend/domains/chat/routes.ts
@@ -40,7 +40,9 @@ import {
 } from './deferred-sends.ts';
 import { getOrgChatHealth } from './health.ts';
 import {
+  deleteMemory,
   listMemories,
+  MemoryError,
   reviewMemory,
   saveMemory,
   searchApprovedMemories,
@@ -856,19 +858,29 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
       .safeParse(await c.req.json());
     if (!body.success) return c.json({ error: 'invalid body' }, 400);
     const { organizationId, userId } = caller(c);
-    const id = await saveMemory(deps.sql, {
-      organizationId,
-      userId,
-      email: c.get('sessionBundle').user.email,
-      content: body.data.content,
-      ...(body.data.sourceThreadId !== undefined
-        ? { sourceThreadId: body.data.sourceThreadId }
-        : {}),
-      ...(body.data.sourceMessageId !== undefined
-        ? { sourceMessageId: body.data.sourceMessageId }
-        : {}),
-    });
-    return c.json({ id }, 201);
+    try {
+      const id = await saveMemory(deps.sql, {
+        organizationId,
+        userId,
+        email: c.get('sessionBundle').user.email,
+        content: body.data.content,
+        ...(body.data.sourceThreadId !== undefined
+          ? { sourceThreadId: body.data.sourceThreadId }
+          : {}),
+        ...(body.data.sourceMessageId !== undefined
+          ? { sourceMessageId: body.data.sourceMessageId }
+          : {}),
+      });
+      return c.json({ id }, 201);
+    } catch (error) {
+      if (error instanceof MemoryError) {
+        return c.json(
+          { error: error.code, message: error.message },
+          error.status,
+        );
+      }
+      throw error;
+    }
   });
 
   app.post('/memories/:memoryId/review', async (c) => {
@@ -883,6 +895,17 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
         userId,
         memoryId: c.req.param('memoryId'),
         decision: body.data.decision,
+      }),
+    });
+  });
+
+  app.delete('/memories/:memoryId', async (c) => {
+    const { organizationId, userId } = caller(c);
+    return c.json({
+      ok: await deleteMemory(deps.sql, {
+        organizationId,
+        userId,
+        memoryId: c.req.param('memoryId'),
       }),
     });
   });

--- a/services/platform/backend/domains/chat/routes.ts
+++ b/services/platform/backend/domains/chat/routes.ts
@@ -15,6 +15,10 @@ import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
 import { requireSession } from '../../auth/session.ts';
 import { sanitizeError } from '../../core/lib/utils/sanitize_secrets.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
+import {
+  registerLiveStream,
+  unregisterLiveStream,
+} from '../../realtime/sse.ts';
 import { isBackendDraining } from '../control/service.ts';
 import { LegalHoldError } from '../legal_holds/service.ts';
 import {
@@ -1386,7 +1390,9 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   // message when it disappears; stays open for the thread's next turn.
   // Polling AT the store's 250ms write throttle: a push (LISTEN/NOTIFY)
   // could not beat the throttle, so a listener hub would add a connection
-  // without adding freshness.
+  // without adding freshness. Enrolled in the shutdown drain like `/events`:
+  // the loop never ends on its own, and an open chat tab used to hold
+  // `server.close()` for the whole force deadline on every deploy.
   app.get('/threads/:threadId/stream', async (c) => {
     const { organizationId, userId } = caller(c);
     const thread = await ownedThread(
@@ -1399,6 +1405,7 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
       return c.json({ error: 'thread not found' }, 404);
     }
     return streamSSE(c, async (stream) => {
+      registerLiveStream(stream);
       let lastSeenUpdate = 0;
       let lastSentParts: string | null = null;
       let lastMessageId: string | null = null;
@@ -1421,80 +1428,85 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
       } catch (error) {
         console.warn('[chat] stream initial probe failed:', error);
       }
-      while (!stream.aborted) {
-        try {
-          const generation = await readGeneration(
-            deps.sql,
-            organizationId,
-            thread.id,
-          );
-          if (generation !== null) {
-            generating = true;
-            lastMessageId = generation.messageId ?? lastMessageId;
-            if (generation.updatedAt > lastSeenUpdate) {
-              lastSeenUpdate = generation.updatedAt;
-              // Parts ride along only when they CHANGED. Text ticks at the
-              // store's throttle while a tool result can be large (a RAG
-              // page), so resending an unchanged array four times a second
-              // would pay for the trace over and over. The client keeps the
-              // last one it saw.
-              let parts: unknown[] | null = null;
-              if (generation.messageId != null) {
-                const live = await readLiveParts(
-                  deps.sql,
-                  organizationId,
-                  generation.messageId,
-                );
-                const serialized = live === null ? null : JSON.stringify(live);
-                if (serialized !== null && serialized !== lastSentParts) {
-                  lastSentParts = serialized;
-                  parts = live;
-                }
-              }
-              await stream.writeSSE({
-                event: 'progress',
-                data: JSON.stringify({
-                  messageId: generation.messageId,
-                  text: generation.text,
-                  reasoning: generation.reasoning,
-                  cancelRequested: generation.cancelRequested,
-                  ...(parts !== null ? { parts } : {}),
-                  serverNow: Date.now(),
-                }),
-              });
-              lastBeatAt = Date.now();
-            }
-          } else if (generating) {
-            // The row's absence is the settle signal — ship the final row.
-            generating = false;
-            lastSeenUpdate = 0;
-            lastSentParts = null;
-            const messages = await listMessageViews(
+      try {
+        while (!stream.aborted) {
+          try {
+            const generation = await readGeneration(
               deps.sql,
               organizationId,
               thread.id,
             );
-            const settled =
-              lastMessageId !== null
-                ? (messages.find((row) => row.id === lastMessageId) ??
-                  messages.at(-1))
-                : messages.at(-1);
-            await stream.writeSSE({
-              event: 'settled',
-              data: JSON.stringify({ message: settled ?? null }),
-            });
-            lastBeatAt = Date.now();
-          } else if (Date.now() - lastBeatAt >= STREAM_HEARTBEAT_MS) {
-            await stream.writeSSE({ event: 'heartbeat', data: '' });
-            lastBeatAt = Date.now();
+            if (generation !== null) {
+              generating = true;
+              lastMessageId = generation.messageId ?? lastMessageId;
+              if (generation.updatedAt > lastSeenUpdate) {
+                lastSeenUpdate = generation.updatedAt;
+                // Parts ride along only when they CHANGED. Text ticks at the
+                // store's throttle while a tool result can be large (a RAG
+                // page), so resending an unchanged array four times a second
+                // would pay for the trace over and over. The client keeps the
+                // last one it saw.
+                let parts: unknown[] | null = null;
+                if (generation.messageId != null) {
+                  const live = await readLiveParts(
+                    deps.sql,
+                    organizationId,
+                    generation.messageId,
+                  );
+                  const serialized =
+                    live === null ? null : JSON.stringify(live);
+                  if (serialized !== null && serialized !== lastSentParts) {
+                    lastSentParts = serialized;
+                    parts = live;
+                  }
+                }
+                await stream.writeSSE({
+                  event: 'progress',
+                  data: JSON.stringify({
+                    messageId: generation.messageId,
+                    text: generation.text,
+                    reasoning: generation.reasoning,
+                    cancelRequested: generation.cancelRequested,
+                    ...(parts !== null ? { parts } : {}),
+                    serverNow: Date.now(),
+                  }),
+                });
+                lastBeatAt = Date.now();
+              }
+            } else if (generating) {
+              // The row's absence is the settle signal — ship the final row.
+              generating = false;
+              lastSeenUpdate = 0;
+              lastSentParts = null;
+              const messages = await listMessageViews(
+                deps.sql,
+                organizationId,
+                thread.id,
+              );
+              const settled =
+                lastMessageId !== null
+                  ? (messages.find((row) => row.id === lastMessageId) ??
+                    messages.at(-1))
+                  : messages.at(-1);
+              await stream.writeSSE({
+                event: 'settled',
+                data: JSON.stringify({ message: settled ?? null }),
+              });
+              lastBeatAt = Date.now();
+            } else if (Date.now() - lastBeatAt >= STREAM_HEARTBEAT_MS) {
+              await stream.writeSSE({ event: 'heartbeat', data: '' });
+              lastBeatAt = Date.now();
+            }
+          } catch (error) {
+            if (stream.aborted) break;
+            console.error('[chat] stream poll failed, backing off:', error);
+            await stream.sleep(1000);
+            continue;
           }
-        } catch (error) {
-          if (stream.aborted) break;
-          console.error('[chat] stream poll failed, backing off:', error);
-          await stream.sleep(1000);
-          continue;
+          await stream.sleep(STREAM_POLL_MS);
         }
-        await stream.sleep(STREAM_POLL_MS);
+      } finally {
+        unregisterLiveStream(stream);
       }
     });
   });

--- a/services/platform/backend/domains/chat/routes.ts
+++ b/services/platform/backend/domains/chat/routes.ts
@@ -30,6 +30,7 @@ import {
 } from './composer.ts';
 import {
   cancelDeferredSend,
+  cancelDeferredSendsForThread,
   enqueueDeferredSend,
   listDeferredSends,
 } from './deferred-sends.ts';
@@ -750,7 +751,17 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
         },
         c.req.param('threadId'),
       );
-      if (ok) await hintThread(c, c.req.param('threadId'));
+      if (ok) {
+        // A trashed conversation takes its parked sends with it — otherwise
+        // they fire into the trash (the poll re-gates too; this cancels the
+        // media the sends were still waiting on).
+        await cancelDeferredSendsForThread(deps.sql, {
+          organizationId,
+          userId,
+          threadId: c.req.param('threadId'),
+        });
+        await hintThread(c, c.req.param('threadId'));
+      }
       return c.json({ ok });
     } catch (error) {
       return handleThreadError(c, error);

--- a/services/platform/backend/domains/chat/routes.ts
+++ b/services/platform/backend/domains/chat/routes.ts
@@ -126,6 +126,20 @@ const createThreadSchema = z.object({
   reasoningEffort: z.enum(['low', 'medium', 'high', 'extra', 'max']).optional(),
 });
 
+// Query strings are a boundary too: `Number('abc')` is NaN, which postgres
+// serializes as the text 'NaN' — a 500 from `::bigint` / LIMIT instead of a
+// 400 — so the numeric params are coerced and bounded here. The listing's
+// own ceiling is the schema's max.
+const archivedQuerySchema = z.object({
+  cursor: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+});
+
+const memorySearchQuerySchema = z.object({
+  q: z.string().max(500).optional(),
+  limit: z.coerce.number().int().min(1).max(50).optional(),
+});
+
 const arenaTurnSchema = z.object({
   userText: z.string().max(200_000),
   modelIdA: z.string().min(1).max(200),
@@ -394,13 +408,15 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   });
 
   app.get('/threads/archived', async (c) => {
+    const query = archivedQuerySchema.safeParse(c.req.query());
+    if (!query.success) return c.json({ error: 'invalid query' }, 400);
     const { organizationId, userId } = caller(c);
-    const cursorRaw = c.req.query('cursor');
-    const limitRaw = c.req.query('limit');
     return c.json(
       await listArchivedThreads(deps.sql, organizationId, userId, {
-        ...(cursorRaw !== undefined ? { cursor: Number(cursorRaw) } : {}),
-        ...(limitRaw !== undefined ? { limit: Number(limitRaw) } : {}),
+        ...(query.data.cursor !== undefined
+          ? { cursor: query.data.cursor }
+          : {}),
+        ...(query.data.limit !== undefined ? { limit: query.data.limit } : {}),
       }),
     );
   });
@@ -846,14 +862,15 @@ export function createChatRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
   });
 
   app.get('/memories/search', async (c) => {
+    const query = memorySearchQuerySchema.safeParse(c.req.query());
+    if (!query.success) return c.json({ error: 'invalid query' }, 400);
     const { organizationId, userId } = caller(c);
-    const limitRaw = c.req.query('limit');
     return c.json({
       memories: await searchApprovedMemories(deps.sql, {
         organizationId,
         userId,
-        ...(c.req.query('q') !== undefined ? { query: c.req.query('q') } : {}),
-        ...(limitRaw !== undefined ? { limit: Number(limitRaw) } : {}),
+        ...(query.data.q !== undefined ? { query: query.data.q } : {}),
+        ...(query.data.limit !== undefined ? { limit: query.data.limit } : {}),
       }),
     });
   });

--- a/services/platform/backend/domains/chat/service.ts
+++ b/services/platform/backend/domains/chat/service.ts
@@ -21,7 +21,8 @@ import { createPgTurnStore, createPgUsageLedger } from './store.ts';
  *
  * Same execution contract as the 0.4 action host: the caller awaits the
  * turn (at-most-once, no retry — an LLM spend must not replay), streaming
- * progress lands on `app.generations` (NOTIFY-nudged, see `store.ts`), and
+ * progress lands on `app.generations` (polled by the stream lane, see
+ * `store.ts`), and
  * cancel is a flag on that row the throttled progress writes read back.
  */
 

--- a/services/platform/backend/domains/chat/service.ts
+++ b/services/platform/backend/domains/chat/service.ts
@@ -5,6 +5,7 @@ import {
   executeTurn,
   type ExecuteTurnArgs,
 } from '../../core/chat/turn_action.ts';
+import { settleDeferredSendOnUserAppend } from '../../core/chat/turn_store.ts';
 import { createCtxShim } from '../../lib/ctx-shim.ts';
 import { chatShimHandlers } from './shim.ts';
 import { createPgTurnStore, createPgUsageLedger } from './store.ts';
@@ -40,6 +41,11 @@ export interface ChatTurnRequest {
   /** Auto — the server resolves a concrete (provider, model) pair for THIS
    * message before anything binds. Exactly one of modelId / this. */
   readonly modelSelection?: 'auto';
+  /** Runs the moment the turn-open write persisted the user message — the
+   * deferred-send lane settles its tray row here, so the parked message is
+   * never shown twice (bubble + "sending" row) for the whole generation.
+   * Never called on a turn that refused or threw before that write. */
+  readonly onUserMessageAppended?: () => Promise<void>;
 }
 
 export async function runChatTurn(
@@ -69,13 +75,20 @@ export async function runChatTurn(
     locale: request.locale ?? 'en',
     ...(request.resend === true ? { resend: true } : {}),
   };
+  const store = createPgTurnStore(sql);
   return executeTurn(
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 host; every ctx facility it touches is covered by chatShimHandlers
     shim as unknown as Parameters<typeof executeTurn>[0],
     args,
     {
       deps: {
-        store: createPgTurnStore(sql),
+        store:
+          request.onUserMessageAppended !== undefined
+            ? settleDeferredSendOnUserAppend(
+                store,
+                request.onUserMessageAppended,
+              )
+            : store,
         usage: createPgUsageLedger(sql),
       },
     },

--- a/services/platform/backend/domains/chat/service.ts
+++ b/services/platform/backend/domains/chat/service.ts
@@ -5,7 +5,6 @@ import {
   executeTurn,
   type ExecuteTurnArgs,
 } from '../../core/chat/turn_action.ts';
-import { settleDeferredSendOnUserAppend } from '../../core/chat/turn_store.ts';
 import { createCtxShim } from '../../lib/ctx-shim.ts';
 import { chatShimHandlers } from './shim.ts';
 import { createPgTurnStore, createPgUsageLedger } from './store.ts';
@@ -75,20 +74,18 @@ export async function runChatTurn(
     locale: request.locale ?? 'en',
     ...(request.resend === true ? { resend: true } : {}),
   };
-  const store = createPgTurnStore(sql);
   return executeTurn(
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 host; every ctx facility it touches is covered by chatShimHandlers
     shim as unknown as Parameters<typeof executeTurn>[0],
     args,
     {
       deps: {
-        store:
+        store: createPgTurnStore(
+          sql,
           request.onUserMessageAppended !== undefined
-            ? settleDeferredSendOnUserAppend(
-                store,
-                request.onUserMessageAppended,
-              )
-            : store,
+            ? { onUserMessageAppended: request.onUserMessageAppended }
+            : {},
+        ),
         usage: createPgUsageLedger(sql),
       },
     },

--- a/services/platform/backend/domains/chat/store.test.ts
+++ b/services/platform/backend/domains/chat/store.test.ts
@@ -132,12 +132,10 @@ function fakeChatSql(options: { threadHeld?: boolean } = {}): {
   pool: Statement[];
   tx: Statement[];
   transactions: Array<'commit' | 'rollback'>;
-  notified: string[];
 } {
   const pool: Statement[] = [];
   const tx: Statement[] = [];
   const transactions: Array<'commit' | 'rollback'> = [];
-  const notified: string[] = [];
   let messageRows = 0;
   const answer = (text: string): unknown[] => {
     if (text.includes('INSERT INTO app.messages')) {
@@ -162,10 +160,6 @@ function fakeChatSql(options: { threadHeld?: boolean } = {}): {
     return tag;
   };
   const pooled = Object.assign(makeTag(pool), {
-    notify(channel: string, payload: string) {
-      notified.push(`${channel}:${payload}`);
-      return Promise.resolve();
-    },
     async begin(fn: (tx: unknown) => Promise<unknown>) {
       try {
         const result = await fn(makeTag(tx));
@@ -177,8 +171,8 @@ function fakeChatSql(options: { threadHeld?: boolean } = {}): {
       }
     },
   });
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the turn store exercises exactly the tag, json, notify, and begin surfaces faked here
-  return { sql: pooled as unknown as Sql, pool, tx, transactions, notified };
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the turn store exercises exactly the tag, json, and begin surfaces faked here
+  return { sql: pooled as unknown as Sql, pool, tx, transactions };
 }
 
 const OPEN = {
@@ -188,7 +182,7 @@ const OPEN = {
 };
 
 describe('createPgTurnStore.beginTurn', () => {
-  it('opens the turn inside ONE transaction and notifies only once it committed', async () => {
+  it('opens the turn inside ONE transaction', async () => {
     const f = fakeChatSql();
     const opened = await createPgTurnStore(f.sql).beginTurn(OPEN);
 
@@ -208,7 +202,6 @@ describe('createPgTurnStore.beginTurn', () => {
     expect(
       texts.some((t) => t.includes("generation_status = 'generating'")),
     ).toBe(true);
-    expect(f.notified).toEqual(['chat_stream:thread_1']);
   });
 
   it('claims the thread with DO NOTHING and rolls the whole open back when another turn holds it', async () => {
@@ -224,9 +217,7 @@ describe('createPgTurnStore.beginTurn', () => {
     );
     expect(claim?.text).toContain('ON CONFLICT (thread_id) DO NOTHING');
     expect(claim?.text).not.toContain('DO UPDATE');
-    // The loser announces nothing — no NOTIFY for a turn that never opened,
-    // and no sidecar write claiming the thread is generating.
-    expect(f.notified).toEqual([]);
+    // The loser leaves no sidecar write claiming the thread is generating.
     expect(
       f.tx.some((s) => s.text.includes("generation_status = 'generating'")),
     ).toBe(false);
@@ -256,6 +247,5 @@ describe('createPgTurnStore.endGeneration', () => {
           t.includes("status = 'failed'") && t.includes("status = 'pending'"),
       ),
     ).toBe(true);
-    expect(f.notified).toEqual(['chat_stream:thread_1']);
   });
 });

--- a/services/platform/backend/domains/chat/store.test.ts
+++ b/services/platform/backend/domains/chat/store.test.ts
@@ -127,7 +127,15 @@ interface Statement {
  * message insert returns the next row id, the generations claim returns a
  * row unless the fake is told the thread is held.
  */
-function fakeChatSql(options: { threadHeld?: boolean } = {}): {
+function fakeChatSql(
+  options: {
+    threadHeld?: boolean;
+    /** What the generation row holds when a finalize reads it back. */
+    streamed?: { text: string; reasoning?: string };
+    /** The placeholder's parts as stored before the finalize. */
+    storedParts?: unknown[];
+  } = {},
+): {
   sql: Sql;
   pool: Statement[];
   tx: Statement[];
@@ -147,6 +155,19 @@ function fakeChatSql(options: { threadHeld?: boolean } = {}): {
     }
     if (text.includes('INSERT INTO app.generations')) {
       return options.threadHeld === true ? [] : [{ threadId: 'thread_1' }];
+    }
+    if (text.includes('SELECT text, reasoning FROM app.generations')) {
+      return options.streamed === undefined
+        ? []
+        : [
+            {
+              text: options.streamed.text,
+              reasoning: options.streamed.reasoning ?? '',
+            },
+          ];
+    }
+    if (text.includes('SELECT parts FROM app.messages')) {
+      return [{ parts: options.storedParts ?? [] }];
     }
     return [];
   };
@@ -247,5 +268,99 @@ describe('createPgTurnStore.endGeneration', () => {
           t.includes("status = 'failed'") && t.includes("status = 'pending'"),
       ),
     ).toBe(true);
+  });
+});
+
+const FAILED = {
+  organizationId: 'org_1',
+  threadId: 'thread_1',
+  messageId: 'msg_2',
+  model: 'z-ai/glm-5.1',
+  providerSlug: 'openrouter',
+  error: 'TALE_ERR1 provider fell over',
+};
+
+describe('createPgTurnStore.finalizeAssistantMessage', () => {
+  it('copies the streamed partial reply onto the message when the turn fails mid-stream', async () => {
+    // The pipeline's failure finalize carries no `text`: "keep what streamed".
+    // In Postgres what streamed lives on the generation row that
+    // endGeneration deletes next, so the finalize must copy it over first —
+    // text, reasoning, AND a trailing text part (the client renders parts).
+    const f = fakeChatSql({
+      streamed: { text: 'partial re', reasoning: 'why' },
+    });
+    await createPgTurnStore(f.sql).finalizeAssistantMessage(FAILED);
+
+    expect(f.transactions).toEqual(['commit']);
+    expect(f.pool).toEqual([]);
+    const update = f.tx.find((s) => s.text.includes('UPDATE app.messages'));
+    expect(update).toBeDefined();
+    expect(update?.values).toContain('partial re');
+    expect(update?.values).toContain('why');
+    expect(update?.values).toContainEqual({
+      json: [{ type: 'text', text: 'partial re' }],
+    });
+    expect(update?.values).toContain('failed');
+    expect(update?.values).toContain(FAILED.error);
+  });
+
+  it('appends the tail after the parts earlier rounds settled, never duplicating one already stored', async () => {
+    const settled = [
+      { type: 'text', text: 'round one' },
+      { type: 'tool-call', capabilityId: 'rag_search', input: {} },
+    ];
+    const f = fakeChatSql({
+      streamed: { text: 'round two tail' },
+      storedParts: settled,
+    });
+    await createPgTurnStore(f.sql).finalizeAssistantMessage(FAILED);
+    const update = f.tx.find((s) => s.text.includes('UPDATE app.messages'));
+    expect(update?.values).toContainEqual({
+      json: [...settled, { type: 'text', text: 'round two tail' }],
+    });
+
+    const dup = fakeChatSql({
+      streamed: { text: 'round one' },
+      storedParts: [{ type: 'text', text: 'round one' }],
+    });
+    await createPgTurnStore(dup.sql).finalizeAssistantMessage(FAILED);
+    const dupUpdate = dup.tx.find((s) =>
+      s.text.includes('UPDATE app.messages'),
+    );
+    expect(
+      dupUpdate?.values.some(
+        (v) => typeof v === 'object' && v !== null && 'json' in v,
+      ),
+    ).toBe(false);
+  });
+
+  it('fabricates nothing when nothing streamed before the failure', async () => {
+    const f = fakeChatSql({ streamed: { text: '' } });
+    await createPgTurnStore(f.sql).finalizeAssistantMessage(FAILED);
+    const update = f.tx.find((s) => s.text.includes('UPDATE app.messages'));
+    // No parts write (coalesce(NULL, parts) keeps the stored value) and the
+    // text stays whatever the row holds (nullif('') → NULL → coalesce → text).
+    expect(
+      update?.values.some(
+        (v) => typeof v === 'object' && v !== null && 'json' in v,
+      ),
+    ).toBe(false);
+    expect(f.tx.some((s) => s.text.includes('SELECT parts'))).toBe(false);
+  });
+
+  it('writes the authoritative text directly when the turn completed', async () => {
+    const f = fakeChatSql();
+    await createPgTurnStore(f.sql).finalizeAssistantMessage({
+      organizationId: 'org_1',
+      threadId: 'thread_1',
+      messageId: 'msg_2',
+      text: 'the whole reply',
+      parts: [{ type: 'text', text: 'the whole reply' }],
+    });
+    // The completed shape never reads the generation row back.
+    expect(f.transactions).toEqual([]);
+    expect(f.pool).toHaveLength(1);
+    expect(f.pool[0]?.values).toContain('the whole reply');
+    expect(f.pool[0]?.values).toContain('complete');
   });
 });

--- a/services/platform/backend/domains/chat/store.ts
+++ b/services/platform/backend/domains/chat/store.ts
@@ -143,6 +143,68 @@ export async function appendMessageRow(
   return { id: row.id, sequence: row.order };
 }
 
+/**
+ * The failure-shaped finalize: no `text` means "keep whatever the throttled
+ * streaming writes persisted" (the pipeline's contract) — but in Postgres the
+ * streamed text and reasoning live on the GENERATION row, which the same
+ * turn's `endGeneration` deletes a moment later. Copy the streamed tail onto
+ * the message first, in one transaction with the failure stamp: the text
+ * column, the reasoning column (the pipeline passes none on failure), and a
+ * trailing text part, because the client renders parts. A tool-round
+ * boundary resets the generation text BEFORE the round's text lands on the
+ * parts, so a non-empty generation text is always an unsettled tail — never
+ * a duplicate of a part already stored.
+ */
+async function finalizeWithStreamedTail(
+  sql: Sql,
+  message: Parameters<TurnStore['finalizeAssistantMessage']>[0],
+): Promise<void> {
+  await sql.begin(async (tx) => {
+    const generation = await tx<{ text: string; reasoning: string | null }[]>`
+      SELECT text, reasoning FROM app.generations
+      WHERE thread_id = ${message.threadId} AND org_id = ${message.organizationId}
+      LIMIT 1
+    `;
+    const streamedText = generation[0]?.text ?? '';
+    const streamedReasoning = generation[0]?.reasoning ?? '';
+    let parts: unknown[] | null = null;
+    if (streamedText.length > 0) {
+      const stored = await tx<{ parts: unknown }[]>`
+        SELECT parts FROM app.messages
+        WHERE id = ${message.messageId} AND org_id = ${message.organizationId}
+        LIMIT 1
+      `;
+      const existing = Array.isArray(stored[0]?.parts) ? stored[0].parts : [];
+      const last: unknown = existing.at(-1);
+      const alreadyStored =
+        typeof last === 'object' &&
+        last !== null &&
+        'type' in last &&
+        last.type === 'text' &&
+        'text' in last &&
+        last.text === streamedText;
+      parts = alreadyStored
+        ? null
+        : [...existing, { type: 'text', text: streamedText }];
+    }
+    await tx`
+      UPDATE app.messages SET
+        text = coalesce(nullif(${streamedText}, ''), text),
+        reasoning = coalesce(
+          ${message.reasoning ?? null}, nullif(${streamedReasoning}, ''), reasoning
+        ),
+        parts = coalesce(${parts === null ? null : tx.json(toJson(parts))}, parts),
+        model = coalesce(${message.model ?? null}, model),
+        provider_slug = coalesce(${message.providerSlug ?? null}, provider_slug),
+        usage = coalesce(${message.usage === undefined ? null : tx.json(toJson(message.usage))}, usage),
+        blocked_reason = ${message.blockedReason ?? null},
+        error = ${message.error ?? null},
+        status = ${message.error !== undefined ? 'failed' : 'complete'}
+      WHERE id = ${message.messageId} AND org_id = ${message.organizationId}
+    `;
+  });
+}
+
 /** A turn store over app.messages + app.generations. */
 export function createPgTurnStore(sql: Sql): TurnStore {
   let lastStreamWriteAt = 0;
@@ -198,9 +260,13 @@ export function createPgTurnStore(sql: Sql): TurnStore {
     },
 
     async finalizeAssistantMessage(message) {
+      if (message.text === undefined) {
+        await finalizeWithStreamedTail(sql, message);
+        return;
+      }
       await sql`
         UPDATE app.messages SET
-          text = coalesce(${message.text ?? null}, text),
+          text = coalesce(${message.text}, text),
           reasoning = ${message.reasoning ?? null},
           parts = coalesce(${message.parts === undefined ? null : sql.json(toJson([...message.parts]))}, parts),
           model = coalesce(${message.model ?? null}, model),

--- a/services/platform/backend/domains/chat/store.ts
+++ b/services/platform/backend/domains/chat/store.ts
@@ -7,6 +7,7 @@ import {
   type UsageLedger,
   type UsageLedgerEntry,
 } from '../../../lib/chat/turn.ts';
+import { settleDeferredSendOnUserAppend } from '../../core/chat/turn_store.ts';
 import { getProviderCatalog } from '../../core/lib/providers/catalog_fetch.ts';
 import { resolveProvidersForOrg } from '../../core/lib/providers/org_providers.ts';
 import { toJson } from '../../db/sql.ts';
@@ -205,8 +206,21 @@ async function finalizeWithStreamedTail(
   });
 }
 
-/** A turn store over app.messages + app.generations. */
-export function createPgTurnStore(sql: Sql): TurnStore {
+/** A turn store over app.messages + app.generations. With
+ * `onUserMessageAppended` the store is decorated to run it the moment
+ * `beginTurn` persisted the user row — the deferred-send lane settles its
+ * tray row there (the 0.4 `settleDeferredSendOnUserAppend` wiring). */
+export function createPgTurnStore(
+  sql: Sql,
+  options: { onUserMessageAppended?: () => Promise<void> } = {},
+): TurnStore {
+  const store = pgTurnStore(sql);
+  return options.onUserMessageAppended !== undefined
+    ? settleDeferredSendOnUserAppend(store, options.onUserMessageAppended)
+    : store;
+}
+
+function pgTurnStore(sql: Sql): TurnStore {
   let lastStreamWriteAt = 0;
   let lastCancelRequested = false;
   return {

--- a/services/platform/backend/domains/chat/store.ts
+++ b/services/platform/backend/domains/chat/store.ts
@@ -22,18 +22,14 @@ import { MESSAGE_SLOT_ATTEMPTS } from '../threads/store.ts';
  * text, so skipped intervals never lose the tail), cancel piggybacked on the
  * progress write, and a generations row whose ABSENCE means idle.
  *
- * Realtime: every progress/finalize/end write NOTIFYs `chat_stream` with the
- * thread id; API pods LISTEN once per process and re-read the row for their
- * subscribed SSE clients (payload-cap-safe, reconnect-safe).
+ * Realtime rides the rows themselves: the per-thread progress lane
+ * (`routes.ts` `/threads/:id/stream`) polls the generation row at this
+ * store's write throttle, so no LISTEN/NOTIFY hub exists — a push could not
+ * beat the throttle, and a listener would add a connection without adding
+ * freshness.
  */
 
 const STREAM_WRITE_INTERVAL_MS = 250;
-
-export const CHAT_STREAM_CHANNEL = 'chat_stream';
-
-async function notifyThread(sql: Sql, threadId: string): Promise<void> {
-  await sql.notify(CHAT_STREAM_CHANNEL, threadId);
-}
 
 export async function appendMessageRow(
   sql: Sql,
@@ -181,7 +177,6 @@ export function createPgTurnStore(sql: Sql): TurnStore {
         RETURNING cancel_requested AS "cancelRequested"
       `;
       lastCancelRequested = rows[0]?.cancelRequested ?? false;
-      await notifyThread(sql, update.threadId);
       return { cancelRequested: lastCancelRequested };
     },
 
@@ -200,7 +195,6 @@ export function createPgTurnStore(sql: Sql): TurnStore {
         WHERE thread_id = ${update.threadId}
           AND org_id = ${update.organizationId}
       `;
-      await notifyThread(sql, update.threadId);
     },
 
     async finalizeAssistantMessage(message) {
@@ -217,7 +211,6 @@ export function createPgTurnStore(sql: Sql): TurnStore {
           status = ${message.error !== undefined ? 'failed' : 'complete'}
         WHERE id = ${message.messageId} AND org_id = ${message.organizationId}
       `;
-      await notifyThread(sql, message.threadId);
     },
 
     async beginTurn(setup) {
@@ -279,7 +272,6 @@ export function createPgTurnStore(sql: Sql): TurnStore {
           assistantMessage,
         };
       });
-      await notifyThread(sql, setup.threadId);
       return opened;
     },
 
@@ -310,7 +302,6 @@ export function createPgTurnStore(sql: Sql): TurnStore {
             AND status = 'pending'
         `;
       });
-      await notifyThread(sql, generation.threadId);
     },
   };
 }

--- a/services/platform/backend/domains/chat/threads.ts
+++ b/services/platform/backend/domains/chat/threads.ts
@@ -42,6 +42,9 @@ export class ChatThreadError extends Error {
   }
 }
 
+/** The 0.4 per-conversation loadout. Read-only in 0.5 — the column is kept
+ * for rows that carry one (branches copy it, summaries project it); no
+ * door writes it, chat runs the fixed loadout. */
 export interface ThreadCapabilities {
   skills: string[];
   connectors: string[];
@@ -149,36 +152,6 @@ function toSummary(
     generating,
     viewerIsOwner,
   };
-}
-
-/** A conversation may equip its agent with at most this many skills /
- * connectors — mirrors the project binding's ceilings. */
-const MAX_THREAD_SKILLS = 25;
-const MAX_THREAD_CONNECTORS = 25;
-
-/** Normalize a capability assembly for storage: enforce the ceilings,
- * dedupe, drop empties; an all-empty assembly collapses to null so the
- * thread falls back to its defaults rather than pinning "nothing". */
-export function sanitizeThreadCapabilities(
-  capabilities: ThreadCapabilities,
-): ThreadCapabilities | null {
-  if (
-    capabilities.skills.length > MAX_THREAD_SKILLS ||
-    capabilities.connectors.length > MAX_THREAD_CONNECTORS
-  ) {
-    throw new ChatThreadError(
-      'too_many_bindings',
-      `A conversation may equip at most ${MAX_THREAD_SKILLS} skills and ${MAX_THREAD_CONNECTORS} connectors.`,
-    );
-  }
-  const skills = [
-    ...new Set(capabilities.skills.filter((slug) => slug.length > 0)),
-  ];
-  const connectors = [
-    ...new Set(capabilities.connectors.filter((slug) => slug.length > 0)),
-  ];
-  if (skills.length === 0 && connectors.length === 0) return null;
-  return { skills, connectors };
 }
 
 /** 256 bits of randomness, hex encoded — the whole credential of the share
@@ -367,8 +340,6 @@ export interface CreateThreadArgs {
   kind: string;
   title?: string;
   agentSlug?: string;
-  harness?: string;
-  capabilities?: ThreadCapabilities;
   projectId?: string;
   reasoningEffort?: string;
 }
@@ -394,10 +365,6 @@ export async function createThread(
       );
     }
   }
-  const capabilities =
-    args.capabilities !== undefined
-      ? sanitizeThreadCapabilities(args.capabilities)
-      : null;
   const now = Date.now();
   return sql.begin(async (tx) => {
     const rows = await tx<{ id: string }[]>`
@@ -409,40 +376,22 @@ export async function createThread(
     `;
     const id = rows[0]?.id;
     if (!id) throw new Error('thread insert failed');
+    // `harness` / `capabilities` are 0.4-era columns no 0.5 writer sets:
+    // chat runs a fixed loadout (`lib/chat/tools.ts`), so a thread is
+    // created without either. The columns stay (deprecated, not dropped):
+    // branches copy them and the summaries still project them.
     await tx`
       INSERT INTO app.thread_metadata (
         thread_id, org_id, user_id, chat_type, status, project_id,
-        agent_slug, harness, capabilities, reasoning_effort, created_at_ms
+        agent_slug, reasoning_effort, created_at_ms
       ) VALUES (
         ${id}, ${args.organizationId}, ${args.userId}, ${args.kind},
         'active', ${args.projectId ?? null}, ${args.agentSlug ?? null},
-        ${args.harness ?? null},
-        ${capabilities === null ? null : tx.json(toJson(capabilities))},
         ${args.reasoningEffort ?? null}, ${now}
       )
     `;
     return id;
   });
-}
-
-/** Replace the conversation's capability assembly for the turns that follow.
- * A metadata edit — `updatedAt` stays untouched. */
-export async function setThreadCapabilities(
-  sql: Sql,
-  organizationId: string,
-  userId: string,
-  threadId: string,
-  capabilities: ThreadCapabilities,
-): Promise<boolean> {
-  const thread = await loadOwnedThread(sql, organizationId, userId, threadId);
-  if (!thread) return false;
-  const sanitized = sanitizeThreadCapabilities(capabilities);
-  await sql`
-    UPDATE app.thread_metadata SET
-      capabilities = ${sanitized === null ? null : sql.json(toJson(sanitized))}
-    WHERE thread_id = ${thread.id}
-  `;
-  return true;
 }
 
 /** Remember the conversation's reasoning-effort pick; absent clears it. */

--- a/services/platform/backend/domains/video_links/service.ts
+++ b/services/platform/backend/domains/video_links/service.ts
@@ -1617,18 +1617,46 @@ export async function bindCompletedJobsToMessage(
 }
 
 /**
+ * Drop the message bind from jobs no SENT message carries — the shared
+ * predicate of every unbind: a job whose transcript rides a user row of its
+ * thread (the row carries the attachment part) stays bound, because
+ * unbinding it would hand the transcript to the unbound-GC a week later and
+ * strand the sent message's attachment. Everything else in `jobIds` goes
+ * back to unbound: visible in the composer again, and reapable once
+ * terminal. `userId` narrows to the uploader's own rows (the composer
+ * door); the deferred-send lane, whose rows were claimed under the row's
+ * stored identity, passes none.
+ */
+export async function unbindJobsWithoutMessage(
+  sql: Sql | TransactionSql,
+  args: { organizationId: string; jobIds: readonly string[]; userId?: string },
+): Promise<void> {
+  const jobIds = [...new Set(args.jobIds)];
+  if (jobIds.length === 0) return;
+  await sql`
+    UPDATE app.video_link_jobs j SET message_bound_at_ms = NULL
+    WHERE j.id = ANY(${jobIds}) AND j.org_id = ${args.organizationId}
+      AND (${args.userId ?? null}::text IS NULL
+           OR j.uploaded_by = ${args.userId ?? null})
+      AND j.message_bound_at_ms IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM app.messages m
+        WHERE m.thread_id = j.thread_id AND m.role = 'user'
+          AND m.parts @> jsonb_build_array(jsonb_build_object(
+            'type', 'attachment', 'fileId', j.storage_ref
+          ))
+      )
+  `;
+}
+
+/**
  * Reverse a bind after a failed send (the 0.4 twin) — idempotent for the
  * caller's OWN rows in THIS organization. Every supplied id must resolve to
  * such a row or the whole batch is refused before anything changes: a job
  * the caller holds in another organization is not theirs here (the org is
  * the scope, like every other video-links verb), and an id the composer
- * never held is a probe, not a chip.
- *
- * A job whose transcript already rides a SENT message in its thread stays
- * bound. The server can tell — the user row carries the attachment part —
- * and unbinding it would hand the transcript to the unbound-GC a week later
- * and strand the sent message's attachment; the legitimate caller (a send
- * that failed) never has such a message.
+ * never held is a probe, not a chip. The sent-message guard is
+ * {@link unbindJobsWithoutMessage}'s.
  */
 export async function unbindJobsFromMessage(
   sql: Sql,
@@ -1646,19 +1674,11 @@ export async function unbindJobsFromMessage(
     if (owned.length !== jobIds.length) {
       throw new VideoLinkError('notFound', 'Video link not found', 404);
     }
-    await tx`
-      UPDATE app.video_link_jobs j SET message_bound_at_ms = NULL
-      WHERE j.id = ANY(${jobIds}) AND j.org_id = ${args.organizationId}
-        AND j.uploaded_by = ${args.userId}
-        AND j.message_bound_at_ms IS NOT NULL
-        AND NOT EXISTS (
-          SELECT 1 FROM app.messages m
-          WHERE m.thread_id = j.thread_id AND m.role = 'user'
-            AND m.parts @> jsonb_build_array(jsonb_build_object(
-              'type', 'attachment', 'fileId', j.storage_ref
-            ))
-        )
-    `;
+    await unbindJobsWithoutMessage(tx, {
+      organizationId: args.organizationId,
+      userId: args.userId,
+      jobIds,
+    });
   });
 }
 

--- a/services/platform/backend/domains/video_links/service.ts
+++ b/services/platform/backend/domains/video_links/service.ts
@@ -1089,9 +1089,12 @@ export async function ingestVideoUrl(
 /** Enqueue-time claim for a deferred send (the 0.4 `bindJobsForDeferredSend`):
  * stamp `message_bound_at_ms` (+ thread for welcome-page rows) on every
  * claimable job — the stamp releases the chips from the composer and keeps
- * the direct-send bind from double-taking them. Returns the ids claimed. */
+ * the direct-send bind from double-taking them. Returns the ids claimed.
+ * Runs on the CALLER's transaction: the park inserts the row with the
+ * claimed set and enqueues its readiness poll behind this claim, so the
+ * first poll can never observe the row before it knows its videos. */
 export async function bindJobsForDeferredSend(
-  sql: Sql,
+  sql: Sql | TransactionSql,
   args: {
     jobIds: readonly string[];
     userId: string;
@@ -1100,25 +1103,23 @@ export async function bindJobsForDeferredSend(
   },
 ): Promise<string[]> {
   if (args.jobIds.length === 0) return [];
-  return sql.begin(async (tx) => {
-    const now = Date.now();
-    const claimed: string[] = [];
-    for (const jobId of args.jobIds) {
-      const rows = await tx<{ id: string }[]>`
-        UPDATE app.video_link_jobs
-        SET message_bound_at_ms = ${now},
-            thread_id = coalesce(thread_id, ${args.threadId})
-        WHERE id = ${jobId} AND org_id = ${args.organizationId}
-          AND uploaded_by = ${args.userId}
-          AND message_bound_at_ms IS NULL
-          AND status <> 'skipped'
-          AND lifecycle_status IS DISTINCT FROM 'trashed'
-        RETURNING id
-      `;
-      if (rows[0]) claimed.push(rows[0].id);
-    }
-    return claimed;
-  });
+  const now = Date.now();
+  const claimed: string[] = [];
+  for (const jobId of args.jobIds) {
+    const rows = await sql<{ id: string }[]>`
+      UPDATE app.video_link_jobs
+      SET message_bound_at_ms = ${now},
+          thread_id = coalesce(thread_id, ${args.threadId})
+      WHERE id = ${jobId} AND org_id = ${args.organizationId}
+        AND uploaded_by = ${args.userId}
+        AND message_bound_at_ms IS NULL
+        AND status <> 'skipped'
+        AND lifecycle_status IS DISTINCT FROM 'trashed'
+      RETURNING id
+    `;
+    if (rows[0]) claimed.push(rows[0].id);
+  }
+  return claimed;
 }
 
 /** Fire-time payloads for a deferred send's claimed jobs (the 0.4

--- a/services/platform/backend/http-shutdown.ts
+++ b/services/platform/backend/http-shutdown.ts
@@ -26,14 +26,15 @@ const IDLE_REAP_INTERVAL_MS = 200;
 /**
  * Close the HTTP server without hanging on connections that never end.
  *
- * `server.close()` waits for every open connection, and the `/events` SSE
- * responses never end on their own (15s heartbeats; their loop exits only on
- * client abort) — so with any browser connected, a plain close never
- * resolved and every deploy ended in SIGKILL with in-flight jobs killed
- * mid-write. Two measures, layered:
+ * `server.close()` waits for every open connection, and the SSE responses
+ * (`/events`, the per-thread chat progress lane) never end on their own (15s
+ * heartbeats; their loops exit only on client abort) — so with any browser
+ * connected, a plain close never resolved and every deploy ended in SIGKILL
+ * with in-flight jobs killed mid-write. Two measures, layered:
  *
  * 1. Proactively end every live SSE stream ({@link endAllEventStreams}) —
- *    the graceful path: clients reconnect and resume via `Last-Event-ID`.
+ *    the graceful path: clients reconnect (`/events` resumes via
+ *    `Last-Event-ID`).
  * 2. After {@link FORCE_CLOSE_AFTER_MS}, force-close whatever connections
  *    remain (long streaming responses, stuck keep-alives) — the backstop
  *    that keeps the deadline honest for anything the registry cannot see.
@@ -45,7 +46,7 @@ export async function closeServerGracefully(
   const forceAfterMs = options.forceAfterMs ?? FORCE_CLOSE_AFTER_MS;
   const ended = endAllEventStreams();
   if (ended > 0) {
-    console.log(`[backend] ended ${ended} open /events stream(s) for shutdown`);
+    console.log(`[backend] ended ${ended} open SSE stream(s) for shutdown`);
   }
   await new Promise<void>((resolve) => {
     // The `in` checks narrow ServerType: the http/1 server (what `serve`

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -29692,14 +29692,22 @@ async function checkChatMemoriesDeferredAuto(
       UPDATE app.file_metadata SET rag_status = 'completed'
       WHERE storage_ref = ${storageRef}
     `;
+    // The tray row settles the moment the turn persists the user message
+    // (well before the reply streams), so "row gone" is not "turn done":
+    // wait for the generation row to disappear too before reading the reply.
     let sendsLeft = -1;
+    let generating = -1;
     for (let i = 0; i < 60; i++) {
-      const rows = await sql<{ count: string }[]>`
-        SELECT count(*)::text AS count FROM app.deferred_sends
-        WHERE thread_id = ${deferThreadId}
+      const rows = await sql<{ sends: string; generating: string }[]>`
+        SELECT
+          (SELECT count(*) FROM app.deferred_sends
+           WHERE thread_id = ${deferThreadId})::text AS sends,
+          (SELECT count(*) FROM app.generations
+           WHERE thread_id = ${deferThreadId})::text AS generating
       `;
-      sendsLeft = Number(rows[0]?.count ?? '-1');
-      if (sendsLeft === 0) break;
+      sendsLeft = Number(rows[0]?.sends ?? '-1');
+      generating = Number(rows[0]?.generating ?? '-1');
+      if (sendsLeft === 0 && generating === 0) break;
       await sleep(300);
     }
     const deferMessages = await sql<{ role: string; text: string | null }[]>`
@@ -29767,7 +29775,7 @@ async function checkChatMemoriesDeferredAuto(
         cancelRow.success &&
         cancelled.success &&
         cancelled.data.ok,
-      `noModel=${noModel.status} (want 400), parkedWhileIndexing=${stillWaiting.success && stillWaiting.data.sends.length > 0}, settled=${sendsLeft === 0}, answered=${deferMessages.filter((row) => row.role === 'assistant').length}, cancel=${cancelled.success ? cancelled.data.ok : 'ERR'}`,
+      `noModel=${noModel.status} (want 400), parkedWhileIndexing=${stillWaiting.success && stillWaiting.data.sends.length > 0}, settled=${sendsLeft === 0}, turnDone=${generating === 0}, answered=${deferMessages.filter((row) => row.role === 'assistant' && (row.text ?? '').includes('Deferred answer done')).length} (want 1), cancel=${cancelled.success ? cancelled.data.ok : 'ERR'}`,
     );
   } finally {
     // Lift the pick pin — later checks (automation llm nodes, the

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -29304,6 +29304,15 @@ async function checkChatMemoriesDeferredAuto(
     (await fetch(`${base}${route}`, { headers: { cookie } })).json();
 
   // ---- memories -----------------------------------------------------------
+  // The feature is OFF until the person (or the org policy) turns it on: a
+  // proposal while off is refused, not queued.
+  const refusedWhileOff = await post(`/api/app/chat/memories?orgId=${orgId}`, {
+    content: 'Prefers metric units',
+  });
+  const enabledMemories = await post(
+    `/api/app/user-preferences/memories-enabled?orgId=${orgId}`,
+    { enabled: true },
+  );
   const saved = z.object({ id: z.string() }).safeParse(
     await (
       await post(`/api/app/chat/memories?orgId=${orgId}`, {
@@ -29341,9 +29350,32 @@ async function checkChatMemoriesDeferredAuto(
         )
       ).json(),
     );
+  // Delete takes a saved memory out of what a search can return; then the
+  // switch off hides the rest from retrieval without touching the rows.
+  const deleted = z.object({ ok: z.boolean() }).safeParse(
+    await (
+      await fetch(`${base}/api/app/chat/memories/${memoryId}?orgId=${orgId}`, {
+        method: 'DELETE',
+        headers: { cookie, origin: base },
+      })
+    ).json(),
+  );
+  const searchAfterDelete = z
+    .object({ memories: z.array(z.unknown()) })
+    .safeParse(
+      await get(`/api/app/chat/memories/search?orgId=${orgId}&q=metric`),
+    );
+  await post(`/api/app/user-preferences/memories-enabled?orgId=${orgId}`, {
+    enabled: false,
+  });
+  const refusedAgain = await post(`/api/app/chat/memories?orgId=${orgId}`, {
+    content: 'Prefers imperial units',
+  });
   record(
-    'memories: pending until approved, retrieval sees approved only',
-    saved.success &&
+    'memories: off until enabled, pending until approved, retrieval sees approved only',
+    refusedWhileOff.status === 403 &&
+      enabledMemories.ok &&
+      saved.success &&
       listedPending.success &&
       listedPending.data.pending.some((row) => row.id === memoryId) &&
       listedPending.data.approved.length === 0 &&
@@ -29352,8 +29384,13 @@ async function checkChatMemoriesDeferredAuto(
       searchApproved.success &&
       searchApproved.data.memories.length === 1 &&
       bogusReview.success &&
-      !bogusReview.data.ok,
-    `pending=${listedPending.success ? listedPending.data.pending.length : 'ERR'}, hiddenWhilePending=${searchWhilePending.success ? searchWhilePending.data.memories.length === 0 : 'ERR'}, approvedHits=${searchApproved.success ? searchApproved.data.memories.length : 'ERR'}, bogus=${bogusReview.success ? bogusReview.data.ok : 'ERR'} (want false)`,
+      !bogusReview.data.ok &&
+      deleted.success &&
+      deleted.data.ok &&
+      searchAfterDelete.success &&
+      searchAfterDelete.data.memories.length === 0 &&
+      refusedAgain.status === 403,
+    `refusedWhileOff=${refusedWhileOff.status} (want 403), pending=${listedPending.success ? listedPending.data.pending.length : 'ERR'}, hiddenWhilePending=${searchWhilePending.success ? searchWhilePending.data.memories.length === 0 : 'ERR'}, approvedHits=${searchApproved.success ? searchApproved.data.memories.length : 'ERR'}, bogus=${bogusReview.success ? bogusReview.data.ok : 'ERR'} (want false), deleted=${deleted.success ? deleted.data.ok : 'ERR'}, afterDelete=${searchAfterDelete.success ? searchAfterDelete.data.memories.length : 'ERR'}, refusedAgain=${refusedAgain.status} (want 403)`,
   );
 
   // ---- a live fake provider (catalog + streaming completions) -------------

--- a/services/platform/backend/main.ts
+++ b/services/platform/backend/main.ts
@@ -150,7 +150,7 @@ async function main(): Promise<void> {
     shuttingDown = true;
     console.log(`[backend] ${signal} received — shutting down`);
     if (server) {
-      // Ends the never-ending /events SSE streams first and force-closes
+      // Ends the never-ending SSE streams first and force-closes
       // stragglers on a deadline — a bare server.close() waits for every
       // open connection, so one connected browser used to park shutdown
       // here until the orchestrator's SIGKILL, never reaching the graceful

--- a/services/platform/backend/realtime/sse.ts
+++ b/services/platform/backend/realtime/sse.ts
@@ -23,21 +23,34 @@ const HEARTBEAT_INTERVAL_MS = 15_000;
 const ERROR_BACKOFF_MS = 1_000;
 
 /**
- * Every live `/events` stream of this process. An SSE response never ends on
- * its own — the loop below exits only on client abort — while
- * `server.close()` waits for every open connection: without a proactive end,
- * graceful shutdown hangs until the orchestrator SIGKILLs the process (10s
- * default compose grace), killing in-flight jobs mid-write. Shutdown calls
- * {@link endAllEventStreams}; clients reconnect against the next pod and
- * resume via `Last-Event-ID`.
+ * Every live SSE stream of this process — the `/events` hint stream below
+ * and the per-thread chat progress lane (`domains/chat/routes.ts`). An SSE
+ * response never ends on its own — each loop exits only on client abort —
+ * while `server.close()` waits for every open connection: without a
+ * proactive end, graceful shutdown hangs until the orchestrator SIGKILLs the
+ * process (10s default compose grace), killing in-flight jobs mid-write.
+ * Shutdown calls {@link endAllEventStreams}; clients reconnect against the
+ * next pod (`/events` resumes via `Last-Event-ID`; the chat lane repaints
+ * from the generation row).
  */
 const liveStreams = new Set<SSEStreamingApi>();
 
+/** Enrol a streaming response in the shutdown drain — pair with
+ * {@link unregisterLiveStream} in the loop's `finally`. */
+export function registerLiveStream(stream: SSEStreamingApi): void {
+  liveStreams.add(stream);
+}
+
+export function unregisterLiveStream(stream: SSEStreamingApi): void {
+  liveStreams.delete(stream);
+}
+
 /**
- * Proactively end every live `/events` stream (shutdown path). `abort()`
- * cancels the response readable — the connection goes idle immediately, so
- * `server.close()` can complete — and flips `stream.aborted`, which the poll
- * loop reads as its exit condition. Returns how many streams were ended.
+ * Proactively end every live SSE stream (shutdown path). `abort()` cancels
+ * the response readable — the connection goes idle immediately, so
+ * `server.close()` can complete — and flips `stream.aborted`, which every
+ * poll loop reads as its exit condition. Returns how many streams were
+ * ended.
  */
 export function endAllEventStreams(): number {
   const ended = liveStreams.size;
@@ -91,7 +104,7 @@ export function createEventsHandler(sql: Sql) {
 
     return streamSSE(c, async (stream) => {
       hintStreamOpened();
-      liveStreams.add(stream);
+      registerLiveStream(stream);
       const resumeCursor =
         resumeFrom !== null && /^\d+$/.test(resumeFrom) ? resumeFrom : null;
       let cursor = resumeCursor ?? (await latestOutboxId(sql));
@@ -148,7 +161,7 @@ export function createEventsHandler(sql: Sql) {
           await stream.sleep(POLL_INTERVAL_MS);
         }
       } finally {
-        liveStreams.delete(stream);
+        unregisterLiveStream(stream);
         // Paired with the open above — an aborted stream decrements too, or
         // the gauge climbs forever on client churn.
         hintStreamClosed();

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -4528,14 +4528,23 @@ personalization:
       empty:
         Erinnerungen erscheinen hier, nachdem der Assistent sie vorgeschlagen hat
         und du sie speicherst.
+      delete: Löschen
+      deleteLabel: "Erinnerung löschen: {content}"
     pending:
       title: Ausstehende Vorschläge
       empty: Keine ausstehenden Vorschläge.
+      save: Speichern
+      saveLabel: "Vorschlag speichern: {content}"
+      discard: Verwerfen
+      discardLabel: "Vorschlag verwerfen: {content}"
   errors:
     saveFailed: Speichern fehlgeschlagen. Versuch es nochmal.
     tooLong: Benutzerdefinierte Anweisungen überschreiten {max} Zeichen.
   toasts:
     preferencesUpdated: Einstellungen aktualisiert.
+    memorySaved: Erinnerung gespeichert.
+    memoryDiscarded: Vorschlag verworfen.
+    memoryDeleted: Erinnerung gelöscht.
 piiConfigPanel:
   modeLabel: Modus
   modeTokenize: Tokenisieren

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -4374,14 +4374,23 @@ personalization:
     memories:
       title: Saved memories
       empty: Memories appear here after the assistant proposes them and you save.
+      delete: Delete
+      deleteLabel: "Delete memory: {content}"
     pending:
       title: Pending suggestions
       empty: No suggestions waiting.
+      save: Save
+      saveLabel: "Save suggestion: {content}"
+      discard: Discard
+      discardLabel: "Discard suggestion: {content}"
   errors:
     saveFailed: Couldn't save. Try again.
     tooLong: Custom instructions exceed {max} characters.
   toasts:
     preferencesUpdated: Preferences updated.
+    memorySaved: Memory saved.
+    memoryDiscarded: Suggestion discarded.
+    memoryDeleted: Memory deleted.
 piiConfigPanel:
   modeLabel: Mode
   modeTokenize: Tokenize

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -4621,14 +4621,23 @@ personalization:
       empty:
         Les souvenirs apparaissent ici après que l'assistant en propose et que tu
         les enregistres.
+      delete: Supprimer
+      deleteLabel: "Supprimer le souvenir : {content}"
     pending:
       title: Suggestions en attente
       empty: Aucune suggestion en attente.
+      save: Enregistrer
+      saveLabel: "Enregistrer la suggestion : {content}"
+      discard: Écarter
+      discardLabel: "Écarter la suggestion : {content}"
   errors:
     saveFailed: Échec de l'enregistrement. Réessaie.
     tooLong: Les instructions personnalisées dépassent {max} caractères.
   toasts:
     preferencesUpdated: Préférences mises à jour.
+    memorySaved: Souvenir enregistré.
+    memoryDiscarded: Suggestion écartée.
+    memoryDeleted: Souvenir supprimé.
 piiConfigPanel:
   modeLabel: Mode
   modeTokenize: Tokeniser


### PR DESCRIPTION
## Summary

Chat domain (`backend/domains/chat/**`) fix batch from the backend deep review: the deferred-send lane is completed end to end (video claim ordering, settle at user append, failure trace, video release, fire-time re-gate, trash cascade), the Postgres turn store keeps a streamed partial reply on failure, the listener-less `chat_stream` NOTIFY and the dead thread-capability door are gone, the chat progress SSE lane joins the shutdown drain, two query strings are validated, and memories are finished as a feature (server gate on the person's switch / org policy, bounded reads, review + delete controls in the app, docs in three locales).

## Findings fixed

- **chat-domain-1** — the video claim (`bindJobsForDeferredSend`) now runs on the park transaction before the INSERT; the row is written with the claimed set and the poll is enqueued last, so the first poll can never observe a video-only row before its ids exist. `claimDeferredSendVideos` + its route call removed.
- **chat-core-4** — `ChatTurnRequest.onUserMessageAppended`; `createPgTurnStore` applies `settleDeferredSendOnUserAppend` when set; the poll deletes the tray row the moment the user row is durable (no more bubble + "sending" row for a whole generation).
- **chat-domain-2** — a turn refused at a pre-flight gate (`steps` empty) or thrown before the turn-open write now leaves the user row (text + attachments) and an assistant error row (REST-lane envelope) before the row settles.
- **chat-domain-3** — `unbindJobsWithoutMessage` (the unbind door's sent-message guard, shared with `unbindJobsFromMessage`) releases a send's unsent videos in the poll `finally`, the watchdog's cleared arm, and the fire-time drop.
- **chat-domain-8** — the poll re-runs `loadOwnedThread` at fire time (trashed/lost thread → row dropped, videos released, `gone`); the trash door cancels the thread's waiting sends with the manual-cancel cascade (`cancelDeferredSendsForThread`).
- **chat-domain-9** — `GET /threads/archived` and `GET /memories/search` query strings are zod-coerced and bounded (400 on malformed) instead of binding `'NaN'`.
- **chat-domain-10** — `registerLiveStream` / `unregisterLiveStream` exported from `realtime/sse.ts`; the chat progress lane enrols around its loop; shutdown wording no longer names `/events` alone.
- **chat-domain-6** — capability route, `setThreadCapabilities`, `sanitizeThreadCapabilities` + ceilings, and the `capabilities` / `harness` create fields (server + app args) removed; columns kept (branches copy, summaries project). `listComposerModels().harnesses` untouched.
- **chat-domain-5** — `notifyThread` / `CHAT_STREAM_CHANNEL` and the five NOTIFY call sites deleted; store/service/route comments corrected.
- **chat-core-1** — the failure finalize reads the generation row's text/reasoning in one transaction and copies them onto the message (+ trailing text part), so a mid-stream failure keeps the partial reply and the live bubble drains.
- **chat-domain-4** — `isMemoriesEnabled` (preference over org `user_memories` policy, OFF by default); `saveMemory` refuses `MEMORIES_DISABLED` (403 / MCP tool error), `searchApprovedMemories` answers nothing while off and pushes ILIKE filter + LIMIT ≤ 50 into SQL; listing bounded; review only settles pending rows; `deleteMemory` + `DELETE /chat/memories/:id`; app Save / Discard / Delete controls (contract entries, adapter rows, hooks, en/de/fr labels + toasts); docs (en/de/fr) state the switch gates the feature; itest lane proves off-until-enabled, delete, off-again.

## Skipped

- **chat-domain-7** — not a defect to remove: `chat/questions:getPendingQuestion` is a one-shot fetch per thread open on the HTTP lane (no `refetchInterval`), not a poll; the server surface is complete and pinned by the `questions:` itest lane; the producer (`ask_question`) is a product decision the owner declined on 2026-08-14 (`lib/chat/tools.ts`). Removing or rewiring it is a product call, not a fix.

## Tests & gates observed

- `bunx vitest --run --project server backend/domains/chat/` — 8 files / 49 tests passed (before the memories commit); memories + routes suites 19/19; new tests in `deferred-sends.test.ts`, `deferred-sends.watchdog.test.ts`, `routes.test.ts` (new), `memories.test.ts` (new), `store.test.ts`, `http-shutdown` coverage via `routes.test.ts`.
- `bunx vitest --run --config vitest.ui.config.ts app/features/settings/personalization` — 1 file / 11 tests passed.
- `bun run check` (worktree root) — exit 0: `Tasks: 40 successful, 40 total`; `@tale/platform:lint: Found 0 warnings and 0 errors.`; `@tale/platform:test: Test Files 521 passed (521)`; `@tale/platform:test:ui: Test Files 455 passed (455)`; `@tale/docs:test: Test Files 31 passed (31)` / `Tests 201 passed (201)`; `@tale/ui:test: Test Files 124 passed (124)`; `@tale/shared:test: Test Files 22 passed (22)`.
- `bun run knip:check` — exit 0 (one pre-existing configuration hint: `cron-parser services/platform knip.config.ts Remove from ignoreDependencies`).
- Integration proof (`run-itest.sh`, real Postgres + MinIO), run 1: `469/473 checks passed across 134/134 lanes`. The four: `knowledge: corpus scope drift` and `webdav re-home` (both known red on main), `automation-run tool lane` (also FAIL on a main-based run, `chat-turn-itest3.log`, PASS on others — flaky, not this theme), and `deferred send: parks on indexing…` — caused by this PR's own settle-at-append change (the lane read the reply as soon as the row was gone); the lane now waits for the generation row too (`ef445fcd9`).
- Integration proof, run 2 (after the lane fix): `471/473 checks passed across 134/134 lanes`, no `RUN TRUNCATED`; the two remaining are the known-red `knowledge: corpus scope drift is corrected and reported — drifted=null` (knowledge theme) and `webdav re-home` (webdav theme). This theme's lanes: `PASS deferred send: parks on indexing, runs on readiness, cancel works — … settled=true, turnDone=true, answered=1 (want 1), cancel=true`; `PASS memories: off until enabled, pending until approved, retrieval sees approved only — refusedWhileOff=403 (want 403), pending=1, hiddenWhilePending=true, approvedHits=1, bogus=false (want false), deleted=true, afterDelete=0, refusedAgain=403 (want 403)`; `PASS deferred-send recovery`, `PASS video links: unbind is org-scoped and keeps a sent message bound`, `PASS questions: …`, `PASS chat watchdog …`.

## Notes for the reviewer

- `domains/video_links/service.ts` is touched only in the bind/unbind pair (`bindJobsForDeferredSend` takes `Sql | TransactionSql` and no longer opens its own transaction; `unbindJobsWithoutMessage` extracted from the unbind door) — the websites-video theme owns the rest of that file.
- `core/chat/turn_store.ts` (chat-turn theme's tree) is imported, not edited: `settleDeferredSendOnUserAppend` is applied inside `createPgTurnStore`.
- The trash cascade is called from the trash route rather than inside `trashThread` because `threads.ts → deferred-sends.ts → threads.ts` would be a new import cycle; the poll's fire-time re-gate covers the window between the flip and the cascade.
- MCP `memory.save` while memories are off surfaces as a tool error (`isError: true`, message "Memories are turned off for this account — nothing was saved.") — the `MemoryStore` port in `lib/chat` (sibling tree) has no refusal channel.
- Migration numbers: none added.
