### PR TITLE
fix(platform): repair the chat store and audit-lock tests after the merges

### DIFF
--- a/services/platform/backend/domains/chat/store.test.ts
+++ b/services/platform/backend/domains/chat/store.test.ts
@@ -257,10 +257,6 @@ describe('createPgTurnStore.appendMessage', () => {
     });
 
     expect(appended.id).toBe('msg_1');
-    // No generation row ever opens for a pre-model refusal, so without this
-    // NOTIFY the other viewers of the thread learn of the two rows only on a
-    // later invalidation.
-    expect(f.notified).toEqual(['chat_stream:thread_1']);
   });
 });
 

--- a/services/platform/backend/domains/chat/store.ts
+++ b/services/platform/backend/domains/chat/store.ts
@@ -7,7 +7,6 @@ import {
   type UsageLedger,
   type UsageLedgerEntry,
 } from '../../../lib/chat/turn.ts';
-import { settleDeferredSendOnUserAppend } from '../../core/chat/turn_store.ts';
 import { getProviderCatalog } from '../../core/lib/providers/catalog_fetch.ts';
 import { resolveProvidersForOrg } from '../../core/lib/providers/org_providers.ts';
 import { toJson } from '../../db/sql.ts';
@@ -206,6 +205,37 @@ async function finalizeWithStreamedTail(
   });
 }
 
+/**
+ * Decorate a turn store so a deferred send's row dies the moment the turn
+ * persists the user message — the turn-open write, when it carries the user
+ * parts. Until that write the row is the parked message's only
+ * representation (the tray above the composer); from it on the thread shows
+ * the bubble, and a row that survived to the action's terminal settle would
+ * double-display the message for the whole generation. A settle failure is
+ * logged, never fatal — the terminal settle in the action retries it.
+ * (Re-homed from the retired `core/chat/turn_store.ts`: the PG store is its
+ * only consumer.)
+ */
+function settleDeferredSendOnUserAppend(
+  store: TurnStore,
+  settle: () => Promise<void>,
+): TurnStore {
+  return {
+    ...store,
+    async beginTurn(setup) {
+      const opened = await store.beginTurn(setup);
+      if (setup.userParts !== undefined) {
+        try {
+          await settle();
+        } catch (error) {
+          console.warn('Deferred send settle at user append failed:', error);
+        }
+      }
+      return opened;
+    },
+  };
+}
+
 /** A turn store over app.messages + app.generations. With
  * `onUserMessageAppended` the store is decorated to run it the moment
  * `beginTurn` persisted the user row — the deferred-send lane settles its
@@ -231,10 +261,6 @@ function pgTurnStore(sql: Sql): TurnStore {
           .map((part) => (part.type === 'text' ? part.text : ''))
           .join(''),
       });
-      // A pre-model refusal lands its two rows through this write alone (no
-      // generation row ever opens), so this is the only signal the thread's
-      // other viewers get that the transcript moved.
-      await notifyThread(sql, message.threadId);
       return appended;
     },
 

--- a/services/platform/backend/domains/members/service.test.ts
+++ b/services/platform/backend/domains/members/service.test.ts
@@ -77,7 +77,10 @@ function createRecordingTx(scenario: Scenario): {
     if (text.startsWith('DELETE FROM "passkey"')) {
       return scenario.passkeyDeleteReturns ?? [{ id: 'pk-1' }];
     }
-    if (text.startsWith('INSERT INTO app.audit_chain_heads')) {
+    if (
+      text.startsWith('SELECT pg_advisory_xact_lock(') ||
+      text.startsWith('INSERT INTO app.audit_chain_heads')
+    ) {
       return [];
     }
     if (text.includes('FROM app.audit_chain_heads')) {

--- a/services/platform/backend/domains/tasks/reattach.stalled.test.ts
+++ b/services/platform/backend/domains/tasks/reattach.stalled.test.ts
@@ -67,7 +67,6 @@ describe('recoverStalledTaskAgentTurns — the op-less arm ages on the run row',
  * `integration-check.ts`.
  */
 
-
 interface Statement {
   text: string;
   values: unknown[];

--- a/services/platform/backend/domains/users/create-member.test.ts
+++ b/services/platform/backend/domains/users/create-member.test.ts
@@ -77,7 +77,10 @@ function createRecordingSql(scenario: Scenario): {
     if (text.startsWith('INSERT INTO "member"')) {
       return [{ id: 'member-new' }];
     }
-    if (text.startsWith('INSERT INTO app.audit_chain_heads')) {
+    if (
+      text.startsWith('SELECT pg_advisory_xact_lock(') ||
+      text.startsWith('INSERT INTO app.audit_chain_heads')
+    ) {
       return [];
     }
     if (text.includes('FROM app.audit_chain_heads')) {


### PR DESCRIPTION
## Summary

Main went red after the campaign merges: three PRs were each CI-green on their own base but not together.

- #3230 deleted `core/chat/turn_store.ts` while #3245 imports `settleDeferredSendOnUserAppend` from it → the pure decorator is re-homed into `domains/chat/store.ts`, its only consumer.
- #3230 added a `notifyThread` call in `appendMessage` (and a test asserting the NOTIFY) on the `chat_stream` channel that #3245 removed as listener-less (nothing LISTENs on it) → the call and the `f.notified` assertion go.
- #3246 put the audit chain head behind `pg_advisory_xact_lock`; #3240's strict recording-tx tests (`members/service.test.ts`, `users/create-member.test.ts`) refused the unexpected SQL → they answer the lock SELECT with `[]`, as `organizations/service.test.ts` already does.

## Gates observed (services/platform, on this tip)

- `bunx tsc --noEmit` — exit 0 (main: 3 errors)
- `bunx oxlint --type-aware` — exit 0
- `bunx vitest --run --project server` — `Test Files 547 passed (547)` / `Tests 6370 passed (6370)` (main: 1 file / 2 tests failing plus the type errors)

No behaviour change beyond restoring what each merged PR intended; no migrations, no locale keys.