### PR TITLE
fix(sandbox): drain a refused runnerd body before answering 413

### DIFF
--- a/services/sandbox-runtime/daemon/src/http-body.test.ts
+++ b/services/sandbox-runtime/daemon/src/http-body.test.ts
@@ -6,6 +6,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { createServer, type Server } from 'node:http';
+import { connect } from 'node:net';
 
 import { readJsonBody } from './http-body.ts';
 import { RUNNERD_MAX_REQUEST_BODY_BYTES } from './protocol.ts';
@@ -18,10 +19,12 @@ beforeAll(async () => {
   server = createServer((req, res) => {
     void (async () => {
       const body = await readJsonBody(req, CAP);
+      const payload = JSON.stringify(body.ok ? { echo: body.value } : body);
       res.writeHead(body.ok ? 200 : body.status, {
         'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
       });
-      res.end(JSON.stringify(body.ok ? { echo: body.value } : body));
+      res.end(payload);
     })();
   });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
@@ -82,6 +85,74 @@ describe('readJsonBody', () => {
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ echo: { files: [] } });
+  });
+
+  // REGRESSION (dirty keep-alive after a refusal): the reader used to answer
+  // the 413 as soon as the running total passed the cap, with the tail of
+  // the upload still unread on the socket — and the next request on that
+  // connection was parsed as body and answered 400 with no JSON at all. Two
+  // requests go down ONE socket in a single write here (the tail of the
+  // oversize chunked body and the whole second request are already buffered
+  // when the cap trips), and the second must still be answered on its own
+  // terms — which takes draining the refused body before answering.
+  test('a refused body is drained, so a pipelined next request is answered', async () => {
+    const chunk = 'x'.repeat(CAP / 2);
+    const chunked = Array.from(
+      { length: 4 },
+      () => `${(CAP / 2).toString(16)}\r\n${chunk}\r\n`,
+    ).join('');
+    const second = '{not json';
+    const wire =
+      `POST / HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n` +
+      `Transfer-Encoding: chunked\r\n\r\n${chunked}0\r\n\r\n` +
+      `POST / HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n` +
+      `Content-Length: ${second.length}\r\n\r\n${second}`;
+    const url = new URL(base);
+    const raw = await new Promise<string>((resolve, reject) => {
+      let received = '';
+      const socket = connect(Number(url.port), url.hostname, () => {
+        socket.write(wire);
+      });
+      const settle = (): void => {
+        socket.destroy();
+        resolve(received);
+      };
+      const deadline = setTimeout(settle, 3000);
+      socket.setEncoding('utf8');
+      socket.on('data', (data: string) => {
+        received += data;
+        // Both responses are Content-Length framed and end in `}`.
+        if (
+          (received.match(/HTTP\/1\.1 /g) ?? []).length === 2 &&
+          received.endsWith('}')
+        ) {
+          clearTimeout(deadline);
+          settle();
+        }
+      });
+      socket.on('error', (error) => {
+        clearTimeout(deadline);
+        reject(error);
+      });
+      socket.on('close', () => {
+        clearTimeout(deadline);
+        resolve(received);
+      });
+    });
+    const responses = raw
+      .split(/(?=HTTP\/1\.1 )/)
+      .filter((part) => part.length > 0)
+      .map((part) => ({
+        status: Number(part.slice(9, 12)),
+        body: part.slice(part.indexOf('\r\n\r\n') + 4),
+      }));
+    expect(responses.map((r) => r.status)).toEqual([413, 400]);
+    expect(JSON.parse(responses[0]?.body ?? 'null')).toMatchObject({
+      error: 'payload_too_large',
+    });
+    expect(JSON.parse(responses[1]?.body ?? 'null')).toMatchObject({
+      error: 'bad_request',
+    });
   });
 
   test('the default cap is the shared protocol constant (8 MiB)', () => {

--- a/services/sandbox-runtime/daemon/src/http-body.ts
+++ b/services/sandbox-runtime/daemon/src/http-body.ts
@@ -17,35 +17,30 @@ export type JsonBodyResult =
 type BodyRead = { kind: 'read'; raw: string } | { kind: 'too_large' };
 
 /**
- * Collect the request body up to `maxBytes` WITHOUT ever destroying the
- * request stream. Refusing from inside a `for await` (throw/break) calls the
- * iterator's `return()`, which destroys the IncomingMessage: on Node that
- * aborts the socket, and under Bun's node:http the 413 the route writes
- * afterwards is lost and the client reads a 200 — so the body is taken off
- * the `data` event, an oversize body is refused by pausing the stream (a
- * declared oversize `Content-Length` before the first byte, a running total
- * past the cap otherwise), and the route's 413 goes out on a live socket
- * that `Connection: close` then closes with the unread remainder.
+ * Collect the request body up to `maxBytes`, reading the stream TO ITS END
+ * whatever the verdict. Refusing from inside a `for await` (throw/break)
+ * calls the iterator's `return()`, which destroys the IncomingMessage: on
+ * Node that aborts the socket, and under Bun's node:http the 413 the route
+ * writes afterwards is lost and the client reads a 200. Answering early on a
+ * live socket is no better: a response that ends with request bytes still
+ * unread leaves the connection in a state the two sides disagree on — the
+ * next request on it is parsed as body and answered 400 with no JSON at
+ * all (this module's own suite flaked that way on Bun 1.3.12), and closing
+ * the socket instead hangs Bun 1.3.12's fetch (the spawner's runtime) on
+ * its next call. So an oversize body — a declared oversize `Content-Length`,
+ * or a running total past the cap — is DRAINED: everything past the cap is
+ * dropped unbuffered (memory stays bounded by `maxBytes`), and the 413 is
+ * answered once the upload has ended, on a clean keep-alive connection.
  */
 function readBody(req: IncomingMessage, maxBytes: number): Promise<BodyRead> {
   return new Promise((resolve, reject) => {
-    const declared = Number(req.headers['content-length']);
-    if (Number.isFinite(declared) && declared > maxBytes) {
-      req.pause();
-      resolve({ kind: 'too_large' });
-      return;
-    }
     const chunks: Buffer[] = [];
     let total = 0;
     let settled = false;
-    const finish = (result: BodyRead): void => {
-      if (settled) return;
-      settled = true;
-      req.removeListener('data', onData);
-      resolve(result);
-    };
-    const onData = (chunk: unknown): void => {
-      if (settled) return;
+    const declared = Number(req.headers['content-length']);
+    let tooLarge = Number.isFinite(declared) && declared > maxBytes;
+    req.on('data', (chunk: unknown) => {
+      if (tooLarge) return;
       const buf = Buffer.isBuffer(chunk)
         ? chunk
         : chunk instanceof Uint8Array
@@ -53,20 +48,24 @@ function readBody(req: IncomingMessage, maxBytes: number): Promise<BodyRead> {
           : Buffer.from(String(chunk), 'utf8');
       total += buf.length;
       if (total > maxBytes) {
-        req.pause();
-        finish({ kind: 'too_large' });
+        tooLarge = true;
+        chunks.length = 0;
         return;
       }
       chunks.push(buf);
-    };
-    req.on('data', onData);
+    });
     req.once('end', () => {
-      finish({ kind: 'read', raw: Buffer.concat(chunks).toString('utf8') });
+      if (settled) return;
+      settled = true;
+      resolve(
+        tooLarge
+          ? { kind: 'too_large' }
+          : { kind: 'read', raw: Buffer.concat(chunks).toString('utf8') },
+      );
     });
     req.once('error', (error: Error) => {
       if (settled) return;
       settled = true;
-      req.removeListener('data', onData);
       reject(error);
     });
   });

--- a/services/sandbox-runtime/daemon/src/main.ts
+++ b/services/sandbox-runtime/daemon/src/main.ts
@@ -148,13 +148,11 @@ function tokenOk(req: IncomingMessage): boolean {
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
   const payload = JSON.stringify(body);
-  res.writeHead(status, {
-    'content-type': 'application/json',
-    // A 413 leaves the oversize request body unread (`readJsonBody` pauses
-    // the stream instead of destroying it); closing the connection drops
-    // that remainder with the socket instead of draining it.
-    ...(status === 413 ? { connection: 'close' } : {}),
-  });
+  // A 413 needs no `Connection: close`: `readJsonBody` drains the refused
+  // body before the route answers, so the keep-alive connection is clean
+  // for the next request (closing it under a half-sent upload hangs Bun
+  // 1.3.12's fetch — the spawner — on its next call).
+  res.writeHead(status, { 'content-type': 'application/json' });
   res.end(payload);
 }
 


### PR DESCRIPTION
## Why

Three campaign PRs (#3251, #3258, #3259) went red on **Unit** with the same single failure in the runnerd daemon suite: `readJsonBody > malformed JSON under the cap is 400 bad_request` — `res.json()` on the 400 was not an object. The test runs right after the chunked-oversize 413 case, on a keep-alive connection Bun's fetch reuses. The reader that #3247 landed answered the 413 as soon as the running total passed the cap and paused the stream, leaving the tail of the upload unread on a live socket; `sendJson` additionally sent `Connection: close` on 413.

Both halves are hazards with the runtimes in play:

- **CI (Bun 1.3.12 test runner):** the next request on the dirty connection comes back `400` with no JSON at all — the flake above (~1 in 2 runs; passed on #3252/#3253/#3257, failed on #3251/#3258/#3259, all with identical daemon code).
- **Production (spawner = Bun 1.3.12, see `services/sandbox/Dockerfile`):** a server that closes the connection under a half-sent upload hangs Bun 1.3.12's `fetch` on its *next* call. Reproduced locally against both a Bun and a Node 22 server: 18/20 follow-up requests timed out with `Connection: close` (or a socket destroy) on the 413; 0/20 with a drained body. Bun 1.4 does not hang.

## What

- `readJsonBody` drains the request to its end whatever the verdict: everything past the cap is dropped unbuffered (memory stays bounded by `maxBytes`), and the 413 goes out once the upload has ended, on a clean keep-alive connection.
- `sendJson` no longer sends `Connection: close` on 413.
- Test: two requests pinned to one raw socket in a single write (oversize chunked body, then a malformed one); the second must be answered on its own terms. The test server frames its responses with `Content-Length` so raw parsing is deterministic.

## Proof

- Daemon suite: 92/92 under Bun 1.4.0 and Bun 1.3.12 (10 consecutive runs of `http-body.test.ts` under 1.3.12).
- Follow-up-request matrix with the drained reader (server × client): Bun 1.3.12 × Bun 1.3.12, Node 22 × Bun 1.3.12, Bun 1.4 × Bun 1.4, Node 22 × Bun 1.4 — 20/20 each for a slow chunked oversize upload, 5/5 each for a 12 MiB declared body, no hangs.
- `tsc --noEmit`, `oxlint --type-aware`, `oxfmt` clean for the daemon workspace.