### PR TITLE
ci: move the CI test toolchain to Bun 1.4.2

### DIFF
--- a/.github/actions/setup-turbo/action.yml
+++ b/.github/actions/setup-turbo/action.yml
@@ -6,9 +6,12 @@ inputs:
     description: Bun version
     # Floor 1.4.1. Earlier Bun ran N-API addon finalizers and cleanup hooks
     # inside process.exit() and could hand a still-queued threadsafe-function
-    # call a null env; rolldown (Vite 8) is such an addon, so the docs client
-    # build hung at its explicit exit on roughly one CI run in fifteen and the
-    # docs Playwright webServer timed out with zero tests run.
+    # call a null env; rolldown (Vite 8) is such an addon. The docs client
+    # build stalled on roughly one CI run in fifteen after its last build
+    # output and before `vite preview` started, and the evidence places that
+    # stall at the build's explicit exit; the docs Playwright webServer then
+    # timed out with zero tests run. The pin is hashed into every Turbo task
+    # (`globalDependencies`), so a bump reruns the cached tasks under it.
     default: '1.4.2'
   start-turbo-cache:
     description: Start the Turborepo GH artifacts cache server

--- a/.github/actions/setup-turbo/action.yml
+++ b/.github/actions/setup-turbo/action.yml
@@ -4,7 +4,12 @@ description: Bun + deps with cache, optional Turbo remote cache server
 inputs:
   bun-version:
     description: Bun version
-    default: '1.3.12'
+    # Floor 1.4.1. Earlier Bun ran N-API addon finalizers and cleanup hooks
+    # inside process.exit() and could hand a still-queued threadsafe-function
+    # call a null env; rolldown (Vite 8) is such an addon, so the docs client
+    # build hung at its explicit exit on roughly one CI run in fifteen and the
+    # docs Playwright webServer timed out with zero tests run.
+    default: '1.4.2'
   start-turbo-cache:
     description: Start the Turborepo GH artifacts cache server
     default: 'true'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,15 +62,16 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          # Deliberately newer than the 1.3.12 the build jobs pin: before 1.4,
-          # `bun audit --prod` run from a workspace root reported workspace
+          # The test toolchain's pin (`.github/actions/setup-turbo`); the audit
+          # itself needs 1.4 or newer: before 1.4, `bun audit --prod` run from
+          # a workspace root reported workspace
           # members' devDependencies as production (oven-sh/bun#26675, fixed
           # in 1.4 by oven-sh/bun#38333). That made the gate below fail on
           # @faker-js/faker 5.5.3, reachable only through the dev-only
           # @stoplight/prism-http mock server (postman-collection pins it and
           # no upstream release lifts the pin). 1.4.0 keeps reporting real
           # production findings (verified against the fast-uri/mysql2 lock).
-          bun-version: '1.4.0'
+          bun-version: '1.4.2'
 
       - name: Run bun audit (report)
         # Full advisory list for visibility; does not fail the build itself.

--- a/services/docs/playwright.config.ts
+++ b/services/docs/playwright.config.ts
@@ -23,7 +23,8 @@ export default createPlaywrightConfig({
     // `scripts/build-client.ts` (vite's JS API + an explicit exit), not the
     // `vite build` CLI: the CLI process occasionally never exits after a
     // successful build, and the `&&` chain then starves silently until this
-    // webServer timeout with zero tests run.
+    // webServer timeout with zero tests run. The explicit exit is only safe
+    // on Bun ≥ 1.4.1 — see build-client.ts for why.
     command:
       `bun --bun scripts/build-search-index.ts && ` +
       `bun --bun scripts/build-client.ts && ` +

--- a/services/docs/scripts/build-client.ts
+++ b/services/docs/scripts/build-client.ts
@@ -1,12 +1,13 @@
 // The Playwright webServer chains client build → preview with `&&`, so the
 // chain advances only when the build PROCESS exits. `bun --bun vite build`
-// occasionally never exits after a successful build — a dangling handle in
-// the rolldown/PWA-plugin pipeline keeps the event loop alive — and the
-// silent hang starves the chain until the webServer timeout with zero tests
-// run. Building through the JS API and exiting explicitly makes process
-// exit a certainty instead of an event-loop accident: `build()` resolves
-// only after every plugin's `closeBundle`, so the PWA artifacts are already
-// on disk when the exit fires.
+// occasionally never exits after a successful build, and the silent hang
+// starves the chain until the webServer timeout with zero tests run.
+// Building through the JS API and exiting explicitly removes the implicit
+// exit from the chain: `build()` resolves only after every plugin's
+// `closeBundle`, so the PWA artifacts are already on disk when the exit
+// fires. The exit itself needs Bun ≥ 1.4.1 — earlier Bun ran rolldown's
+// N-API finalizers and cleanup hooks inside `process.exit()` and could hang
+// there just the same (pinned in `.github/actions/setup-turbo/action.yml`).
 
 import { build } from 'vite';
 

--- a/services/docs/scripts/build-client.ts
+++ b/services/docs/scripts/build-client.ts
@@ -6,8 +6,10 @@
 // exit from the chain: `build()` resolves only after every plugin's
 // `closeBundle`, so the PWA artifacts are already on disk when the exit
 // fires. The exit itself needs Bun ≥ 1.4.1 — earlier Bun ran rolldown's
-// N-API finalizers and cleanup hooks inside `process.exit()` and could hang
-// there just the same (pinned in `.github/actions/setup-turbo/action.yml`).
+// N-API finalizers and cleanup hooks inside `process.exit()`, and the
+// evidence places CI's remaining stalls there (pinned in
+// `.github/actions/setup-turbo/action.yml`). The line logged after `build()`
+// resolves puts any future stall on one side of the exit or the other.
 
 import { build } from 'vite';
 
@@ -17,4 +19,5 @@ try {
   console.error(error);
   process.exit(1);
 }
+console.info('[build-client] build resolved, exiting 0');
 process.exit(0);

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.v2.json",
+  "globalDependencies": [".github/actions/setup-turbo/action.yml"],
   "globalPassThroughEnv": [
     "DO_NOT_TRACK",
     "TURBO_TELEMETRY_DISABLED",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.v2.json",
-  "globalDependencies": [".github/actions/setup-turbo/action.yml"],
   "globalPassThroughEnv": [
     "DO_NOT_TRACK",
     "TURBO_TELEMETRY_DISABLED",
@@ -110,6 +109,7 @@
     }
   },
   "globalDependencies": [
+    ".github/actions/setup-turbo/action.yml",
     ".oxlintrc.json",
     ".oxfmtrc.json",
     "tsconfig.base.json"


### PR DESCRIPTION
## Why

The docs Playwright job (E2E workflow, `Playwright (docs)`) times out in Playwright's `webServer` on roughly one run in fifteen — 3 of the last 40 E2E runs, and twice in a row on #3262 (runs 34011390460 attempts 1+2, and 34007884968 on another branch). The failing logs all stop at the same line: the client build prints the PWA plugin's `files generated`, then nothing follows for the remaining ~3m50s of the 240 s budget. `vite preview` never prints its banner, so zero tests run.

The PWA file list is printed from inside rolldown's native close, so the rest of that close, `build()` returning, the explicit `process.exit(0)` in `services/docs/scripts/build-client.ts`, the shell `&&` and `vite preview`'s start all sit in the unobserved window (0.8 s in a passing run). The evidence places the stall at the exit: the natural-exit `vite build` path that runs the same `bundle.close()` is green across the sampled Build history, web's identical `vite preview` never stalled, and Bun 1.4.1 names an exit-time hang in exactly this addon class.

## Root cause

[Bun v1.4.1's release notes](https://bun.com/blog/bun-v1.4.1) (2026-09-04):

> On the main thread, `process.exit()` previously ran addon finalizers and cleanup hooks, and these could crash. It now skips them, as Node does.
> `process.exit()` with calls still queued on a threadsafe function no longer passes a null `env` to the addon's callback.

rolldown — what Vite 8 builds with — is an N-API addon whose JS plugin bridge runs on threadsafe functions. CI ran Bun **1.3.12** through the `setup-turbo` composite action's default, so every docs build exited through that path; under runner contention it occasionally never came back. The pre-#2982 `vite build` CLI "never exits after a successful build" hang is the same class (natural exit runs the same teardown).

## Change

- `.github/actions/setup-turbo/action.yml`: default `bun-version` `1.3.12` → `1.4.2` (current release, 2026-09-05), with the floor documented in place. This is the pin behind Checks, E2E, Commitlint and the two Build jobs that call the action without a version.
- `services/docs/scripts/build-client.ts`, `services/docs/playwright.config.ts`: the comments that explained the hang as a dangling event-loop handle now state the real dependency.

## Deliberately left alone (release-engineering decisions)

- `build.yml` / `release.yml` (1.3.12) and `cli.yml` (1.3.13) — they compile the shipped CLI binaries.
- The Dockerfiles (`oven/bun:1.3.12` in web, docs, sandbox, plop template) — runtime images; the `Docs container test` job shows no failures in the last 25 Build runs.
- `security.yml`'s 1.4.0 audit pin (#3211) and `package.json`'s `packageManager: bun@1.3.10`.

## Verification

- Bun 1.4.2, this branch: `bun install --frozen-lockfile --dry-run` resolves the lockfile; `CI=1 bun run --filter @tale/docs test:e2e` → build, `➜ Local: http://localhost:3002/`, **3 passed**.
- Bun 1.3.12 and 1.4.0 locally never reproduced the hang (36 contended builds, 0 hangs) — the failure needs the runner's timing; the CI runs of this PR are the observation that counts, and the docs job's pass rate over the next runs is the proof.
- `oxfmt --check` clean on the changed files.

## Review follow-ups (adversarial review: approve, advisory only) — 10341847d

- **Turbo cache** (`turbo.json`): the task hash ignored the Bun version, so this PR's first CI run replayed the CLI unit task from a 1.3.12 cache (`bun test v1.3.12` in the log) and never executed it under 1.4.2. `.github/actions/setup-turbo/action.yml` is now in `globalDependencies`, so a pin change reruns every cached task. (First attempt added a second top-level `globalDependencies` key that the parser dropped, so 10341847d replayed the same 1.3.12 log again; 3abb75b05 puts the file in the existing list and Turbo's dry run shows it among the global files — that push is the first run where the CLI tests execute under 1.4.2 in CI.) (The reviewer ran `tools/cli` under 1.4.2 locally meanwhile: 334 pass / 18 skip / 0 fail.)
- **Audit gate** (`security.yml`): its 1.4.0 pin, documented as "deliberately newer than the build jobs", was now the older one; aligned to 1.4.2 with the comment corrected.
- **Wording**: comments, this body and the follow-up commit state that the evidence *places* the stall at the exit instead of asserting the site. `build-client.ts` now logs `[build-client] build resolved, exiting 0` after `build()` resolves, so any future timeout lands on one side of the exit.
- Not addressed here: Storybook (also a Vite/rolldown build under `--bun`) is path-filtered off this PR and gets its first 1.4.2 observation with the next UI change; the repo-wide dev floor stays "Bun >= 1.3" (local runs skip the build chain via `reuseExistingServer`).

- Fifth occurrence while this PR was open: run 34016343826 on #3267 (a platform-only change, no docs content touched) — `bun-version: 1.3.12`, `files generated`, then the 240 s timeout. Same shape, unrelated content.

- Observed on 3abb75b05: the Checks Unit job ran with **zero cache replays** — `@tale/cli:test` was a cache miss and executed under `bun test v1.4.2`, as did every other Bun-native suite.
- Sixth occurrence: run 34017745677 on #3267's polish head (platform-only again) — `bun-version: 1.3.12`, `files generated`, 240 s timeout. Under 1.3.12 the docs job has now stalled on 6 of today's runs; on this PR's three 1.4.2 heads it passed 3 of 3.
