### PR TITLE
feat(platform): ship Z.ai embedding-3 and harden the embedder for it

### DIFF
--- a/configs/platform/system/models/zai/models.yml
+++ b/configs/platform/system/models/zai/models.yml
@@ -5,7 +5,8 @@
 # refreshed and glm-5.3 / glm-4.6v added from the 2026-08-26 listing.
 # glm-5.3-flash added from the vendor docs + listing on 2026-08-28;
 # prices are the vendor's list rates, not the launch promo running
-# until 2026-09-09.
+# until 2026-09-09. embedding-3 added from the vendor's API reference on
+# 2026-09-06 (see its entry for the facts that shaped it).
 - id: glm-5.3
   provider: zai
   tags:
@@ -100,3 +101,27 @@
   pricing:
     inputCentsPerMillion: 30
     outputCentsPerMillion: 90
+# Embedding model — the vendor's current one (embedding-2 is a fixed-1024
+# legacy tag). Facts from the vendor's API reference, 2026-09-06: `dimensions`
+# accepts 256, 512, 1024 or 2048 (default 2048); one input holds at most 3072
+# tokens; one request carries at most 64 inputs (error 1214 — the embedder's
+# batch cap). 1024 is curated because the 2048 default sits above pgvector's
+# 2000-dim HNSW ceiling (a corpus that could only scan sequentially) and 1536
+# — the width the other curated picks share — is not an accepted value, so an
+# organization sharing the bundled knowledge database with a 1536-pinned
+# corpus needs its own database for this pick. Embeddings bill the API
+# balance, NOT the GLM Coding Plan quota: a plan key without balance gets 429
+# "Insufficient balance or no resource package" (code 1113) on the coding
+# base and the general base alike (verified 2026-09-06). No price: the
+# international pricing page publishes none for embeddings, so usage books at
+# 0 rather than at a rate converted from the CN list.
+- id: embedding-3
+  provider: zai
+  tags:
+    - embedding
+  supportsTools: false
+  supportsVision: false
+  contextWindow: 3072
+  embedding:
+    dimensions: 1024
+    recommended: true

--- a/configs/platform/system/models/zai/models.yml
+++ b/configs/platform/system/models/zai/models.yml
@@ -102,19 +102,22 @@
     inputCentsPerMillion: 30
     outputCentsPerMillion: 90
 # Embedding model — the vendor's current one (embedding-2 is a fixed-1024
-# legacy tag). Facts from the vendor's API reference, 2026-09-06: `dimensions`
-# accepts 256, 512, 1024 or 2048 (default 2048); one input holds at most 3072
-# tokens; one request carries at most 64 inputs (error 1214 — the embedder's
-# batch cap). 1024 is curated because the 2048 default sits above pgvector's
-# 2000-dim HNSW ceiling (a corpus that could only scan sequentially) and 1536
-# — the width the other curated picks share — is not an accepted value, so an
-# organization sharing the bundled knowledge database with a 1536-pinned
-# corpus needs its own database for this pick. Embeddings bill the API
-# balance, NOT the GLM Coding Plan quota: a plan key without balance gets 429
-# "Insufficient balance or no resource package" (code 1113) on the coding
-# base and the general base alike (verified 2026-09-06). No price: the
-# international pricing page publishes none for embeddings, so usage books at
-# 0 rather than at a rate converted from the CN list.
+# legacy tag). The vendor's API reference lists `dimensions` 256, 512, 1024
+# or 2048 (default 2048), 3072 tokens per input and at most 64 inputs per
+# request; live on api.z.ai (both bases, 2026-09-06) the model truncates to
+# ANY requested width — 1536 and 1000 came back at exactly that width — and
+# a 22k-token input was embedded, while the 64-input cap is enforced before
+# billing (error 1214; the embedder's batch cap). 1536 is curated: the 2048
+# default sits above pgvector's 2000-dim HNSW ceiling (a corpus that could
+# only scan sequentially), and 1536 is the width the other curated picks and
+# every existing bundled corpus are pinned to, so an organization adopting
+# this model can share the deployment's knowledge database instead of
+# needing its own. Embeddings bill the API balance, NOT the GLM Coding Plan
+# quota: a plan key without balance gets 429 "Insufficient balance or no
+# resource package" (code 1113) on the coding base and the general base
+# alike. No price: the international pricing page publishes none for
+# embeddings, so usage books at 0 rather than at a rate converted from the
+# CN list. contextWindow is the vendor's documented per-input limit.
 - id: embedding-3
   provider: zai
   tags:
@@ -123,5 +126,5 @@
   supportsVision: false
   contextWindow: 3072
   embedding:
-    dimensions: 1024
+    dimensions: 1536
     recommended: true

--- a/services/platform/backend/core/knowledge/dimensions.ts
+++ b/services/platform/backend/core/knowledge/dimensions.ts
@@ -34,8 +34,10 @@ import { logger } from '../../../lib/knowledge/logger';
 import { PRIVATE_KNOWLEDGE_SCHEMA } from '../../../lib/knowledge/types';
 import { isProgramLimitExceeded, isUndefinedTable } from './pool';
 
-/** pgvector cannot build an HNSW index above this width. */
-const HNSW_DIMENSION_LIMIT = 2000;
+/** pgvector cannot build an HNSW index above this width. Exported so the
+ * shipped-catalog gate can refuse a curated embedding width that would leave
+ * a corpus scanning sequentially. */
+export const HNSW_DIMENSION_LIMIT = 2000;
 
 /** What one database has been pinned to, keyed by connection string. The
  * width is a per-DATABASE policy — every schema in it stores the same

--- a/services/platform/backend/core/knowledge/embedding.test.ts
+++ b/services/platform/backend/core/knowledge/embedding.test.ts
@@ -15,7 +15,10 @@ const { constructed, create } = vi.hoisted(() => ({
   create:
     vi.fn<
       (args: {
+        model: string;
         input: string[];
+        dimensions: number;
+        encoding_format?: string;
       }) => Promise<{ data: { embedding: number[] }[] }>
     >(),
 }));
@@ -126,5 +129,28 @@ describe('batching', () => {
       MAX_BATCH,
       1,
     ]);
+  });
+});
+
+describe('the request shape', () => {
+  it('asks for float vectors explicitly, never the SDK base64 default', async () => {
+    // Left unspecified, the SDK requests base64 and decodes the answer as
+    // base64 without checking that it is a string. A provider that ignores
+    // the parameter (Z.ai) returns floats, which that decoder turns into a
+    // short vector of zeros — 256 for a 1024-wide request.
+    create.mockImplementation((args) =>
+      Promise.resolve({
+        data: args.input.map(() => ({ embedding: [1, 2, 3] })),
+      }),
+    );
+    const embedder = new Embedder(MODEL, 'sk-test');
+
+    await expect(embedder.embed('hello')).resolves.toEqual([1, 2, 3]);
+    expect(create).toHaveBeenCalledWith({
+      model: 'text-embedding-3-small',
+      input: ['hello'],
+      dimensions: 3,
+      encoding_format: 'float',
+    });
   });
 });

--- a/services/platform/backend/core/knowledge/embedding.test.ts
+++ b/services/platform/backend/core/knowledge/embedding.test.ts
@@ -12,7 +12,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { constructed, create } = vi.hoisted(() => ({
   constructed: [] as Record<string, unknown>[],
-  create: vi.fn(),
+  create:
+    vi.fn<
+      (args: {
+        input: string[];
+      }) => Promise<{ data: { embedding: number[] }[] }>
+    >(),
 }));
 
 vi.mock('openai', async (importOriginal) => {
@@ -29,7 +34,8 @@ vi.mock('openai', async (importOriginal) => {
 });
 
 const OpenAI = (await import('openai')).default;
-const { Embedder, EMBED_REQUEST_TIMEOUT_MS } = await import('./embedding.ts');
+const { Embedder, EMBED_REQUEST_TIMEOUT_MS, MAX_BATCH } =
+  await import('./embedding.ts');
 
 const MODEL = {
   providerSlug: 'openai',
@@ -96,5 +102,29 @@ describe('the one retry policy', () => {
 
     await expect(embedder.embed('hello')).rejects.toThrow('bad request');
     expect(create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('batching', () => {
+  it('never sends more texts per request than the tightest shipped cap', async () => {
+    // Z.ai's embedding-3 refuses more than 64 inputs (error 1214) before it
+    // bills anything; a document with more chunks than that must still index.
+    expect(MAX_BATCH).toBeLessThanOrEqual(64);
+    create.mockImplementation((args) =>
+      Promise.resolve({
+        data: args.input.map(() => ({ embedding: [1, 2, 3] })),
+      }),
+    );
+    const embedder = new Embedder(MODEL, 'sk-test');
+
+    const vectors = await embedder.embedAll(
+      Array.from({ length: MAX_BATCH + 1 }, (_, i) => `text ${i}`),
+    );
+
+    expect(vectors).toHaveLength(MAX_BATCH + 1);
+    expect(create.mock.calls.map(([args]) => args.input.length)).toEqual([
+      MAX_BATCH,
+      1,
+    ]);
   });
 });

--- a/services/platform/backend/core/knowledge/embedding.ts
+++ b/services/platform/backend/core/knowledge/embedding.ts
@@ -163,6 +163,15 @@ export class Embedder implements QueryEmbedder {
           model: this.model.model,
           input: [...texts],
           dimensions: this.model.dimensions,
+          // Stated explicitly because the SDK otherwise asks for base64 and
+          // then base64-decodes whatever comes back WITHOUT checking that it
+          // is a string. An OpenAI-compatible provider that ignores the
+          // parameter (Z.ai does) answers with a plain float array, which
+          // that decoder turns into a short vector of zeros — 256 of them for
+          // a 1024-wide request (observed 2026-09-06). The width check below
+          // caught it, but only because the garbage happened to be the wrong
+          // length; asking for floats makes the response unambiguous.
+          encoding_format: 'float',
         });
         const vectors: number[][] = [];
         for (const item of response.data) vectors.push(item.embedding);

--- a/services/platform/backend/core/knowledge/embedding.ts
+++ b/services/platform/backend/core/knowledge/embedding.ts
@@ -34,9 +34,11 @@ import { resolveProvidersForOrgId } from '../lib/providers/org_providers';
 import { resolveProviderCredential } from '../provider_credentials/resolve_credential';
 import { assertVectorWidth } from './dimensions';
 
-/** Texts per request. Providers cap batch size, and a smaller batch also caps
- * how much work one failure throws away. */
-export const MAX_BATCH = 128;
+/** Texts per request. Providers cap batch size — Z.ai's embedding-3 refuses
+ * more than 64 inputs outright (error 1214, raised before anything is
+ * billed), the tightest cap among the shipped catalogs — and a smaller batch
+ * also caps how much work one failure throws away. */
+export const MAX_BATCH = 64;
 
 /** Concurrent requests in flight. Enough to keep indexing moving, low enough
  * not to trip a provider's rate limit on the first large document. */

--- a/services/platform/backend/core/lib/providers/load_system_config.test.ts
+++ b/services/platform/backend/core/lib/providers/load_system_config.test.ts
@@ -149,10 +149,10 @@ describe('shipped static model catalogs', () => {
     expect(embedding?.tags).toEqual(['embedding']);
     expect(embedding?.supportsTools).toBe(false);
     expect(embedding?.supportsVision).toBe(false);
-    // The vendor accepts 256/512/1024/2048 only; its 2048 default is above
-    // pgvector's HNSW ceiling, so 1024 is the widest indexable width.
+    // The vendor's 2048 default is above pgvector's HNSW ceiling; 1536 is the
+    // width the other curated picks share, so one bundled corpus serves all.
     expect(embedding?.embedding).toEqual({
-      dimensions: 1024,
+      dimensions: 1536,
       recommended: true,
     });
     // The GLM chat lineup stays chat-only and the embedding tag never leaks

--- a/services/platform/backend/core/lib/providers/load_system_config.test.ts
+++ b/services/platform/backend/core/lib/providers/load_system_config.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { buildHarnessTable } from '../../../../lib/shared/providers/resolve_execution';
+import { HNSW_DIMENSION_LIMIT } from '../../knowledge/dimensions';
 import {
   loadHarnesses,
   loadProviderDefinitions,
@@ -140,6 +141,48 @@ describe('shipped static model catalogs', () => {
       expect(model.supportsVision).toBe(true);
       expect(model.reasoning).toEqual({ knob: 'effort' });
     }
+  });
+
+  it('zai curates embedding-3 as its knowledge-embedding pick', () => {
+    const zai = loadStaticCatalogs().get('zai');
+    const embedding = zai?.find((m) => m.id === 'embedding-3');
+    expect(embedding?.tags).toEqual(['embedding']);
+    expect(embedding?.supportsTools).toBe(false);
+    expect(embedding?.supportsVision).toBe(false);
+    // The vendor accepts 256/512/1024/2048 only; its 2048 default is above
+    // pgvector's HNSW ceiling, so 1024 is the widest indexable width.
+    expect(embedding?.embedding).toEqual({
+      dimensions: 1024,
+      recommended: true,
+    });
+    // The GLM chat lineup stays chat-only and the embedding tag never leaks
+    // into a chat picker: each entry is one or the other.
+    for (const model of zai ?? []) {
+      expect(model.tags.includes('chat')).toBe(
+        !model.tags.includes('embedding'),
+      );
+    }
+  });
+
+  it('every curated embedding pick is embedding-tagged and HNSW-indexable', () => {
+    const curated: string[] = [];
+    for (const [provider, entries] of loadStaticCatalogs()) {
+      for (const entry of entries) {
+        if (entry.embedding === undefined) continue;
+        curated.push(`${provider}/${entry.id}`);
+        expect(entry.tags).toContain('embedding');
+        // A recommended width above the limit would hand the one-click setup
+        // a corpus that can only scan sequentially.
+        expect(entry.embedding.dimensions).toBeLessThanOrEqual(
+          HNSW_DIMENSION_LIMIT,
+        );
+      }
+    }
+    expect(curated).toEqual([
+      'openai/text-embedding-3-small',
+      'openrouter/qwen/qwen3-embedding-8b',
+      'zai/embedding-3',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

An organization whose only credential is Z.ai had nothing to pick for knowledge indexing: the zai static catalog listed the GLM chat/vision models only. This ships `embedding-3` as the curated knowledge-embedding pick and fixes two defects that surfaced the moment a real document went through that lane.

## Catalog entry (`configs/platform/system/models/zai/models.yml`)

| fact | value | source |
| --- | --- | --- |
| `dimensions` | curated **1536**, `recommended: true` | vendor reference lists 256/512/1024/2048 (default 2048); live on api.z.ai any width is honoured (1536→1536, 1000→1000, both bases, 2026-09-06). 2048 sits above pgvector's 2000-dim HNSW ceiling; 1536 is the width the other curated picks and every existing bundled corpus are pinned to, so a zai org can share the deployment's knowledge DB. |
| per-input limit | `contextWindow: 3072` | vendor reference (live accepted a 22k-token input, so this is the documented floor) |
| batch cap | 64 inputs per request | live: error 1214 "The maximum size of the input array cannot exceed 64", raised before billing |
| pricing | omitted | the international pricing page publishes none for embeddings; books at 0 instead of a rate converted from the CN list |
| billing | API balance, **not** the GLM Coding Plan | a plan key without balance answers 429 code 1113 on the coding base and the general base alike |

## Defects fixed in the same lane

1. **Embedder batch size** — `MAX_BATCH` was 128; Z.ai refuses more than 64 inputs, so any document with more than 64 chunks could never index. Capped at 64 (the tightest cap among shipped catalogs) with a batching test.
2. **SDK base64 default** — the first real indexing run failed with `the embedding model "embedding-3" produced 256-dimensional vectors, but this knowledge database stores 1024-dimensional ones`. Not the provider's doing: when `encoding_format` is omitted, openai-node 6.42 asks for base64 and then base64-decodes every `embedding` field without checking it is a string. Z.ai ignores the parameter and returns a float array, which `Buffer.from(array, 'base64')` turns into 1024 bytes → 256 zero floats. The embedder now passes `encoding_format: 'float'` explicitly (locked by a request-shape test). Any OpenAI-compatible provider that ignores the parameter had this latent bug.

## Guards added

- `load_system_config.test.ts`: zai ships `embedding-3` as an embedding-only entry; every curated embedding width is embedding-tagged and ≤ `HNSW_DIMENSION_LIMIT` (now exported from `core/knowledge/dimensions.ts`); the exact curated set is asserted (openai, openrouter, zai).
- `embedding.test.ts`: ≤ 64 texts per request; every request carries `encoding_format: 'float'`.

## Verification

- Live probes against api.z.ai with the dev org's key (coding + general base): widths honoured for 2048/1536/1024/1000; batch 65 and 128 → 1214; SDK default path → 256 zeros, SDK with `encoding_format: 'float'` → the real 1024-wide vector.
- Dev UI (org with a single zai credential): Data residency → "Your zai credential can serve embedding-3 (…-dimensional vectors)" → **Use this model** fills provider/model/width; the running backend picked the yml up without a restart.
- Gates: vitest (catalog, embedder, recommendations) green; oxlint, oxfmt, tsc green; opengrep 0 findings.
- **Not observed yet:** a full document index → search round trip with the fixed embedder. The dev backend does not hot-reload; retrying the failed upload after a restart is the remaining proof.

## Not in scope

No docs change: the docs name providers with a builtin catalog, never individual models. The CLI embeds `configs/platform/custom` only, so no regeneration.
