### PR TITLE
fix(platform): hint tasks on document writes, file into project folders

### DIFF
--- a/services/platform/app/lib/backend/documents.test.ts
+++ b/services/platform/app/lib/backend/documents.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+import { documentWriteAdapters } from './documents';
+
+/**
+ * A document write is also a TASK fact: the task DTO stamps `hasFiles` /
+ * `folderExists` from the project's documents, and an automation-owned
+ * task's Start gate reads that stamp. Regression: uploading into a task's
+ * bound folder from the task modal refreshed the Files zone (the `document`
+ * family) while the panel beside it kept the pre-upload task DTO — "waiting
+ * for input files", Start inert — until a reload.
+ */
+
+function invalidatedKeys(name: string): unknown[] {
+  const adapter = documentWriteAdapters[name];
+  if (adapter?.invalidate === undefined) {
+    throw new Error(`${name} declares no invalidation`);
+  }
+  const invalidateQueries = vi.fn();
+  adapter.invalidate(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- only invalidateQueries is exercised
+    { invalidateQueries } as never,
+    { organizationId: 'org-1' },
+    { organizationId: 'org-1' },
+  );
+  return invalidateQueries.mock.calls.map(
+    (call) => (call[0] as { queryKey: unknown }).queryKey,
+  );
+}
+
+describe('document write invalidations', () => {
+  it.each([
+    'documents/mutations:createDocumentFromUpload',
+    'documents/mutations:deleteDocument',
+    'documents/mutations:updateDocument',
+  ])('%s refreshes the document AND task families', (name) => {
+    const keys = invalidatedKeys(name);
+    expect(keys).toContainEqual(['backend', 'org-1', 'document']);
+    expect(keys).toContainEqual(['backend', 'org-1', 'task']);
+  });
+
+  it('a folder write refreshes folders, documents and the task facts', () => {
+    const keys = invalidatedKeys('folders/mutations:deleteFolder');
+    expect(keys).toContainEqual(['backend', 'org-1', 'folder']);
+    expect(keys).toContainEqual(['backend', 'org-1', 'document']);
+    expect(keys).toContainEqual(['backend', 'org-1', 'task']);
+  });
+});

--- a/services/platform/app/lib/backend/documents.ts
+++ b/services/platform/app/lib/backend/documents.ts
@@ -620,6 +620,16 @@ export const documentPaginatedAdapters: Record<string, PaginatedAdapter> = {
 // Write adapters
 // ---------------------------------------------------------------------------
 
+/**
+ * A document write refreshes the document reads — and the TASK reads: the
+ * task DTO stamps folder facts (`hasFiles`, `folderExists`) from the
+ * project's documents, and an automation-owned task's Start gate is that
+ * stamp. The server emits the matching `task` hint for every project
+ * document write (`backend/domains/documents/hints.ts`); this is the actor's
+ * own immediate refetch, the same pairing every entity family has, so the
+ * panel flips from "waiting for input files" to Start as the upload lands
+ * instead of a hint-poll later.
+ */
 function invalidateDocuments(
   client: QueryClient,
   args: Record<string, unknown>,
@@ -629,6 +639,9 @@ function invalidateDocuments(
   if (orgId === undefined) return;
   void client.invalidateQueries({
     queryKey: backendEntityPrefix(orgId, 'document'),
+  });
+  void client.invalidateQueries({
+    queryKey: backendEntityPrefix(orgId, 'task'),
   });
 }
 
@@ -643,9 +656,13 @@ function invalidateFolders(
     queryKey: backendEntityPrefix(orgId, 'folder'),
   });
   // Folder team changes cascade to member documents; a folder delete
-  // removes its documents — refresh both families.
+  // removes its documents — refresh both families, and the task facts a
+  // project folder carries (see `invalidateDocuments`).
   void client.invalidateQueries({
     queryKey: backendEntityPrefix(orgId, 'document'),
+  });
+  void client.invalidateQueries({
+    queryKey: backendEntityPrefix(orgId, 'task'),
   });
 }
 

--- a/services/platform/backend/domains/connectors/document-store.test.ts
+++ b/services/platform/backend/domains/connectors/document-store.test.ts
@@ -1,0 +1,320 @@
+// @vitest-environment node
+
+/**
+ * The workflow `document.*` natives over the 0.5 documents domain.
+ *
+ * Regression: the first 0.5 store answered "the folder does not exist" for
+ * every PROJECT folder and filed created documents through the hub-only door,
+ * which dropped the harvested blob (`storageId`) and the idempotency key — a
+ * desk automation's deliverables never reached the quarter folder its task is
+ * bound to. This pins the 0.4 contract: any org folder; a blob-backed row in
+ * THAT folder, stamped as the run's output, keyed per (folder, name) unless
+ * the node names its own key; a blob the org does not hold is refused before
+ * any row is written.
+ */
+
+import type { Sql } from 'postgres';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConnectorError } from '../../../lib/connectors/errors.ts';
+import {
+  linkAgentDocumentFile,
+  storeAgentTextBlob,
+  upsertAgentDocument,
+} from '../documents/agent-write.ts';
+import { listFolderDocumentsBounded } from '../documents/service.ts';
+import { getFileMetadataByIdOrRef } from '../files/service.ts';
+import {
+  FolderError,
+  listFolders,
+  loadFolderOrThrow,
+} from '../folders/service.ts';
+import { getProjectAuthContext } from '../projects/service.ts';
+import { pgDocumentStore } from './document-store.ts';
+
+vi.mock('../documents/agent-write.ts', () => ({
+  linkAgentDocumentFile: vi.fn(),
+  storeAgentTextBlob: vi.fn(),
+  upsertAgentDocument: vi.fn(),
+}));
+vi.mock('../documents/service.ts', () => ({
+  listFolderDocumentsBounded: vi.fn(),
+}));
+vi.mock('../files/service.ts', () => ({ getFileMetadataByIdOrRef: vi.fn() }));
+vi.mock('../folders/paths.ts', () => ({ findHubFolderByPath: vi.fn() }));
+vi.mock('../folders/service.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../folders/service.ts')>()),
+  listFolders: vi.fn(),
+  loadFolderOrThrow: vi.fn(),
+}));
+vi.mock('../projects/service.ts', () => ({ getProjectAuthContext: vi.fn() }));
+
+const sql = {} as unknown as Sql;
+
+const QUARTER_FOLDER = {
+  id: 'fld-q1',
+  organizationId: 'org_1',
+  name: '2026Q1',
+  parentId: null,
+  teamId: null,
+  teamTags: [] as string[],
+  projectId: 'proj-1',
+  createdBy: 'user-1',
+  createdAt: 1,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getProjectAuthContext).mockResolvedValue({
+    organizationId: 'org_1',
+    userId: 'system',
+    role: 'owner',
+    teamIds: [],
+  } as never);
+  vi.mocked(loadFolderOrThrow).mockResolvedValue(QUARTER_FOLDER);
+  vi.mocked(upsertAgentDocument).mockResolvedValue({
+    documentId: 'doc-1',
+    action: 'created',
+    contentChanged: true,
+  });
+});
+
+describe('pgDocumentStore.create', () => {
+  it('claims a harvested blob into a PROJECT folder as the run s document', async () => {
+    vi.mocked(getFileMetadataByIdOrRef).mockResolvedValue({
+      id: 'file-1',
+      organizationId: 'org_1',
+      storageRef: 's3:test/blob-1',
+      fileName: 'return.xml',
+      contentType: 'application/octet-stream',
+      size: 12,
+      uploadedBy: null,
+      documentId: null,
+      threadId: null,
+      conversationId: null,
+      createdAt: 1,
+    });
+
+    const result = await pgDocumentStore(sql).create({
+      organizationId: 'org_1',
+      folderId: 'fld-q1',
+      name: 'return.xml',
+      storageId: 's3:test/blob-1',
+      contentType: 'application/xml',
+    });
+
+    expect(result).toEqual({ documentId: 'doc-1', action: 'created' });
+    // The blob is verified as THIS org's before anything is written.
+    expect(getFileMetadataByIdOrRef).toHaveBeenCalledWith(
+      sql,
+      'org_1',
+      's3:test/blob-1',
+    );
+    expect(upsertAgentDocument).toHaveBeenCalledWith(sql, {
+      organizationId: 'org_1',
+      externalItemId: 'workflow:fld-q1:return.xml',
+      title: 'return.xml',
+      fileRef: 's3:test/blob-1',
+      mimeType: 'application/xml',
+      extension: 'xml',
+      sourceProvider: 'agent',
+      createdBy: 'workflow',
+      folderId: 'fld-q1',
+      auditActorId: 'workflow',
+    });
+    // Promoted like an upload: file row bound, indexing queued.
+    expect(linkAgentDocumentFile).toHaveBeenCalledWith(sql, {
+      storageRef: 's3:test/blob-1',
+      documentId: 'doc-1',
+    });
+    expect(storeAgentTextBlob).not.toHaveBeenCalled();
+  });
+
+  it('keeps the node s own idempotency key and the blob s type when none is named', async () => {
+    vi.mocked(getFileMetadataByIdOrRef).mockResolvedValue({
+      storageRef: 's3:test/blob-2',
+      contentType: 'text/csv',
+    } as never);
+
+    await pgDocumentStore(sql).create({
+      organizationId: 'org_1',
+      folderId: 'fld-q1',
+      name: 'journal.csv',
+      storageId: 's3:test/blob-2',
+      externalItemId: 'vat:2026Q1:journal',
+    });
+
+    expect(upsertAgentDocument).toHaveBeenCalledWith(
+      sql,
+      expect.objectContaining({
+        externalItemId: 'vat:2026Q1:journal',
+        mimeType: 'text/csv',
+      }),
+    );
+  });
+
+  it('stores inline text first — a document always carries a blob', async () => {
+    vi.mocked(storeAgentTextBlob).mockResolvedValue({
+      storageRef: 's3:test/inline-1',
+      fileId: 'file-9',
+      size: 5,
+    });
+
+    await pgDocumentStore(sql).create({
+      organizationId: 'org_1',
+      folderId: 'fld-q1',
+      name: 'notes.md',
+      content: 'hello',
+      contentType: 'text/markdown',
+    });
+
+    expect(storeAgentTextBlob).toHaveBeenCalledWith(sql, {
+      organizationId: 'org_1',
+      fileName: 'notes.md',
+      content: 'hello',
+      contentType: 'text/markdown',
+      uploadedBy: 'workflow',
+    });
+    expect(upsertAgentDocument).toHaveBeenCalledWith(
+      sql,
+      expect.objectContaining({
+        fileRef: 's3:test/inline-1',
+        mimeType: 'text/markdown',
+        folderId: 'fld-q1',
+      }),
+    );
+    expect(getFileMetadataByIdOrRef).not.toHaveBeenCalled();
+  });
+
+  it('does not re-promote a same-blob re-run', async () => {
+    vi.mocked(getFileMetadataByIdOrRef).mockResolvedValue({
+      storageRef: 's3:test/blob-1',
+      contentType: 'application/xml',
+    } as never);
+    vi.mocked(upsertAgentDocument).mockResolvedValue({
+      documentId: 'doc-1',
+      action: 'updated',
+      contentChanged: false,
+    });
+
+    const result = await pgDocumentStore(sql).create({
+      organizationId: 'org_1',
+      folderId: 'fld-q1',
+      name: 'return.xml',
+      storageId: 's3:test/blob-1',
+    });
+
+    expect(result).toEqual({ documentId: 'doc-1', action: 'updated' });
+    expect(linkAgentDocumentFile).not.toHaveBeenCalled();
+  });
+
+  it('refuses a blob the organization does not hold, before any row', async () => {
+    vi.mocked(getFileMetadataByIdOrRef).mockResolvedValue(null);
+
+    const refused = await pgDocumentStore(sql)
+      .create({
+        organizationId: 'org_1',
+        folderId: 'fld-q1',
+        name: 'return.xml',
+        storageId: 's3:other-org/blob-1',
+      })
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+    expect(refused).toBeInstanceOf(ConnectorError);
+    if (!(refused instanceof ConnectorError)) throw new Error('unreachable');
+    expect(refused.code).toBe('INPUT_INVALID');
+    expect(refused.message).toContain('not a stored file of this organization');
+    expect(upsertAgentDocument).not.toHaveBeenCalled();
+    expect(storeAgentTextBlob).not.toHaveBeenCalled();
+  });
+
+  it('refuses a folder outside the organization as missing, before any row', async () => {
+    vi.mocked(loadFolderOrThrow).mockResolvedValue({
+      ...QUARTER_FOLDER,
+      organizationId: 'org_other',
+    });
+
+    await expect(
+      pgDocumentStore(sql).create({
+        organizationId: 'org_1',
+        folderId: 'fld-q1',
+        name: 'return.xml',
+        content: 'x',
+      }),
+    ).rejects.toMatchObject({ code: 'INPUT_INVALID' });
+    expect(storeAgentTextBlob).not.toHaveBeenCalled();
+    expect(upsertAgentDocument).not.toHaveBeenCalled();
+  });
+
+  it('reads a folder the org does not have as missing (FolderError → refusal)', async () => {
+    vi.mocked(loadFolderOrThrow).mockRejectedValue(
+      new FolderError('FOLDER_NOT_FOUND', 'Folder not found', 404),
+    );
+
+    await expect(
+      pgDocumentStore(sql).create({
+        organizationId: 'org_1',
+        folderId: 'fld-missing',
+        name: 'return.xml',
+        content: 'x',
+      }),
+    ).rejects.toMatchObject({ code: 'INPUT_INVALID' });
+  });
+});
+
+describe('pgDocumentStore.listFolder', () => {
+  it('lists a PROJECT folder and walks its subfolders under the project', async () => {
+    vi.mocked(listFolderDocumentsBounded).mockResolvedValue({
+      documents: [
+        { id: 'doc-a', title: 'sales.csv', fileRef: 's3:test/a' },
+        { id: 'doc-b', title: 'memo', fileRef: null },
+      ] as never,
+      truncated: false,
+    });
+    vi.mocked(listFolders).mockResolvedValue([]);
+
+    const listing = await pgDocumentStore(sql).listFolder({
+      organizationId: 'org_1',
+      folderId: 'fld-q1',
+      recursive: true,
+    });
+
+    expect(listing).toEqual({
+      files: [
+        { name: 'sales.csv', storageId: 's3:test/a' },
+        // A text-only document rides along under its document id.
+        { name: 'memo', storageId: 'doc-b' },
+      ],
+      truncated: false,
+    });
+    expect(listFolderDocumentsBounded).toHaveBeenCalledWith(
+      sql,
+      expect.anything(),
+      { folderId: 'fld-q1', limit: 200 },
+    );
+    // Subfolders of a project folder are the PROJECT's — the hub family
+    // would answer nothing and the tree would read as flat.
+    expect(listFolders).toHaveBeenCalledWith(sql, expect.anything(), {
+      parentId: 'fld-q1',
+      projectId: 'proj-1',
+    });
+  });
+
+  it('answers null for a folder of another organization', async () => {
+    vi.mocked(loadFolderOrThrow).mockResolvedValue({
+      ...QUARTER_FOLDER,
+      organizationId: 'org_other',
+    });
+
+    await expect(
+      pgDocumentStore(sql).listFolder({
+        organizationId: 'org_1',
+        folderId: 'fld-q1',
+      }),
+    ).resolves.toBeNull();
+    expect(listFolderDocumentsBounded).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/domains/connectors/document-store.ts
+++ b/services/platform/backend/domains/connectors/document-store.ts
@@ -1,0 +1,262 @@
+import type { Sql } from 'postgres';
+
+import { ConnectorError } from '../../../lib/connectors/errors.ts';
+import type {
+  WorkflowDocumentStore,
+  WorkflowFolderFile,
+} from '../../../lib/connectors/natives/index.ts';
+import { extractExtension } from '../../../lib/shared/file-types.ts';
+import {
+  linkAgentDocumentFile,
+  storeAgentTextBlob,
+  upsertAgentDocument,
+} from '../documents/agent-write.ts';
+import { listFolderDocumentsBounded } from '../documents/service.ts';
+import { getFileMetadataByIdOrRef } from '../files/service.ts';
+import { findHubFolderByPath } from '../folders/paths.ts';
+import {
+  FolderError,
+  listFolders,
+  loadFolderOrThrow,
+  MAX_FOLDER_DEPTH,
+  type FolderRow,
+} from '../folders/service.ts';
+import { getProjectAuthContext } from '../projects/service.ts';
+import { collectWorkflowFolderFiles } from './document-listing.ts';
+
+/**
+ * The document natives over the 0.5 documents domain — the `document.list`
+ * and `document.create` capabilities an automation's nodes reach.
+ *
+ * Both work on ANY folder of the organization: a Knowledge Hub folder (by id
+ * or by human path, "Clients/Acme") and a PROJECT folder (by id — the task
+ * subject's `externalId`/`externalUrl` are project folders). The first 0.5
+ * cut answered "the folder does not exist" for every project folder and
+ * filed created documents through the hub-only door, which dropped the
+ * harvested blob (`storageId`) and the idempotency key: a desk automation's
+ * deliverables never reached the quarter folder its task is bound to.
+ *
+ * `create` is the second half of the sandbox harvest contract and keeps the
+ * 0.4 semantics (`convex/connectors/platform_stores.ts`): a document always
+ * carries a blob (inline `content` is stored first — sandbox staging skips
+ * content-only rows); same folder + same name is the SAME document whoever
+ * wrote it first (an upload, a seed, an earlier run), refreshed in place; a
+ * fresh file is keyed `externalItemId ?? workflow:<folder>:<name>` so a
+ * re-run of the node refreshes the artifact instead of duplicating it; the
+ * row is stamped `sourceProvider: 'agent'` — the provenance the task's Files
+ * and Outcome zones split on — and takes the FOLDER's scope (project or hub
+ * team), never a scope the caller names.
+ */
+
+/** The most files one `document.list` answers; past it the listing says
+ * `truncated` so the agent narrows the folder instead of trusting a cut. */
+const WORKFLOW_FOLDER_LIST_CAP = 200;
+
+/** The actor every workflow-filed document names — the task store's own
+ * (`task.comment` posts as `workflow`), so the audit trail and the Files
+ * zone read the same author for one run's work. */
+const WORKFLOW_ACTOR = 'workflow';
+
+const systemAuthFor = async (sql: Sql, organizationId: string) =>
+  getProjectAuthContext(sql, {
+    organizationId,
+    userId: 'system',
+    role: 'owner',
+  });
+
+/** The folder a native names, in THIS org — null when it does not exist
+ * here (a foreign or mistyped id reads as missing, never as forbidden). */
+async function resolveOrgFolder(
+  sql: Sql,
+  organizationId: string,
+  folderId: string,
+): Promise<FolderRow | null> {
+  const folder = await loadFolderOrThrow(sql, folderId).catch(
+    (error: unknown) => {
+      if (error instanceof FolderError) return null;
+      throw error;
+    },
+  );
+  return folder === null || folder.organizationId !== organizationId
+    ? null
+    : folder;
+}
+
+/**
+ * The bounded folder walk behind `document.list` — "which files does this
+ * folder hold for a run", text-only documents included (they carry their
+ * document id as the handle). The folder is named by id (hub or project) or
+ * by human hub path; null = it does not exist in this org. The agent/script
+ * hosts' `files` mounts are a different contract (blob refs only,
+ * path-prefixed names) and list through `documents/agent-list.ts`.
+ */
+export async function listWorkflowFolderFiles(
+  sql: Sql,
+  {
+    organizationId,
+    folderId,
+    folderPath,
+    recursive,
+  }: {
+    organizationId: string;
+    folderId?: string;
+    folderPath?: string;
+    recursive?: boolean;
+  },
+): Promise<{
+  files: Array<WorkflowFolderFile & { blobRef: string | null }>;
+  truncated: boolean;
+} | null> {
+  let rootFolderId: string;
+  // A project folder's subfolders list under its project; a hub folder's
+  // under the hub — the walk must ask for the right family or a project
+  // tree reads as flat.
+  let projectId: string | null = null;
+  if (folderId !== undefined) {
+    const folder = await resolveOrgFolder(sql, organizationId, folderId);
+    if (folder === null) return null;
+    rootFolderId = folder.id;
+    projectId = folder.projectId;
+  } else if (folderPath !== undefined) {
+    const resolved = await findHubFolderByPath(
+      sql,
+      organizationId,
+      folderPath.split('/'),
+    );
+    if (resolved === null) return null;
+    rootFolderId = resolved;
+  } else {
+    return null;
+  }
+  const auth = await systemAuthFor(sql, organizationId);
+  const walked = await collectWorkflowFolderFiles(
+    {
+      filesIn: async (id, limit) => {
+        const page = await listFolderDocumentsBounded(sql, auth, {
+          folderId: id,
+          limit,
+        });
+        return {
+          files: page.documents.map((doc) => ({
+            name: doc.title ?? doc.id,
+            storageId: doc.fileRef ?? doc.id,
+            blobRef: doc.fileRef ?? null,
+          })),
+          truncated: page.truncated,
+        };
+      },
+      subfoldersOf: async (id) =>
+        (
+          await listFolders(sql, auth, {
+            parentId: id,
+            ...(projectId !== null ? { projectId } : {}),
+          })
+        ).map((folder) => ({
+          id: folder.id,
+          name: folder.name,
+        })),
+    },
+    {
+      rootFolderId,
+      recursive: recursive ?? false,
+      cap: WORKFLOW_FOLDER_LIST_CAP,
+      maxDepth: MAX_FOLDER_DEPTH,
+    },
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the walk preserves the file shape it was fed, blobRef included
+  return walked as {
+    files: Array<WorkflowFolderFile & { blobRef: string | null }>;
+    truncated: boolean;
+  };
+}
+
+export function pgDocumentStore(sql: Sql): WorkflowDocumentStore {
+  return {
+    async listFolder(args) {
+      const listing = await listWorkflowFolderFiles(sql, args);
+      if (listing === null) return null;
+      return {
+        files: listing.files.map(({ name, storageId }) => ({
+          name,
+          storageId,
+        })),
+        truncated: listing.truncated,
+      };
+    },
+    async create({
+      organizationId,
+      folderId,
+      name,
+      storageId,
+      content,
+      contentType,
+      externalItemId,
+    }) {
+      const folder = await resolveOrgFolder(sql, organizationId, folderId);
+      if (folder === null) {
+        throw new ConnectorError(
+          'INPUT_INVALID',
+          `document.create: the folder does not exist (${JSON.stringify({ folderId })})`,
+        );
+      }
+      let fileRef: string;
+      let mimeType: string;
+      if (storageId !== undefined) {
+        // The harvest's blob — a stored file of THIS organization. A ref
+        // nothing registered here (or another org's) is refused before any
+        // row is written: claiming it would file a document over bytes the
+        // org does not own.
+        const file = await getFileMetadataByIdOrRef(
+          sql,
+          organizationId,
+          storageId,
+        );
+        if (file === null) {
+          throw new ConnectorError(
+            'INPUT_INVALID',
+            `document.create: storageId is not a stored file of this organization (${JSON.stringify({ storageId })})`,
+          );
+        }
+        fileRef = file.storageRef;
+        mimeType = contentType ?? file.contentType;
+      } else {
+        // Inline text: store the bytes first — sandbox staging skips
+        // content-only rows, so a document must always carry a blob.
+        mimeType = contentType ?? 'text/plain';
+        const stored = await storeAgentTextBlob(sql, {
+          organizationId,
+          fileName: name,
+          content: content ?? '',
+          contentType: mimeType,
+          uploadedBy: WORKFLOW_ACTOR,
+        });
+        fileRef = stored.storageRef;
+      }
+      const extension = extractExtension(name);
+      const upserted = await upsertAgentDocument(sql, {
+        organizationId,
+        // Idempotent per (folder, name) for fresh files too: a re-run of the
+        // same node refreshes the artifact instead of duplicating it.
+        externalItemId: externalItemId ?? `workflow:${folderId}:${name}`,
+        title: name,
+        fileRef,
+        mimeType,
+        ...(extension !== undefined ? { extension } : {}),
+        sourceProvider: 'agent',
+        createdBy: WORKFLOW_ACTOR,
+        folderId,
+        auditActorId: WORKFLOW_ACTOR,
+      });
+      // Promote the blob to the document as a human upload does — bind the
+      // file row and queue indexing — when the bytes are new to the row; a
+      // same-blob re-run is already bound and indexed.
+      if (upserted.contentChanged) {
+        await linkAgentDocumentFile(sql, {
+          storageRef: fileRef,
+          documentId: upserted.documentId,
+        });
+      }
+      return { documentId: upserted.documentId, action: upserted.action };
+    },
+  };
+}

--- a/services/platform/backend/domains/connectors/service.ts
+++ b/services/platform/backend/domains/connectors/service.ts
@@ -16,8 +16,6 @@ import {
   type MailTransport,
   type SandboxScriptRunner,
   type WorkflowConversationStore,
-  type WorkflowDocumentStore,
-  type WorkflowFolderFile,
 } from '../../../lib/connectors/natives/index.ts';
 import type { PortableHostCall } from '../../../lib/connectors/portable-live.ts';
 import {
@@ -40,22 +38,10 @@ import { evaluateApprovalGate } from '../approvals/gate.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
 import { resolveConnectorCredential } from '../connector_credentials/service.ts';
 import { conversationShimHandlers } from '../conversations/shim.ts';
-import {
-  createHubDocument,
-  listFolderDocumentsBounded,
-} from '../documents/service.ts';
 import { getOrgBlobBytes } from '../files/service.ts';
-import { findHubFolderByPath } from '../folders/paths.ts';
-import {
-  FolderError,
-  listFolders,
-  loadFolderOrThrow,
-  MAX_FOLDER_DEPTH,
-} from '../folders/service.ts';
-import { getProjectAuthContext } from '../projects/service.ts';
 import { pgWebdavStore } from '../webdav/connector-store.ts';
 import { connectorBlobSink } from './blob-sink.ts';
-import { collectWorkflowFolderFiles } from './document-listing.ts';
+import { pgDocumentStore } from './document-store.ts';
 import { pgTaskStore } from './task-store.ts';
 
 /**
@@ -113,138 +99,6 @@ function workflowScripts(sql: Sql): SandboxScriptRunner {
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- reused 0.4 host; every ctx facility it touches is covered by automationShimHandlers
       ctx as unknown as Parameters<typeof workflowScriptRunner>[0],
     )(run);
-  };
-}
-
-/** The most files one `document.list` answers; past it the listing says
- * `truncated` so the agent narrows the folder instead of trusting a cut. */
-const WORKFLOW_FOLDER_LIST_CAP = 200;
-
-const systemAuthFor = async (sql: Sql, organizationId: string) =>
-  getProjectAuthContext(sql, {
-    organizationId,
-    userId: 'system',
-    role: 'owner',
-  });
-
-/**
- * The bounded hub-folder walk behind the workflow `document.list` native —
- * "which files does this folder hold for a run", text-only documents
- * included (they carry their document id as the handle). The folder is
- * named by id or by human path ("Clients/Acme" — the same walk the sync
- * engines resolve with); null = it does not exist in this org's hub tree.
- * The agent/script hosts' `files` mounts are a different contract (blob
- * refs only, path-prefixed names) and list through
- * `documents/agent-list.ts:listFilesByFolder`.
- */
-async function listWorkflowFolderFiles(
-  sql: Sql,
-  {
-    organizationId,
-    folderId,
-    folderPath,
-    recursive,
-  }: {
-    organizationId: string;
-    folderId?: string;
-    folderPath?: string;
-    recursive?: boolean;
-  },
-): Promise<{
-  files: Array<WorkflowFolderFile & { blobRef: string | null }>;
-  truncated: boolean;
-} | null> {
-  let rootFolderId: string;
-  if (folderId !== undefined) {
-    const folder = await loadFolderOrThrow(sql, folderId).catch(
-      (error: unknown) => {
-        if (error instanceof FolderError) return null;
-        throw error;
-      },
-    );
-    if (
-      folder === null ||
-      folder.organizationId !== organizationId ||
-      folder.projectId !== null
-    ) {
-      return null;
-    }
-    rootFolderId = folder.id;
-  } else if (folderPath !== undefined) {
-    const resolved = await findHubFolderByPath(
-      sql,
-      organizationId,
-      folderPath.split('/'),
-    );
-    if (resolved === null) return null;
-    rootFolderId = resolved;
-  } else {
-    return null;
-  }
-  const auth = await systemAuthFor(sql, organizationId);
-  const walked = await collectWorkflowFolderFiles(
-    {
-      filesIn: async (id, limit) => {
-        const page = await listFolderDocumentsBounded(sql, auth, {
-          folderId: id,
-          limit,
-        });
-        return {
-          files: page.documents.map((doc) => ({
-            name: doc.title ?? doc.id,
-            storageId: doc.fileRef ?? doc.id,
-            blobRef: doc.fileRef ?? null,
-          })),
-          truncated: page.truncated,
-        };
-      },
-      subfoldersOf: async (id) =>
-        (await listFolders(sql, auth, { parentId: id })).map((folder) => ({
-          id: folder.id,
-          name: folder.name,
-        })),
-    },
-    {
-      rootFolderId,
-      recursive: recursive ?? false,
-      cap: WORKFLOW_FOLDER_LIST_CAP,
-      maxDepth: MAX_FOLDER_DEPTH,
-    },
-  );
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the walk preserves the file shape it was fed, blobRef included
-  return walked as {
-    files: Array<WorkflowFolderFile & { blobRef: string | null }>;
-    truncated: boolean;
-  };
-}
-
-/** The document natives over the 0.5 documents domain. */
-function pgDocumentStore(sql: Sql): WorkflowDocumentStore {
-  return {
-    async listFolder(args) {
-      const listing = await listWorkflowFolderFiles(sql, args);
-      if (listing === null) return null;
-      return {
-        files: listing.files.map(({ name, storageId }) => ({
-          name,
-          storageId,
-        })),
-        truncated: listing.truncated,
-      };
-    },
-    async create({ organizationId, folderId, name, content, contentType }) {
-      const auth = await systemAuthFor(sql, organizationId);
-      const documentId = await sql.begin((tx) =>
-        createHubDocument(tx, auth, {
-          title: name,
-          ...(content !== undefined ? { content } : {}),
-          ...(contentType !== undefined ? { mimeType: contentType } : {}),
-          folderId,
-          sourceProvider: 'workflow',
-        }),
-      );
-      return { documentId, action: 'created' };
-    },
   };
 }
 

--- a/services/platform/backend/domains/documents/agent-write.test.ts
+++ b/services/platform/backend/domains/documents/agent-write.test.ts
@@ -33,13 +33,24 @@ interface Statement {
 
 const LOOKUP = 'SELECT id, file_ref AS "fileRef", record FROM app.documents';
 
+/** A folder row as the scope read answers it (the folder write's target). */
+interface FolderScope {
+  projectId: string | null;
+  teamId: string | null;
+  teamTags: string[];
+}
+
 function fakeUpsert(script: {
+  /** Answers, in order, to every locked document read — by key AND, for a
+   * folder write, the same-name-in-folder fallback (same SELECT shape). */
   lookups: {
     id: string;
     fileRef: string | null;
     record: Record<string, unknown> | null;
   }[][];
   inserts: { id: string }[][];
+  /** The folder the write targets; `null` = no such folder in the org. */
+  folder?: FolderScope | null;
 }): { sql: Sql; statements: Statement[] } {
   const statements: Statement[] = [];
   const tx = (strings: TemplateStringsArray, ...values: unknown[]) => {
@@ -47,6 +58,9 @@ function fakeUpsert(script: {
     statements.push({ text, values });
     if (text.startsWith('SELECT content_hash')) {
       return Promise.resolve([{ contentHash: 'sha-1' }]);
+    }
+    if (text.startsWith('SELECT project_id AS "projectId", team_id')) {
+      return Promise.resolve(script.folder ? [script.folder] : []);
     }
     if (text.startsWith(LOOKUP)) {
       return Promise.resolve(script.lookups.shift() ?? []);
@@ -60,6 +74,13 @@ function fakeUpsert(script: {
     begin: (callback: (t: typeof tx) => unknown): unknown => callback(tx),
   } as unknown as Sql;
   return { sql, statements };
+}
+
+/** The realtime hints the transaction wrote, as `(entity)` in order. */
+function hintEntities(statements: Statement[]): string[] {
+  return statements
+    .filter((s) => s.text.startsWith('INSERT INTO app_realtime.outbox'))
+    .map((s) => String(s.values[2]));
 }
 
 const args = {
@@ -82,7 +103,11 @@ describe('upsertAgentDocument', () => {
 
     const result = await upsertAgentDocument(fake.sql, args);
 
-    expect(result).toEqual({ documentId: 'doc-1', action: 'created' });
+    expect(result).toEqual({
+      documentId: 'doc-1',
+      action: 'created',
+      contentChanged: true,
+    });
     const insert = fake.statements.find((s) =>
       s.text.startsWith('INSERT INTO app.documents'),
     );
@@ -109,7 +134,12 @@ describe('upsertAgentDocument', () => {
 
     const result = await upsertAgentDocument(fake.sql, args);
 
-    expect(result).toEqual({ documentId: 'doc-winner', action: 'updated' });
+    // The winner's row served no bytes yet: this refresh brought new content.
+    expect(result).toEqual({
+      documentId: 'doc-winner',
+      action: 'updated',
+      contentChanged: true,
+    });
     const lookups = fake.statements.filter((s) => s.text.startsWith(LOOKUP));
     expect(lookups).toHaveLength(2);
     for (const lookup of lookups) expect(lookup.text).toContain('FOR UPDATE');
@@ -135,7 +165,12 @@ describe('upsertAgentDocument', () => {
 
     const result = await upsertAgentDocument(fake.sql, args);
 
-    expect(result).toEqual({ documentId: 'doc-1', action: 'updated' });
+    // Same blob again: the row's bytes did not change.
+    expect(result).toEqual({
+      documentId: 'doc-1',
+      action: 'updated',
+      contentChanged: false,
+    });
     expect(
       fake.statements.some((s) =>
         s.text.startsWith('INSERT INTO app.documents'),
@@ -173,5 +208,185 @@ describe('upsertAgentDocument', () => {
       'knowledge.release_refs',
       { organizationId: 'org_1', refs: ['s3:acme/blob-0'] },
     );
+  });
+
+  it('answers contentChanged only when the bytes are new to the row', async () => {
+    const fresh = fakeUpsert({ lookups: [[]], inserts: [[{ id: 'doc-1' }]] });
+    await expect(upsertAgentDocument(fresh.sql, args)).resolves.toMatchObject({
+      contentChanged: true,
+    });
+    const sameBlob = fakeUpsert({
+      lookups: [[{ id: 'doc-1', fileRef: 's3:acme/blob-1', record: null }]],
+      inserts: [],
+    });
+    await expect(
+      upsertAgentDocument(sameBlob.sql, args),
+    ).resolves.toMatchObject({ action: 'updated', contentChanged: false });
+    const swapped = fakeUpsert({
+      lookups: [[{ id: 'doc-1', fileRef: 's3:acme/blob-0', record: null }]],
+      inserts: [],
+    });
+    await expect(upsertAgentDocument(swapped.sql, args)).resolves.toMatchObject(
+      { action: 'updated', contentChanged: true },
+    );
+  });
+
+  // Every write is a realtime fact: a hub row owes the document hint; a
+  // project row ALSO owes the task hint (its folder's facts ride the task
+  // DTO — see documents/hints.ts).
+  it('emits the document hint, and the task hint for a project document', async () => {
+    const hub = fakeUpsert({ lookups: [[]], inserts: [[{ id: 'doc-1' }]] });
+    await upsertAgentDocument(hub.sql, args);
+    expect(hintEntities(hub.statements)).toEqual(['document']);
+
+    const project = fakeUpsert({
+      lookups: [[]],
+      inserts: [[{ id: 'doc-2' }]],
+      folder: { projectId: 'proj-1', teamId: null, teamTags: [] },
+    });
+    await upsertAgentDocument(project.sql, { ...args, folderId: 'fld-q1' });
+    expect(hintEntities(project.statements)).toEqual(['document', 'task']);
+  });
+});
+
+// The workflow `document.create` contract rides `folderId`: the document
+// lands IN the folder and takes the folder's scope — never a scope the
+// caller names — and a same-named active document in that folder is the
+// same document, refreshed rather than duplicated. The first 0.5 cut had no
+// folder at all here, so a desk automation's deliverables (return.xml,
+// report.md) landed at the project root where no task's Files zone lists
+// them, and a fresh row per run when they did.
+describe('upsertAgentDocument into a folder', () => {
+  const folderArgs = { ...args, folderId: 'fld-q1' };
+
+  it('files the row into the folder with the folder s project scope', async () => {
+    const fake = fakeUpsert({
+      lookups: [[], []],
+      inserts: [[{ id: 'doc-1' }]],
+      folder: { projectId: 'proj-1', teamId: null, teamTags: [] },
+    });
+
+    const result = await upsertAgentDocument(fake.sql, {
+      ...folderArgs,
+      // The folder wins over a caller-named project.
+      projectId: 'proj-other',
+    });
+
+    expect(result).toMatchObject({ documentId: 'doc-1', action: 'created' });
+    const scopeRead = fake.statements.find((s) =>
+      s.text.startsWith('SELECT project_id AS "projectId", team_id'),
+    );
+    expect(scopeRead?.values).toEqual(['fld-q1', 'org_1']);
+    const insert = fake.statements.find((s) =>
+      s.text.startsWith('INSERT INTO app.documents'),
+    );
+    expect(insert?.text).toContain('project_id, folder_id, team_id');
+    expect(insert?.values).toEqual(
+      expect.arrayContaining(['proj-1', 'fld-q1', 'agent']),
+    );
+    expect(insert?.values).not.toContain('proj-other');
+  });
+
+  it('inherits a hub folder s team scope and owes no task hint there', async () => {
+    const fake = fakeUpsert({
+      lookups: [[], []],
+      inserts: [[{ id: 'doc-1' }]],
+      folder: { projectId: null, teamId: 'team-9', teamTags: ['team-9'] },
+    });
+
+    await upsertAgentDocument(fake.sql, folderArgs);
+
+    const insert = fake.statements.find((s) =>
+      s.text.startsWith('INSERT INTO app.documents'),
+    );
+    expect(insert?.values).toEqual(
+      expect.arrayContaining(['fld-q1', 'team-9', ['team-9']]),
+    );
+    expect(hintEntities(fake.statements)).toEqual(['document']);
+  });
+
+  it('refreshes the folder s same-named document instead of parking a sibling', async () => {
+    const fake = fakeUpsert({
+      // No row under the key; the folder holds a same-named upload.
+      lookups: [
+        [],
+        [{ id: 'doc-upload', fileRef: 's3:acme/old', record: null }],
+      ],
+      inserts: [],
+      folder: { projectId: 'proj-1', teamId: null, teamTags: [] },
+    });
+
+    const result = await upsertAgentDocument(fake.sql, folderArgs);
+
+    expect(result).toEqual({
+      documentId: 'doc-upload',
+      action: 'updated',
+      contentChanged: true,
+    });
+    const byTitle = fake.statements.filter((s) => s.text.startsWith(LOOKUP))[1];
+    expect(byTitle?.text).toContain('AND folder_id = ? AND title = ?');
+    expect(byTitle?.text).toContain(
+      "(lifecycle_status IS NULL OR lifecycle_status = 'active')",
+    );
+    expect(byTitle?.text).toContain('FOR UPDATE');
+    expect(byTitle?.values).toEqual(['org_1', 'fld-q1', 'report.md']);
+    expect(
+      fake.statements.some((s) =>
+        s.text.startsWith('INSERT INTO app.documents'),
+      ),
+    ).toBe(false);
+    const update = fake.statements.find((s) =>
+      s.text.startsWith('UPDATE app.documents'),
+    );
+    // Filed there, re-scoped to the folder, stamped as the run's output; the
+    // row keeps its own key (a sync-owned row must stay reconcilable).
+    expect(update?.text).toContain(
+      'folder_id = CASE WHEN ? THEN ? ELSE folder_id END',
+    );
+    expect(update?.text).not.toContain('external_item_id');
+    expect(update?.values).toEqual(
+      expect.arrayContaining([
+        's3:acme/blob-1',
+        'agent',
+        'proj-1',
+        true,
+        'fld-q1',
+      ]),
+    );
+    expect(hintEntities(fake.statements)).toEqual(['document', 'task']);
+  });
+
+  it('refuses a folder the organization does not hold, before any row', async () => {
+    const fake = fakeUpsert({ lookups: [], inserts: [], folder: null });
+
+    await expect(
+      upsertAgentDocument(fake.sql, folderArgs),
+    ).rejects.toMatchObject({ code: 'FOLDER_NOT_FOUND' });
+    expect(
+      fake.statements.some(
+        (s) =>
+          s.text.startsWith('INSERT INTO app.documents') ||
+          s.text.startsWith('UPDATE app.documents'),
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps a folderless refresh where the row already sits', async () => {
+    const fake = fakeUpsert({
+      lookups: [[{ id: 'doc-1', fileRef: 's3:acme/blob-1', record: null }]],
+      inserts: [],
+    });
+
+    await upsertAgentDocument(fake.sql, args);
+
+    const update = fake.statements.find((s) =>
+      s.text.startsWith('UPDATE app.documents'),
+    );
+    expect(update?.text).toContain('ELSE folder_id END');
+    expect(update?.text).toContain('ELSE team_id END');
+    expect(update?.text).toContain('ELSE team_tags END');
+    // The re-file switch is off: every CASE keeps the column.
+    expect(update?.values).toContain(false);
+    expect(update?.values).not.toContain(true);
   });
 });

--- a/services/platform/backend/domains/documents/agent-write.ts
+++ b/services/platform/backend/domains/documents/agent-write.ts
@@ -8,6 +8,7 @@ import { createAuditLog } from '../audit_logs/service.ts';
 import { putOrgBlobBytes, registerUploadedBytes } from '../files/service.ts';
 import { markRagQueued } from '../knowledge/service.ts';
 import { releasePreviousBlob } from './blob-rotation.ts';
+import { emitDocumentChangeHints } from './hints.ts';
 import {
   assertGenericDocumentContentWritableJson,
   DocumentError,
@@ -78,11 +79,39 @@ export interface UpsertAgentDocumentArgs {
   sourceProvider?: string;
   createdBy: string;
   /** Present for a project-bound run: the document is a PROJECT file, not an
-   * org-hub one every other project's agents would retrieve. */
+   * org-hub one every other project's agents would retrieve. A `folderId`
+   * wins over it — scope follows the folder there — so this only applies to
+   * a FOLDERLESS write. */
   projectId?: string;
+  /**
+   * File the document INTO this folder (the workflow `document.create`
+   * contract). The folder's scope becomes the document's — its project, or
+   * its hub team — derived from the folder row instead of trusted from the
+   * caller, so a filed output is never invisible in the project's Files
+   * tree. Within a folder, a same-named ACTIVE document is the same document
+   * whoever wrote it first (an upload, a seed, an earlier run): the write
+   * refreshes that row's blob instead of parking a same-named sibling.
+   */
+  folderId?: string;
   /** Whom the governance trail names — the binding actor, never whoever
    * deployed the automation. Absent writes no audit row. */
   auditActorId?: string;
+}
+
+/** The scope a filed document takes: the folder's, or the caller's project. */
+interface TargetScope {
+  projectId: string | null;
+  teamId: string | null;
+  teamTags: string[];
+}
+
+export interface UpsertAgentDocumentResult {
+  documentId: string;
+  action: 'created' | 'updated';
+  /** Whether the row now serves DIFFERENT bytes than before — a fresh row, or
+   * a refresh that swapped the blob. False for a same-blob re-run, so a
+   * caller keys blob promotion (file binding, indexing) on new content. */
+  contentChanged: boolean;
 }
 
 /**
@@ -100,31 +129,16 @@ export interface UpsertAgentDocumentArgs {
 export async function upsertAgentDocument(
   sql: Sql,
   args: UpsertAgentDocumentArgs,
-): Promise<{ documentId: string; action: 'created' | 'updated' }> {
+): Promise<UpsertAgentDocumentResult> {
   const title = args.title.trim();
   if (title === '' || title.length > 512) {
     throw new DocumentError('DOCUMENT_TITLE_INVALID', 'Invalid title');
   }
   const extension = args.extension ?? extractExtension(title);
+  const sourceProvider = args.sourceProvider ?? 'agent';
   return sql.begin(async (tx) => {
     const now = Date.now();
-    if (args.projectId !== undefined) {
-      // A project id would otherwise land on the row unverified — and a
-      // mistyped or foreign id files the document where nothing reaches it:
-      // the hub lists `project_id IS NULL`, retrieval scopes need a readable
-      // project, so the write answers "ok" and the work is lost. The same
-      // org-scoped gate the task writer applies (`agentCreateTaskTrusted`):
-      // a project in ANOTHER org reads as missing, never as forbidden, so an
-      // opaque id cannot be probed for existence.
-      const owned = await tx<{ id: string }[]>`
-        SELECT id FROM app.projects
-        WHERE id = ${args.projectId} AND org_id = ${args.organizationId}
-        LIMIT 1
-      `;
-      if (owned.length === 0) {
-        throw new DocumentError('PROJECT_NOT_FOUND', 'Project not found', 404);
-      }
-    }
+    const scope = await resolveTargetScope(tx, args);
     // `content_hash` mirrors the bytes `file_ref` serves — resolved from the
     // blob's ledger row (`storeAgentTextBlob` stamps it) so a refreshed
     // document never keeps the previous blob's hash.
@@ -134,23 +148,42 @@ export async function upsertAgentDocument(
       LIMIT 1
     `;
     const contentHash = ledger[0]?.contentHash ?? null;
+    // Every write is also a realtime fact: the document reads refetch, and
+    // a project document moves its folder's task facts (`hints.ts`).
+    const hint = (documentId: string) =>
+      emitDocumentChangeHints(tx, {
+        orgId: args.organizationId,
+        entityId: documentId,
+        projectId: scope.projectId,
+      });
 
     const refresh = async (existing: {
       id: string;
       fileRef: string | null;
       record: Record<string, unknown> | null;
-    }): Promise<{ documentId: string; action: 'updated' }> => {
+    }): Promise<UpsertAgentDocumentResult> => {
       // 'agent' documents can be controlled records (records.ts): a re-run
       // is a generic content writer, so the SAME freeze rule every human
       // content path applies holds here — a controlled record's bytes move
       // only through the attested replacement flow.
       assertGenericDocumentContentWritableJson(existing.record);
+      // A folderless write keeps the row where it is (the hub root, or the
+      // folder a person moved it to); a folder write files it there and
+      // re-scopes it to that folder — a hub team's row cannot keep a team
+      // once it sits in a project folder, and vice versa.
+      const refile = args.folderId !== undefined;
       await tx`
         UPDATE app.documents SET
           title = ${title}, file_ref = ${args.fileRef},
           mime_type = ${args.mimeType}, extension = ${extension ?? null},
+          source_provider = ${sourceProvider},
           content_hash = ${contentHash},
-          project_id = ${args.projectId ?? null},
+          project_id = ${scope.projectId},
+          folder_id = CASE WHEN ${refile} THEN ${args.folderId ?? null}
+                           ELSE folder_id END,
+          team_id = CASE WHEN ${refile} THEN ${scope.teamId} ELSE team_id END,
+          team_tags = CASE WHEN ${refile} THEN ${scope.teamTags}::text[]
+                           ELSE team_tags END,
           lifecycle_status = 'active', updated_at_ms = ${now}
         WHERE id = ${existing.id}
       `;
@@ -162,21 +195,40 @@ export async function upsertAgentDocument(
         });
       }
       await auditWrite(tx, args, 'updated', existing.id, title);
-      return { documentId: existing.id, action: 'updated' as const };
+      await hint(existing.id);
+      return {
+        documentId: existing.id,
+        action: 'updated' as const,
+        contentChanged: existing.fileRef !== args.fileRef,
+      };
     };
 
     const existing = await lockAgentDocument(tx, args);
     if (existing !== null) return refresh(existing);
+    // Same folder + same name = the same document, WHOEVER wrote it first
+    // (an upload, a seed, an earlier run under another key): publishing
+    // refreshes that document's blob instead of parking a sibling. Its own
+    // key stays — a sync-owned row must keep reconciling under the id its
+    // connector knows.
+    if (args.folderId !== undefined) {
+      const sameName = await lockDocumentInFolderByTitle(tx, {
+        organizationId: args.organizationId,
+        folderId: args.folderId,
+        title,
+      });
+      if (sameName !== null) return refresh(sameName);
+    }
 
     const inserted = await tx<{ id: string }[]>`
       INSERT INTO app.documents (
         org_id, title, file_ref, mime_type, extension, source_provider,
-        external_item_id, content_hash, project_id, created_by,
-        created_at_ms, updated_at_ms
+        external_item_id, content_hash, project_id, folder_id, team_id,
+        team_tags, created_by, created_at_ms, updated_at_ms
       ) VALUES (
         ${args.organizationId}, ${title}, ${args.fileRef}, ${args.mimeType},
-        ${extension ?? null}, ${args.sourceProvider ?? 'agent'},
-        ${args.externalItemId}, ${contentHash}, ${args.projectId ?? null},
+        ${extension ?? null}, ${sourceProvider},
+        ${args.externalItemId}, ${contentHash}, ${scope.projectId},
+        ${args.folderId ?? null}, ${scope.teamId}, ${scope.teamTags},
         ${args.createdBy}, ${now}, ${now}
       )
       ON CONFLICT (org_id, external_item_id)
@@ -187,7 +239,12 @@ export async function upsertAgentDocument(
     const created = inserted[0]?.id;
     if (created !== undefined) {
       await auditWrite(tx, args, 'created', created, title);
-      return { documentId: created, action: 'created' as const };
+      await hint(created);
+      return {
+        documentId: created,
+        action: 'created' as const,
+        contentChanged: true,
+      };
     }
     // Lost the insert race: the winner's row is committed by now (ON
     // CONFLICT waits for it) — refresh it exactly as a re-run would.
@@ -197,6 +254,83 @@ export async function upsertAgentDocument(
     }
     return refresh(winner);
   });
+}
+
+/**
+ * Where the document lands. A folder decides everything — its project or
+ * its hub team, read from the folder row itself (org-coherent, else the
+ * folder reads as missing). A folderless write takes the caller's project,
+ * verified the same way: a project id would otherwise land on the row
+ * unverified — and a mistyped or foreign id files the document where nothing
+ * reaches it (the hub lists `project_id IS NULL`, retrieval scopes need a
+ * readable project), so the write answers "ok" and the work is lost. The
+ * same org-scoped gate the task writer applies (`agentCreateTaskTrusted`): a
+ * project or folder in ANOTHER org reads as missing, never as forbidden, so
+ * an opaque id cannot be probed for existence.
+ */
+async function resolveTargetScope(
+  tx: TransactionSql,
+  args: Pick<
+    UpsertAgentDocumentArgs,
+    'organizationId' | 'projectId' | 'folderId'
+  >,
+): Promise<TargetScope> {
+  if (args.folderId !== undefined) {
+    const folders = await tx<TargetScope[]>`
+      SELECT project_id AS "projectId", team_id AS "teamId",
+             team_tags AS "teamTags"
+      FROM app.folders
+      WHERE id = ${args.folderId} AND org_id = ${args.organizationId}
+      LIMIT 1
+    `;
+    const folder = folders[0];
+    if (folder === undefined) {
+      throw new DocumentError('FOLDER_NOT_FOUND', 'Folder not found', 404);
+    }
+    return folder;
+  }
+  if (args.projectId !== undefined) {
+    const owned = await tx<{ id: string }[]>`
+      SELECT id FROM app.projects
+      WHERE id = ${args.projectId} AND org_id = ${args.organizationId}
+      LIMIT 1
+    `;
+    if (owned.length === 0) {
+      throw new DocumentError('PROJECT_NOT_FOUND', 'Project not found', 404);
+    }
+    return { projectId: args.projectId, teamId: null, teamTags: [] };
+  }
+  return { projectId: null, teamId: null, teamTags: [] };
+}
+
+/** The folder's ACTIVE row of that name, locked for the upsert transaction —
+ * trashed twins stay out: a person who deleted `report.md` must get a fresh
+ * document, not the one they removed brought back under the run's name. */
+async function lockDocumentInFolderByTitle(
+  tx: TransactionSql,
+  args: { organizationId: string; folderId: string; title: string },
+): Promise<{
+  id: string;
+  fileRef: string | null;
+  record: Record<string, unknown> | null;
+} | null> {
+  const rows = await tx<
+    {
+      id: string;
+      fileRef: string | null;
+      record: Record<string, unknown> | null;
+    }[]
+  >`
+    SELECT id, file_ref AS "fileRef", record FROM app.documents
+    WHERE org_id = ${args.organizationId}
+      AND folder_id = ${args.folderId}
+      AND title = ${args.title}
+      AND (lifecycle_status IS NULL OR lifecycle_status = 'active')
+    ORDER BY created_at_ms
+    LIMIT 1
+    FOR UPDATE
+  `;
+  return rows[0] ?? null;
 }
 
 /** The key's row (any lifecycle), locked for the upsert transaction. */

--- a/services/platform/backend/domains/documents/hints.test.ts
+++ b/services/platform/backend/domains/documents/hints.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+
+/**
+ * A project document's change is ALSO a task change: the task DTO stamps
+ * `hasFiles` / `folderExists` from the project's documents, and the Start
+ * gate of an automation-owned task reads that stamp. Regression: an upload
+ * into a task's bound folder emitted only a `document` hint, so the Files
+ * zone showed the six new files while the panel beside it kept the task's
+ * pre-upload DTO — "waiting for input files", Start inert — until a reload.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { emitHintInTx } from '../../realtime/outbox.ts';
+import { emitDocumentChangeHints } from './hints.ts';
+
+vi.mock('../../realtime/outbox.ts', () => ({ emitHintInTx: vi.fn() }));
+
+const tx = {} as never;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('emitDocumentChangeHints', () => {
+  it('a project document owes the document hint AND a task hint', async () => {
+    await emitDocumentChangeHints(tx, {
+      orgId: 'org_1',
+      entityId: 'doc-1',
+      projectId: 'proj-1',
+    });
+
+    expect(vi.mocked(emitHintInTx).mock.calls.map((call) => call[1])).toEqual([
+      { orgId: 'org_1', entity: 'document', entityId: 'doc-1' },
+      { orgId: 'org_1', entity: 'task', entityId: null },
+    ]);
+  });
+
+  it('a hub document owes only the document hint', async () => {
+    await emitDocumentChangeHints(tx, {
+      orgId: 'org_1',
+      entityId: 'doc-1',
+      projectId: null,
+    });
+
+    expect(vi.mocked(emitHintInTx).mock.calls.map((call) => call[1])).toEqual([
+      { orgId: 'org_1', entity: 'document', entityId: 'doc-1' },
+    ]);
+  });
+});

--- a/services/platform/backend/domains/documents/hints.ts
+++ b/services/platform/backend/domains/documents/hints.ts
@@ -1,0 +1,47 @@
+import type { Sql, TransactionSql } from 'postgres';
+
+import { emitHintInTx } from '../../realtime/outbox.ts';
+
+/**
+ * The realtime hints one document write owes — emitted INSIDE the writing
+ * transaction, like every outbox hint.
+ *
+ * `document` names the changed row (or, for a folder cascade, the folder) so
+ * the document reads refetch. A PROJECT document owes a `task` hint as well:
+ * the task DTO carries folder facts derived from the project's documents —
+ * `hasFiles` and `folderExists` (`collectFolderFacts`, tasks/service.ts) —
+ * and an automation-owned task's Start gate IS that stamp. Before this, an
+ * upload into a task's bound folder refreshed the Files zone (a `document`
+ * read) while the panel beside it kept saying "waiting for input files"
+ * until a reload: nothing told the task reads to refetch. Comments set the
+ * precedent — a comment write emits `task` because `commentCount` rides the
+ * task DTO — and this is the same rule for the folder facts.
+ *
+ * The task hint carries no task id: one folder change can move the facts of
+ * several tasks, and the client invalidates the whole `task` family by prefix
+ * anyway. Hub documents (no project) can never be a task's input, so they owe
+ * only the `document` hint.
+ */
+export async function emitDocumentChangeHints(
+  tx: TransactionSql | Sql,
+  args: {
+    orgId: string;
+    /** The document id, or the folder id for a whole-folder change. */
+    entityId: string | null;
+    /** The document's project — `null` for a Knowledge Hub row. */
+    projectId: string | null;
+  },
+): Promise<void> {
+  await emitHintInTx(tx, {
+    orgId: args.orgId,
+    entity: 'document',
+    entityId: args.entityId,
+  });
+  if (args.projectId !== null) {
+    await emitHintInTx(tx, {
+      orgId: args.orgId,
+      entity: 'task',
+      entityId: null,
+    });
+  }
+}

--- a/services/platform/backend/domains/documents/project-text.ts
+++ b/services/platform/backend/domains/documents/project-text.ts
@@ -21,6 +21,7 @@ import {
   type ProjectAuthContext,
 } from '../projects/service.ts';
 import { releasePreviousBlob } from './blob-rotation.ts';
+import { emitDocumentChangeHints } from './hints.ts';
 import { DocumentError } from './service.ts';
 
 /**
@@ -204,6 +205,11 @@ export async function ensureProjectTextDocument(
           previousFileRef: existing.fileRef,
         });
       }
+      await emitDocumentChangeHints(tx, {
+        orgId: auth.organizationId,
+        entityId: existing.id,
+        projectId: args.projectId,
+      });
       return {
         folderId: folder.folderId,
         documentId: existing.id,
@@ -244,6 +250,11 @@ export async function ensureProjectTextDocument(
       UPDATE app.file_metadata SET document_id = ${documentId}
       WHERE id = ${fileId}
     `;
+    await emitDocumentChangeHints(tx, {
+      orgId: auth.organizationId,
+      entityId: documentId,
+      projectId: args.projectId,
+    });
     return {
       folderId: folder.folderId,
       documentId,

--- a/services/platform/backend/domains/documents/service.delete.test.ts
+++ b/services/platform/backend/domains/documents/service.delete.test.ts
@@ -14,6 +14,7 @@
 import type { Sql } from 'postgres';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { emitHintInTx } from '../../realtime/outbox.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
 import { purgeDocument } from '../retention/service.ts';
 import { deleteDocumentHard } from './service.ts';
@@ -54,16 +55,33 @@ const HUB_DOC = {
   metadata: {},
 };
 
-/** A recorder answering the one point read the lane makes; `begin` runs the
- * callback inline so the transaction's statements are recorded too. */
-function fakeSql(): { sql: Sql; statements: Statement[]; begun: number[] } {
+/** The project a project-scoped fixture belongs to: org-wide, so the admin
+ * caller passes the edit gate without team membership. */
+const PROJECT = {
+  id: 'proj-1',
+  organizationId: 'org_1',
+  teamId: null,
+  sharedWithTeamIds: [] as string[],
+};
+
+/** A recorder answering the point reads the lane makes (the document, and
+ * its project for a project-scoped fixture); `begin` runs the callback
+ * inline so the transaction's statements are recorded too. */
+function fakeSql(doc: Record<string, unknown> = HUB_DOC): {
+  sql: Sql;
+  statements: Statement[];
+  begun: number[];
+} {
   const statements: Statement[] = [];
   const begun: number[] = [];
   const run = (strings: TemplateStringsArray, ...values: unknown[]) => {
     const text = strings.join('?').replace(/\s+/g, ' ').trim();
     statements.push({ text, values });
     if (text.includes('FROM app.documents WHERE id = ?')) {
-      return Promise.resolve([HUB_DOC]);
+      return Promise.resolve([doc]);
+    }
+    if (text.includes('FROM app.projects WHERE id = ?')) {
+      return Promise.resolve([PROJECT]);
     }
     return Promise.resolve([]);
   };
@@ -130,5 +148,29 @@ describe('deleteDocumentHard', () => {
     const purgeOrder = vi.mocked(purgeDocument).mock.invocationCallOrder[0];
     const auditOrder = vi.mocked(createAuditLog).mock.invocationCallOrder[0];
     expect(purgeOrder).toBeLessThan(auditOrder ?? -1);
+  });
+
+  // The Files zone's "Delete" removes the last input of an automation-owned
+  // task: the task DTO's `hasFiles` flips, so the task reads must refetch —
+  // a hub document's deletion moves no task fact and owes no task hint.
+  it('emits the task hint for a project document, only the document hint for a hub one', async () => {
+    vi.mocked(purgeDocument).mockResolvedValue(undefined);
+
+    await deleteDocumentHard(fakeSql().sql, auth, 'doc-1');
+    expect(vi.mocked(emitHintInTx).mock.calls.map((call) => call[1])).toEqual([
+      { orgId: 'org_1', entity: 'document', entityId: 'doc-1' },
+    ]);
+
+    vi.clearAllMocks();
+    vi.mocked(purgeDocument).mockResolvedValue(undefined);
+    await deleteDocumentHard(
+      fakeSql({ ...HUB_DOC, projectId: 'proj-1' }).sql,
+      auth,
+      'doc-1',
+    );
+    expect(vi.mocked(emitHintInTx).mock.calls.map((call) => call[1])).toEqual([
+      { orgId: 'org_1', entity: 'document', entityId: 'doc-1' },
+      { orgId: 'org_1', entity: 'task', entityId: null },
+    ]);
   });
 });

--- a/services/platform/backend/domains/documents/service.ts
+++ b/services/platform/backend/domains/documents/service.ts
@@ -42,6 +42,7 @@ import {
   type ProjectAuthContext,
 } from '../projects/service.ts';
 import { purgeDocument } from '../retention/service.ts';
+import { emitDocumentChangeHints } from './hints.ts';
 
 /**
  * Documents domain, Tier A — the Document Hub core: create-from-upload,
@@ -475,10 +476,10 @@ export async function createDocumentFromUpload(
     },
     status: 'success',
   });
-  await emitHintInTx(tx, {
+  await emitDocumentChangeHints(tx, {
     orgId: auth.organizationId,
-    entity: 'document',
     entityId: documentId,
+    projectId: args.projectId ?? null,
   });
   // RAG ingest rides the same transaction: rollback enqueues nothing. A
   // skip-flagged upload never enters the corpus (sticky on the file row).
@@ -620,10 +621,10 @@ export async function updateDocument(
       updated_at_ms = ${Date.now()}
     WHERE id = ${args.documentId}
   `;
-  await emitHintInTx(tx, {
+  await emitDocumentChangeHints(tx, {
     orgId: auth.organizationId,
-    entity: 'document',
     entityId: args.documentId,
+    projectId: doc.projectId,
   });
   return { teamScopeChanged, folderChanged, fileRef: doc.fileRef };
 }
@@ -679,6 +680,12 @@ export async function detachDocumentFromProject(
     resourceName: project.name,
     metadata: { documentId, destination: 'org-library' },
     status: 'success',
+  });
+  // The row LEFT the project: its folder's task facts move with it.
+  await emitDocumentChangeHints(tx, {
+    orgId: auth.organizationId,
+    entityId: documentId,
+    projectId: doc.projectId,
   });
   return { fileRef: doc.fileRef };
 }
@@ -756,14 +763,31 @@ export async function listFolderDocumentsBounded(
   args: { folderId: string | null; limit: number },
 ): Promise<{ documents: DocumentRow[]; truncated: boolean }> {
   const limit = Math.min(Math.max(args.limit, 1), HUB_LIST_READ_MAX);
-  const rows = await selectHubDocuments(sql, auth, {
-    folderId: args.folderId,
-    limit: limit + 1,
-  });
+  // `null` is the hub root. A CONCRETE folder lists that folder whatever its
+  // scope — a project folder's rows included: the caller resolved the id in
+  // this org, and a task subject's folders ARE project folders. Hub rows
+  // still pass the team gate; project rows are the project's, gated by the
+  // caller's project access, never by hub team tags.
+  const rows =
+    args.folderId === null
+      ? await selectHubDocuments(sql, auth, {
+          folderId: null,
+          limit: limit + 1,
+        })
+      : await sql<DocumentRow[]>`
+          SELECT ${sql.unsafe(DOCUMENT_COLUMNS)} FROM app.documents
+          WHERE org_id = ${auth.organizationId}
+            AND folder_id = ${args.folderId}
+            AND (lifecycle_status IS NULL OR lifecycle_status = 'active')
+          ORDER BY created_at_ms DESC
+          LIMIT ${limit + 1}
+        `;
   const truncated = rows.length > limit;
   return {
-    documents: (truncated ? rows.slice(0, limit) : rows).filter((doc) =>
-      hasKnowledgeHubDocumentAccess(doc, auth.teamIds),
+    documents: (truncated ? rows.slice(0, limit) : rows).filter(
+      (doc) =>
+        isProjectScoped(doc) ||
+        hasKnowledgeHubDocumentAccess(doc, auth.teamIds),
     ),
     truncated,
   };
@@ -907,10 +931,10 @@ export async function createHubDocument(
     metadata: { sourceProvider: args.sourceProvider ?? 'api_import' },
     status: 'success',
   });
-  await emitHintInTx(tx, {
+  await emitDocumentChangeHints(tx, {
     orgId: auth.organizationId,
-    entity: 'document',
     entityId: documentId,
+    projectId: null,
   });
   return documentId;
 }
@@ -1730,10 +1754,10 @@ export async function deleteDocumentHard(
       },
       status: 'success',
     });
-    await emitHintInTx(tx, {
+    await emitDocumentChangeHints(tx, {
       orgId: auth.organizationId,
-      entity: 'document',
       entityId: documentId,
+      projectId: doc.projectId,
     });
   });
 }
@@ -1817,10 +1841,12 @@ export async function deleteFolderCascade(
       metadata: { deletedDocumentCount: docs.length },
       status: 'success',
     });
-    await emitHintInTx(tx, {
+    // A project folder's deletion flips `folderExists` on every task bound
+    // to it — the same task hint a document change in it owes.
+    await emitDocumentChangeHints(tx, {
       orgId: auth.organizationId,
-      entity: 'document',
       entityId: folderId,
+      projectId: folder.projectId,
     });
     await emitHintInTx(tx, {
       orgId: auth.organizationId,

--- a/services/platform/backend/domains/retention/service.ts
+++ b/services/platform/backend/domains/retention/service.ts
@@ -19,6 +19,7 @@ import {
   resolveOrgSlug,
 } from '../../lib/org-config.ts';
 import { createAuditLog } from '../audit_logs/service.ts';
+import { emitDocumentChangeHints } from '../documents/hints.ts';
 import { releaseRefs, type ReleaseFailure } from '../knowledge/release.ts';
 import {
   markEntryChainDeletedForDocument,
@@ -502,7 +503,7 @@ async function sweepDocuments(
   // served to the agent leg for the whole grace window while they are.
   if (graceDays > 0) {
     processed += await sql.begin(async (tx) => {
-      const flipped = await tx<{ id: string }[]>`
+      const flipped = await tx<{ id: string; projectId: string | null }[]>`
         UPDATE app.documents SET
           lifecycle_status = 'expired', status_changed_at_ms = ${Date.now()}
         WHERE id IN (
@@ -513,13 +514,23 @@ async function sweepDocuments(
             AND ${custodianFree}
           LIMIT ${BATCH_LIMIT}
         )
-        RETURNING id
+        RETURNING id, project_id AS "projectId"
       `;
       await markEntryChainsDeletedForDocuments(
         tx,
         org.organizationId,
         flipped.map((row) => row.id),
       );
+      if (flipped.length > 0) {
+        // The flip hides rows from every Files list and from a bound folder's
+        // task facts — one batch-level hint per family, like every writer.
+        await emitDocumentChangeHints(tx, {
+          orgId: org.organizationId,
+          entityId: null,
+          projectId:
+            flipped.find((row) => row.projectId !== null)?.projectId ?? null,
+        });
+      }
       return flipped.length;
     });
   }
@@ -533,9 +544,11 @@ async function sweepDocuments(
             id: string;
             fileRef: string | null;
             historyFiles: string[];
+            projectId: string | null;
           }[]
         >`
-          SELECT id, file_ref AS "fileRef", history_files AS "historyFiles"
+          SELECT id, file_ref AS "fileRef", history_files AS "historyFiles",
+                 project_id AS "projectId"
           FROM app.documents
           WHERE org_id = ${org.organizationId}
             AND lifecycle_status IN ('trashed', 'expired')
@@ -554,9 +567,11 @@ async function sweepDocuments(
             id: string;
             fileRef: string | null;
             historyFiles: string[];
+            projectId: string | null;
           }[]
         >`
-          SELECT id, file_ref AS "fileRef", history_files AS "historyFiles"
+          SELECT id, file_ref AS "fileRef", history_files AS "historyFiles",
+                 project_id AS "projectId"
           FROM app.documents
           WHERE org_id = ${org.organizationId}
             AND ((lifecycle_status IS NULL
@@ -568,6 +583,8 @@ async function sweepDocuments(
         `;
   if (passB.length === 0) return processed;
   const orgSlug = await resolveOrgSlug(sql, org.organizationId);
+  let purged = 0;
+  let purgedProjectId: string | null = null;
   for (const doc of passB) {
     try {
       await purgeDocument(sql, orgSlug, {
@@ -583,6 +600,19 @@ async function sweepDocuments(
       continue;
     }
     processed += 1;
+    purged += 1;
+    purgedProjectId ??= doc.projectId;
+  }
+  if (purged > 0) {
+    // Rows are gone from the Files lists and from a bound folder's task
+    // facts — one batch-level hint per family, after the purges committed.
+    await sql.begin((tx) =>
+      emitDocumentChangeHints(tx, {
+        orgId: org.organizationId,
+        entityId: null,
+        projectId: purgedProjectId,
+      }),
+    );
   }
   return processed;
 }

--- a/services/platform/backend/domains/sandbox/workspace-write-shim.ts
+++ b/services/platform/backend/domains/sandbox/workspace-write-shim.ts
@@ -188,11 +188,10 @@ export function workspaceWriteShimHandlers(sql: Sql): ShimHandlers {
         auditActorId?: string;
       };
       const { fileId, ...rest } = args;
-      const result = await coded(() =>
-        // The bridge's `fileId` IS the blob ref `storeRawContent` answered.
+      // The bridge's `fileId` IS the blob ref `storeRawContent` answered.
+      return coded(() =>
         upsertAgentDocument(sql, { ...rest, fileRef: fileId }),
       );
-      return { ...result, contentChanged: true };
     },
 
     'file_metadata/internal_mutations:linkDocumentToFile': async (raw) => {

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -4669,6 +4669,225 @@ async function checkDocuments(
 }
 
 /**
+ * The folder-bound task's live facts, on a real store.
+ *
+ * The Start gate of an automation-owned task IS the server's `hasFiles`
+ * stamp. An upload into the bound folder must flip the stamp AND emit a
+ * `task` hint — the modal's task read is keyed `task`, and before this the
+ * Files zone showed the new file while the panel beside it kept "waiting for
+ * input files" until a reload. The workflow `document.*` natives then read
+ * and write THAT project folder: `document.list` used to answer "does not
+ * exist" for every project folder, and `document.create` filed through the
+ * hub-only door — refusing the folder, dropping the harvested blob and the
+ * idempotency key. Needs the object store (a document always carries a blob),
+ * so it runs after `checkDocuments` seeded the deployment default.
+ */
+async function checkFolderBoundTaskFacts(
+  sql: Sql,
+  base: string,
+  ctx: { cookie: string; orgId: string },
+): Promise<void> {
+  if (!process.env.ITEST_S3_ENDPOINT) {
+    record(
+      'folder-bound task facts + document natives (SKIPPED)',
+      true,
+      'no ITEST_S3_ENDPOINT — S3 lanes not exercised in this run',
+    );
+    return;
+  }
+  const { cookie, orgId } = ctx;
+  const get = async (route: string): Promise<unknown> =>
+    (await fetch(`${base}${route}`, { headers: { cookie } })).json();
+  const send = (route: string, body: unknown): Promise<Response> =>
+    fetch(`${base}${route}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie, origin: base },
+      body: JSON.stringify(body),
+    });
+  try {
+    const proj = z.object({ projectId: z.string() }).safeParse(
+      await (
+        await send(`/api/app/projects?orgId=${orgId}`, {
+          name: 'Folder Desk Project',
+        })
+      ).json(),
+    );
+    const projectId = proj.success ? proj.data.projectId : '';
+    const fromIssue = z
+      .object({ taskId: z.string(), folderId: z.string() })
+      .safeParse(
+        await (
+          await send(`/api/app/tasks/from-external-issue?orgId=${orgId}`, {
+            projectId,
+            externalSystem: 'folder-desk',
+            ensureFolder: { name: '2026Q1' },
+            title: 'VAT return 2026Q1',
+          })
+        ).json(),
+      );
+    if (!fromIssue.success) {
+      record(
+        'folder-bound task: an upload into the bound folder flips hasFiles and hints the task family',
+        false,
+        `folder-bound task create failed (project=${projectId || 'ERR'})`,
+      );
+      return;
+    }
+    const { taskId, folderId } = fromIssue.data;
+    const before = z
+      .object({ task: z.object({ hasFiles: z.literal(false) }).loose() })
+      .safeParse(await get(`/api/app/tasks/${taskId}?orgId=${orgId}`));
+    const outboxBefore = await latestOutboxId(sql);
+    const presign = z
+      .object({ url: z.string().url(), s3Ref: z.string() })
+      .safeParse(
+        await (
+          await send(`/api/app/files/blob-upload?orgId=${orgId}`, {
+            contentType: 'text/csv',
+          })
+        ).json(),
+      );
+    let uploadedDocId = '';
+    if (presign.success) {
+      await fetch(presign.data.url, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/csv' },
+        body: 'date;amount\n2026-01-15;100\n',
+      });
+      const bound = z.object({ documentId: z.string() }).safeParse(
+        await (
+          await send(`/api/app/documents/from-blob-upload?orgId=${orgId}`, {
+            storageRef: presign.data.s3Ref,
+            fileName: 'sales.csv',
+            contentType: 'text/csv',
+            projectId,
+            folderId,
+          })
+        ).json(),
+      );
+      uploadedDocId = bound.success ? bound.data.documentId : '';
+    }
+    const afterUpload = z
+      .object({ task: z.object({ hasFiles: z.literal(true) }).loose() })
+      .safeParse(await get(`/api/app/tasks/${taskId}?orgId=${orgId}`));
+    const taskHints = await sql<{ count: string }[]>`
+      SELECT count(*)::text AS count FROM app_realtime.outbox
+      WHERE org_id = ${orgId} AND entity = 'task'
+        AND id > ${outboxBefore}::bigint
+    `;
+    record(
+      'folder-bound task: an upload into the bound folder flips hasFiles and hints the task family',
+      before.success &&
+        uploadedDocId !== '' &&
+        afterUpload.success &&
+        Number(taskHints[0]?.count ?? '0') >= 1,
+      `before=${before.success} (want hasFiles false), doc=${uploadedDocId || 'ERR'}, hasFiles=${afterUpload.success} (want true), taskHints=${taskHints[0]?.count ?? '0'} (want ≥1)`,
+    );
+
+    const { runConnectorAction } =
+      await import('./domains/connectors/service.ts');
+    const caller = {
+      kind: 'system' as const,
+      reason: 'itest document natives on a project folder',
+    };
+    const createInput = {
+      folderId,
+      name: 'return.xml',
+      content: '<return/>',
+      contentType: 'application/xml',
+    };
+    const filedShape = z.object({ documentId: z.string(), action: z.string() });
+    const created = await runConnectorAction(sql, {
+      organizationId: orgId,
+      connector: 'document',
+      action: 'create',
+      input: createInput,
+      mode: 'live',
+      caller,
+    });
+    const createdOut =
+      created.status === 'ok'
+        ? filedShape.safeParse(created.output)
+        : { success: false as const };
+    // Same node again: the artifact is refreshed, never duplicated.
+    const again = await runConnectorAction(sql, {
+      organizationId: orgId,
+      connector: 'document',
+      action: 'create',
+      input: createInput,
+      mode: 'live',
+      caller,
+    });
+    const againOut =
+      again.status === 'ok'
+        ? filedShape.safeParse(again.output)
+        : { success: false as const };
+    const filedRows = await sql<
+      {
+        id: string;
+        projectId: string | null;
+        sourceProvider: string | null;
+        fileRef: string | null;
+        externalItemId: string | null;
+      }[]
+    >`
+      SELECT id, project_id AS "projectId",
+             source_provider AS "sourceProvider", file_ref AS "fileRef",
+             external_item_id AS "externalItemId"
+      FROM app.documents
+      WHERE org_id = ${orgId} AND folder_id = ${folderId}
+        AND title = 'return.xml'
+    `;
+    const filed = filedRows[0];
+    const folderListing = await runConnectorAction(sql, {
+      organizationId: orgId,
+      connector: 'document',
+      action: 'list',
+      input: { folderId },
+      mode: 'live',
+      caller,
+    });
+    const folderListingOut =
+      folderListing.status === 'ok'
+        ? z
+            .object({
+              count: z.number(),
+              files: z.array(
+                z.object({ name: z.string(), storageId: z.string() }),
+              ),
+            })
+            .safeParse(folderListing.output)
+        : { success: false as const };
+    const folderListingNames = folderListingOut.success
+      ? folderListingOut.data.files.map((file) => file.name).sort()
+      : [];
+    record(
+      'document natives file into and list a PROJECT folder (blob-backed, idempotent, run-stamped)',
+      createdOut.success &&
+        createdOut.data.action === 'created' &&
+        againOut.success &&
+        againOut.data.action === 'updated' &&
+        againOut.data.documentId === createdOut.data.documentId &&
+        filedRows.length === 1 &&
+        filed?.id === createdOut.data.documentId &&
+        filed.projectId === projectId &&
+        filed.sourceProvider === 'agent' &&
+        filed.fileRef !== null &&
+        filed.externalItemId === `workflow:${folderId}:return.xml` &&
+        folderListingOut.success &&
+        folderListingNames.join(',') === 'return.xml,sales.csv',
+      `create=${created.status}/${createdOut.success ? createdOut.data.action : 'ERR'}, again=${again.status}/${againOut.success ? againOut.data.action : 'ERR'}, rows=${filedRows.length}, project=${filed?.projectId === projectId}, provider=${filed?.sourceProvider ?? '-'}, blob=${filed?.fileRef != null}, key=${filed?.externalItemId ?? '-'}, list=${folderListing.status}:${folderListingNames.join(',')}`,
+    );
+  } catch (error) {
+    record(
+      'folder-bound task facts + document natives',
+      false,
+      `threw ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
  * The document write-guard class: the org-role write matrix on every
  * mutating documents door (app + REST v1), the controlled-record content
  * freeze at the service seam, REST delete protection derived from the
@@ -44282,6 +44501,10 @@ async function main(): Promise<void> {
       ],
       ['checkFiles', () => checkFiles(baseUrl, authCtx)],
       ['checkDocuments', () => checkDocuments(sql, baseUrl, authCtx)],
+      [
+        'checkFolderBoundTaskFacts',
+        () => checkFolderBoundTaskFacts(sql, baseUrl, authCtx),
+      ],
       [
         'checkWorkflowDocumentListing',
         () => checkWorkflowDocumentListing(sql, baseUrl, authCtx),


### PR DESCRIPTION
## Defect

Reported on GS-5 "VAT return 2026Q1" (vat-return-desk bound to a project): six files uploaded into the quarter folder, the Files zone listed all six, and the panel still said "Waiting for input files" with Start soft-disabled. A fresh page load showed "Ready to start" — the database was right, the client was stale. Two platform defects sat behind it, and the second would have killed the run as soon as Start was clickable:

1. **The task DTO never refetched after an upload.** An automation-owned task's Start gate is the server stamp `task.hasFiles` (`collectFolderFacts`), keyed under the `task` hint family. An upload emitted only a `document` hint and the upload adapter invalidated only the `document` reads, so the task read kept the pre-upload DTO until something else touched the task or the page reloaded. The same staleness hit the board chip, Delete in the Files zone (last file gone, Start still offered), and every agent/workflow/project-text/retention write — those emitted no hint at all.
2. **The 0.5 workflow `document.*` natives were hub-only and lossy** (since #3107). `document.list` answered "the folder does not exist" for every project folder, so a task-bound desk's node on the Setup folder dies. `document.create` went through `createHubDocument`: refuses project folders, DROPPED `storageId` (the harvested blob) and `externalItemId` (idempotency), and stamped `sourceProvider: 'workflow'` while the Files/Outcome zones split on `'agent'`. The 0.4 store (`convex/connectors/platform_stores.ts` at `fd5c009aa^`) had all of this.

## Fix

- `documents/hints.ts` — `emitDocumentChangeHints`: the `document` hint plus, for a PROJECT document, a `task` hint (precedent: comments emit `task` for `commentCount`). Routed through upload, update, detach (no hint before), hard delete, folder cascade, `upsertAgentDocument`, `ensureProjectTextDocument` and both retention sweep passes (none before). Client `invalidateDocuments` / `invalidateFolders` also refetch the `task` family — the actor's own immediate refresh, the pairing every entity has.
- `connectors/document-store.ts` (sibling of `task-store.ts`) — the 0.4 contract on the 0.5 domain: any org folder (hub by id/path, project by id, subfolders walked under the right family); a document always carries a blob (inline text → `storeAgentTextBlob`); same folder + same name = same document, refreshed in place; fresh files keyed `externalItemId ?? workflow:<folder>:<name>`; stamped `sourceProvider: 'agent'`; scope follows the FOLDER row, never a caller-named scope; a `storageId` the org does not hold is refused before any row is written.
- `upsertAgentDocument` — optional `folderId` (scope resolved from the folder row, same-name-in-folder lock excluding trashed twins, hub team scope inherited, hints inside the tx) and `contentChanged` in the result so blob promotion (file binding + indexing) runs only for new bytes. The sandbox `document_create` shim passes the real flag instead of `true`. Folderless writes behave as before (row keeps its folder/team).
- `listFolderDocumentsBounded` — a concrete folder id lists that folder whatever its scope; `null` stays the hub root.

## Proof

- Real-Postgres + MinIO integration run: **529/529 across 141/141 lanes**. New lane `checkFolderBoundTaskFacts` (after `checkDocuments`, S3-gated): `before=true (hasFiles false), hasFiles=true, taskHints=1`; `create=ok/created, again=ok/updated` (same document id), one row, `project=true, provider=agent, blob=true, key=workflow:<folder>:return.xml`, `list=ok:return.xml,sales.csv`.
- Unit: `hints.test.ts`, `agent-write.test.ts` (folder scope, same-name refresh keeps the row's own key, hub team scope, foreign folder refused, folderless refresh keeps place, `contentChanged`), `service.delete.test.ts` (task hint only for a project doc), `connectors/document-store.test.ts` (blob claim, own key, inline text, no re-promotion on a same-blob re-run, foreign blob/folder refused, project folder listing walks under the project), `app/lib/backend/documents.test.ts` (adapter invalidations).
- `bun run check`: tsc, oxlint, oxfmt green; server vitest 73609 passed (one PII throughput timing test tripped under full machine load and passes alone); UI vitest 3510 passed.
- Live on the dev stack, the reported task: Start → `document.list` on the quarter folder (6 files) → invoice reader → two `.ocr.json` filed INTO the quarter folder → `needs_setup` → setup author (one `ask_human`, answered in the UI, resumed) → `transform.py`/`profile.yaml` frozen into Setup → recalculation PASS (114 transactions) → `return.xml`/`report.md`/`journal.csv`/`result.json` in the quarter folder, `history-2026-Q1.json` in Setup → figures comment → task In review with the Outcome zone filled. The Files zone and the panel updated live at every step without a reload.
