### PR TITLE
fix(sandbox): state session log opts and attribute spawner failures

### DIFF
--- a/services/platform/backend/core/node_only/sandbox/helpers/session_client.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/helpers/session_client.test.ts
@@ -8,7 +8,9 @@ import {
   chunkStageFiles,
   drainSessionExecResilient,
   STAGE_BODY_BUDGET_BYTES,
+  SpawnerUnreachableError,
   sessionCreate,
+  sessionIsAlive,
   sessionStageFiles,
   type SessionStageFile,
 } from './session_client';
@@ -68,12 +70,23 @@ const RESULT_OK = `event: result\ndata: ${JSON.stringify({
 })}\n\n`;
 
 const origFetch = globalThis.fetch;
+const origToken = process.env.SANDBOX_TOKEN;
+const origUrl = process.env.SANDBOX_URL;
 afterEach(() => {
   globalThis.fetch = origFetch;
+  restoreEnv('SANDBOX_TOKEN', origToken);
+  restoreEnv('SANDBOX_URL', origUrl);
 });
 beforeEach(() => {
-  delete process.env.SANDBOX_TOKEN; // unsigned dev mode → no HMAC needed
+  // Every spawner request is signed and the client refuses to send an
+  // unsigned one, so the suite carries a secret like a real deployment.
+  process.env.SANDBOX_TOKEN = 'test-sandbox-token';
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 describe('drainSessionExecResilient', () => {
   test('re-attaches after a mid-turn drop and feeds each delta once', async () => {
@@ -340,4 +353,77 @@ describe('sessionCreate drain-retry', () => {
     expect(n).toBe(6);
     // The give-up path sleeps 5 × 400ms ≈ 2s across the retries.
   }, 10_000);
+});
+
+describe('spawner call preconditions', () => {
+  test('an unreachable spawner names the target, the call and the syscall', async () => {
+    process.env.SANDBOX_URL = 'http://sandbox:8003';
+    // What Bun/undici throws when the request never completed: a TypeError
+    // whose own cause carries the syscall — the whole diagnosis.
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed', {
+        cause: new Error('getaddrinfo EAI_AGAIN sandbox'),
+      });
+      // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    }) as any;
+
+    const err = await sessionIsAlive('ses-dead').catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SpawnerUnreachableError);
+    const message = err instanceof Error ? err.message : String(err);
+    expect(message).toContain('http://sandbox:8003');
+    expect(message).toContain('GET /v1/sessions/ses-dead');
+    expect(message).toContain('getaddrinfo EAI_AGAIN sandbox');
+    expect(message).toContain('SANDBOX_URL');
+  });
+
+  test('a deliberate abort passes through, unwrapped', async () => {
+    // The turn-ended cut and every caller signal abort in-flight requests,
+    // and the resilient drain branches on the rejection — reporting one as an
+    // unreachable spawner would read as a dead sandbox and fail the turn.
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    globalThis.fetch = (async () => {
+      throw new DOMException('The operation was aborted', 'AbortError');
+      // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    }) as any;
+
+    const err = await sessionIsAlive('ses-cut').catch((e: unknown) => e);
+
+    expect(err).not.toBeInstanceOf(SpawnerUnreachableError);
+    expect(err instanceof Error ? err.name : '').toBe('AbortError');
+  });
+
+  test('credentials in SANDBOX_URL never reach the error message', async () => {
+    // The message is what lands in the error tracker.
+    process.env.SANDBOX_URL = 'http://ops:s3cret@sandbox:8003';
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    globalThis.fetch = (async () => {
+      throw new TypeError('fetch failed');
+      // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    }) as any;
+
+    const err = await sessionIsAlive('ses-secret').catch((e: unknown) => e);
+
+    const message = err instanceof Error ? err.message : String(err);
+    expect(message).toContain('sandbox:8003');
+    expect(message).not.toContain('s3cret');
+    expect(message).not.toContain('ops:');
+  });
+
+  test('a missing SANDBOX_TOKEN fails before any request goes out', async () => {
+    delete process.env.SANDBOX_TOKEN;
+    let calls = 0;
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return createdResponse('ses-unsigned');
+      // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    }) as any;
+
+    await expect(sessionIsAlive('ses-unsigned')).rejects.toThrow(
+      /SANDBOX_TOKEN is not set/,
+    );
+    expect(calls).toBe(0);
+  });
 });

--- a/services/platform/backend/core/node_only/sandbox/helpers/session_client.ts
+++ b/services/platform/backend/core/node_only/sandbox/helpers/session_client.ts
@@ -1,8 +1,9 @@
 'use node';
 
-// Platform → spawner client for the persistent-session API. Mirrors
-// spawner_client.ts (same HMAC signing contract + SANDBOX_URL/SANDBOX_TOKEN
-// env), adds the session verbs. Lives in node_only because it streams SSE.
+// Platform → spawner client for the persistent-session API: the HMAC signing
+// contract (SANDBOX_URL / SANDBOX_TOKEN env) plus the session verbs — the
+// one-shot `spawner_client.ts` it used to mirror is retired. Lives in
+// node_only because it streams SSE. Every call goes through `spawnerFetch`.
 //
 // Signature contract (services/sandbox/src/auth.ts):
 //   signedString = `${METHOD}\n${path}\n${timestamp}\n${nonce}\n${sha256Hex(body)}`
@@ -78,6 +79,49 @@ export class SpawnerBusyError extends Error {
   }
 }
 
+/**
+ * The spawner did not answer at all: DNS, connect or socket failure — no
+ * status, no body. Wrapped because the bare `TypeError: fetch failed` names
+ * nothing it was doing: a spawner that refuses to boot (2026-09: an unset
+ * `SANDBOX_TOKEN` crash-looped it) takes every agent turn on the deployment
+ * down, and the runs could only report "the agent turn could not start: fetch
+ * failed". Carries WHAT was called, WHERE it was called, and the syscall the
+ * runtime reported — and keeps the original as `cause`.
+ */
+export class SpawnerUnreachableError extends Error {
+  constructor(method: string, path: string, target: string, cause: unknown) {
+    const where = spawnerTargetLabel(target);
+    // fetch reports the syscall on its own `cause` (getaddrinfo EAI_AGAIN,
+    // ECONNREFUSED, ...) — that inner line is the whole diagnosis, so lift it
+    // into the message instead of leaving it two `cause` hops deep.
+    const outer = cause instanceof Error ? cause.message : String(cause);
+    const inner =
+      cause instanceof Error && cause.cause instanceof Error
+        ? `: ${cause.cause.message}`
+        : '';
+    super(
+      `sandbox spawner unreachable at ${where} (${method} ${path}): ${outer}${inner} — is the sandbox service running, and does SANDBOX_URL point at it?`,
+      { cause },
+    );
+    this.name = 'SpawnerUnreachableError';
+  }
+}
+
+/** The spawner URL as it may be printed. This message reaches the error
+ * tracker, so credentials an operator embedded in SANDBOX_URL are dropped
+ * rather than reported; an unparseable value is echoed as given (it is the
+ * misconfiguration the reader needs to see). */
+function spawnerTargetLabel(target: string): string {
+  try {
+    const parsed = new URL(target);
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return target;
+  }
+}
+
 /** Parse an HTTP `retry-after` header (delta-seconds) into ms, if present. */
 export function parseRetryAfterMs(res: Response): number | undefined {
   const raw = res.headers.get('retry-after');
@@ -101,8 +145,9 @@ export class ExecStreamIdleError extends Error {
 
 function getSpawnerUrl(): string {
   // Host bun-dev default. Container api/worker MUST set SANDBOX_URL
-  // (compose / entrypoint default http://sandbox:8003) or every session
-  // call dies with TypeError: fetch failed against localhost.
+  // (compose / entrypoint default http://sandbox:8003) or every session call
+  // goes to localhost inside the container and fails — as
+  // SpawnerUnreachableError, which names this URL so the mistake is readable.
   return process.env.SANDBOX_URL ?? 'http://localhost:8003';
 }
 
@@ -111,12 +156,28 @@ export interface SessionCreateResult {
   session: SessionInfo;
 }
 
-function getSpawnerToken(): string | null {
-  // Trim so a whitespace-only token is treated as unset — must match the
-  // server (sandbox config.ts) and spawner_client trim or a padded token would
-  // derive a different HMAC key on each side.
+/**
+ * The shared HMAC secret every spawner call is signed with. REQUIRED — fail
+ * closed: the spawner refuses to start without it and answers 401 to anything
+ * unsigned (services/sandbox/src/{config,request-auth}.ts), so sending
+ * unsigned requests is not a mode, it is a misconfiguration this process can
+ * see in its own env. Surfaced before any network call, the same way
+ * `requireGatewayAdminPassword` guards the gateway's management plane.
+ *
+ * Trimmed so a whitespace-only value counts as unset — must match the server's
+ * trim, or a padded token would derive a different HMAC key on each side.
+ */
+function requireSpawnerToken(): string {
   const token = process.env.SANDBOX_TOKEN?.trim();
-  return token && token.length > 0 ? token : null;
+  if (!token) {
+    throw new Error(
+      'SANDBOX_TOKEN is not set — the sandbox spawner signs every request with it and rejects ' +
+        'unsigned ones. `tale deploy` and `bun run dev` mint it into .env; for a hand-rolled ' +
+        'compose stack set SANDBOX_TOKEN=$(openssl rand -hex 32) there. The SAME value must reach ' +
+        'the backend, the platform and the sandbox service.',
+    );
+  }
+  return token;
 }
 
 /** Build signed headers for a request to the spawner (method + path + body). */
@@ -126,26 +187,52 @@ function signedHeaders(
   body: string,
   accept?: string,
 ): Record<string, string> {
+  const token = requireSpawnerToken();
+  const timestamp = String(Date.now());
+  const nonce = randomUUID();
   const headers: Record<string, string> = {
     'content-type': 'application/json',
-  };
-  if (accept) headers.accept = accept;
-  const token = getSpawnerToken();
-  if (token !== null) {
-    const timestamp = String(Date.now());
-    const nonce = randomUUID();
-    headers[SIGNATURE_HEADER] = signRequest(
+    [SIGNATURE_HEADER]: signRequest(
       method,
       path,
       timestamp,
       nonce,
       body,
       token,
-    );
-    headers[TIMESTAMP_HEADER] = timestamp;
-    headers[NONCE_HEADER] = nonce;
-  }
+    ),
+    [TIMESTAMP_HEADER]: timestamp,
+    [NONCE_HEADER]: nonce,
+  };
+  if (accept) headers.accept = accept;
   return headers;
+}
+
+/**
+ * The one door for every spawner call: composes the URL, signs the request,
+ * and attributes a transport failure to the call that suffered it.
+ *
+ * ONLY a `TypeError` (what fetch throws when the request never completed) is
+ * wrapped. An abort — the caller's signal, the turn-ended cut — and a timeout
+ * are control flow the callers branch on (the resilient drain re-attaches on
+ * them), so they pass through untouched.
+ */
+async function spawnerFetch(
+  method: string,
+  path: string,
+  opts: { body?: string; accept?: string; signal?: AbortSignal } = {},
+): Promise<Response> {
+  const target = getSpawnerUrl();
+  try {
+    return await fetch(`${target}${path}`, {
+      method,
+      headers: signedHeaders(method, path, opts.body ?? '', opts.accept),
+      ...(opts.body !== undefined ? { body: opts.body } : {}),
+      ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+    });
+  } catch (err) {
+    if (!(err instanceof TypeError)) throw err;
+    throw new SpawnerUnreachableError(method, path, target, err);
+  }
 }
 
 export interface SessionCreateBody {
@@ -212,9 +299,7 @@ export async function sessionCreate(
   // Re-sign per attempt: each retry needs a fresh timestamp (clock-skew window)
   // and a fresh nonce (spawner replay cache) — see signedHeaders.
   for (let attempt = 0; ; attempt++) {
-    const res = await fetch(`${getSpawnerUrl()}${path}`, {
-      method: 'POST',
-      headers: signedHeaders('POST', path, bodyJson),
+    const res = await spawnerFetch('POST', path, {
       body: bodyJson,
       signal: AbortSignal.timeout(CREATE_TIMEOUT_MS),
     });
@@ -250,9 +335,7 @@ export async function sessionCreate(
  * spawner blip is never misread as "session gone". */
 export async function sessionIsAlive(sessionId: string): Promise<boolean> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}`;
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'GET',
-    headers: signedHeaders('GET', path, ''),
+  const res = await spawnerFetch('GET', path, {
     signal: AbortSignal.timeout(15_000),
   });
   if (res.status === 404) return false;
@@ -269,10 +352,7 @@ export async function sessionIsAlive(sessionId: string): Promise<boolean> {
  * 409ing on every future create. */
 export async function sessionDestroy(sessionId: string): Promise<boolean> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}`;
-  const headers = signedHeaders('DELETE', path, '');
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'DELETE',
-    headers,
+  const res = await spawnerFetch('DELETE', path, {
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) {
@@ -292,10 +372,7 @@ export async function sessionDestroyIfIdle(
   sessionId: string,
 ): Promise<{ destroyed: boolean; busy: boolean }> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}?if_idle=1`;
-  const headers = signedHeaders('DELETE', path, '');
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'DELETE',
-    headers,
+  const res = await spawnerFetch('DELETE', path, {
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) {
@@ -315,9 +392,7 @@ export async function sessionSetPinned(
 ): Promise<boolean> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}/pin`;
   const bodyJson = JSON.stringify({ pinned });
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'PATCH',
-    headers: signedHeaders('PATCH', path, bodyJson),
+  const res = await spawnerFetch('PATCH', path, {
     body: bodyJson,
     signal: AbortSignal.timeout(30_000),
   });
@@ -336,9 +411,7 @@ export async function sessionCancelExec(
   execId: string,
 ): Promise<boolean> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}/exec/${encodeURIComponent(execId)}/cancel`;
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'POST',
-    headers: signedHeaders('POST', path, ''),
+  const res = await spawnerFetch('POST', path, {
     body: '',
     signal: AbortSignal.timeout(30_000),
   });
@@ -366,9 +439,7 @@ export async function sessionExecStatus(
   execId: string,
 ): Promise<ExecLiveness> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}/exec/${encodeURIComponent(execId)}`;
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'GET',
-    headers: signedHeaders('GET', path, ''),
+  const res = await spawnerFetch('GET', path, {
     signal: AbortSignal.timeout(30_000),
   });
   if (res.status === 404) return { state: 'gone' };
@@ -464,9 +535,7 @@ async function postStageFiles(
 ): Promise<SessionStageResult> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}/files/stage`;
   const bodyJson = JSON.stringify({ files });
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'POST',
-    headers: signedHeaders('POST', path, bodyJson),
+  const res = await spawnerFetch('POST', path, {
     body: bodyJson,
     signal: AbortSignal.timeout(30_000),
   });
@@ -511,9 +580,7 @@ export async function sessionDeleteFiles(
 ): Promise<SessionDeleteResult> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}/files/delete`;
   const bodyJson = JSON.stringify({ paths });
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'POST',
-    headers: signedHeaders('POST', path, bodyJson),
+  const res = await spawnerFetch('POST', path, {
     body: bodyJson,
     signal: AbortSignal.timeout(30_000),
   });
@@ -540,9 +607,7 @@ export async function sessionListFiles(
   dirPath: string,
 ): Promise<SessionFsEntry[] | null> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}/files?path=${encodeURIComponent(dirPath)}`;
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'GET',
-    headers: signedHeaders('GET', path, ''),
+  const res = await spawnerFetch('GET', path, {
     signal: AbortSignal.timeout(30_000),
   });
   if (res.status === 404) return null;
@@ -588,9 +653,7 @@ export async function sessionReadFile(
   filePath: string,
 ): Promise<{ bytes: ArrayBuffer; contentType: string } | null> {
   const path = `/v1/sessions/${encodeURIComponent(sessionId)}/files/content?path=${encodeURIComponent(filePath)}`;
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'GET',
-    headers: signedHeaders('GET', path, ''),
+  const res = await spawnerFetch('GET', path, {
     signal: AbortSignal.timeout(30_000),
   });
   if (res.status === 404) return null;
@@ -644,9 +707,7 @@ export async function sessionWriteExecStdin(
     ...(write.dataBase64 !== undefined ? { b64: write.dataBase64 } : {}),
     ...(write.eof === true ? { eof: true } : {}),
   });
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'POST',
-    headers: signedHeaders('POST', path, bodyJson),
+  const res = await spawnerFetch('POST', path, {
     body: bodyJson,
     signal: AbortSignal.timeout(30_000),
   });
@@ -698,10 +759,9 @@ export async function sessionExec(
       (body.timeoutMs ?? EXEC_FALLBACK_TIMEOUT_MS) + EXEC_FETCH_GRACE_MS,
     ),
   ]);
-  const res = await fetch(`${getSpawnerUrl()}${path}`, {
-    method: 'POST',
-    headers: signedHeaders('POST', path, bodyJson, 'text/event-stream'),
+  const res = await spawnerFetch('POST', path, {
     body: bodyJson,
+    accept: 'text/event-stream',
     signal: fetchAbort,
   });
   if (res.status === 404) throw new SessionNotFoundError(sessionId);
@@ -739,9 +799,8 @@ export async function sessionAttachExec(
       (timeoutMs ?? EXEC_FALLBACK_TIMEOUT_MS) + EXEC_FETCH_GRACE_MS,
     ),
   ]);
-  const res = await fetch(`${getSpawnerUrl()}${signedPath}`, {
-    method: 'GET',
-    headers: signedHeaders('GET', signedPath, '', 'text/event-stream'),
+  const res = await spawnerFetch('GET', signedPath, {
+    accept: 'text/event-stream',
     signal: fetchAbort,
   });
   if (res.status === 404) throw new SessionNotFoundError(sessionId);

--- a/services/sandbox/src/session/docker-session-args.test.ts
+++ b/services/sandbox/src/session/docker-session-args.test.ts
@@ -49,6 +49,19 @@ const goodInput = {
 };
 
 describe('buildDockerSessionRunArgs', () => {
+  test('logging is fully stated so a host default cannot break the run', () => {
+    const args = buildDockerSessionRunArgs(cfg, goodInput);
+    // Any log-opt left unset falls through to the host daemon's `log-opts`,
+    // and the json-file driver refuses compress=true with max-file<2: a host
+    // that defaults compression on made `docker run` fail with "failed to
+    // initialize logging driver" — a 502 on every session create.
+    const opts = args
+      .map((a, i) => (args[i - 1] === '--log-opt' ? a : null))
+      .filter((a): a is string => a !== null);
+    expect(args).toContain('--log-driver=json-file');
+    expect(opts).toEqual(['max-size=10m', 'max-file=1', 'compress=false']);
+  });
+
   test('agent profile: detached, daemon entrypoint, distinct label, no cpu ulimit', () => {
     const args = buildDockerSessionRunArgs(cfg, goodInput);
     // Detached — the container outlives the create request.

--- a/services/sandbox/src/session/docker-session-args.ts
+++ b/services/sandbox/src/session/docker-session-args.ts
@@ -368,8 +368,8 @@ export function buildDockerSessionRunArgs(
     // ~/.config/opencode, ~/.gitconfig) survives every exec + restart.
     '--env',
     `HOME=/agent/.runtime/home`,
-    // Per-session runnerd auth. Empty in unsigned dev mode (runnerd skips the
-    // check); a real hex token otherwise.
+    // Per-session runnerd auth: always a real hex token — SANDBOX_TOKEN is
+    // required, so deriveRunnerdToken has something to derive from.
     '--env',
     `TALE_RUNNERD_TOKEN=${inp.runnerdToken}`,
     // DinD signal + tier for the entrypoint (empty when DinD is off).
@@ -382,11 +382,20 @@ export function buildDockerSessionRunArgs(
     `--memory=${profile.memory}`,
     `--memory-swap=${profile.memory}`,
     `--pids-limit=${pidsLimitValue}`,
+    // The WHOLE logging posture, compression included: any option left unset
+    // falls through to the host daemon's `log-opts` defaults, and the
+    // json-file driver refuses compress=true together with max-file<2. A host
+    // that defaults compression on (a common log-disk policy) would make every
+    // session container unstartable — `docker run` fails with "failed to
+    // initialize logging driver", which surfaces as a 502 on session create
+    // and takes down every agent turn on the box.
     '--log-driver=json-file',
     '--log-opt',
     'max-size=10m',
     '--log-opt',
     'max-file=1',
+    '--log-opt',
+    'compress=false',
     ...ulimitFlags,
     '--oom-score-adj=500',
     // Read-only root unless DinD (dockerd needs a writable rootfs; its store is


### PR DESCRIPTION
## What happened

`demo05.tale.dev` ran no agent turns for two days (2026-09-05 02:10Z → 2026-09-07 02:18Z). Every automation run reported one line:

```
agent: the agent turn could not start: fetch failed (after 4 attempts)
```

Two separate defects were hiding behind that sentence, and neither was visible from it.

**1. A dead spawner cannot say so.** The deployment's `.env` had no `SANDBOX_TOKEN`, so the spawner fail-closed at boot (`services/sandbox/src/config.ts`, since 0.5.8) and crash-looped every 60 s. With the container down, `sandbox` stopped resolving and every spawner call threw a bare `TypeError: fetch failed`, naming neither the call nor the target. The actual diagnosis — `getaddrinfo EAI_AGAIN sandbox` — sat two `cause` hops deep in an error nobody printed. The backend could also have read its own env and said "SANDBOX_TOKEN is not set" from the first turn, but the client treated the missing secret as "unsigned mode", a mode the spawner stopped accepting in 0.5.8.

**2. A host log default makes every session container unstartable.** With the spawner back up, session creates failed 502:

```
docker run (session) failed: docker: Error response from daemon: failed to create task for
container: failed to initialize logging driver: compress cannot be true when max-file is
less than 2 or max-size is not set.
```

The session argv pins `--log-opt max-file=1` and left compression unset, so it inherited the host daemon's `log-opts` — and json-file refuses `compress=true` with `max-file<2`. Any operator whose daemon defaults compression on (a common log-disk policy) loses every agent session on the box, with nothing in the spawner's own config to explain it.

## What changed

- **`services/sandbox`** — a session container states its whole logging posture (`compress=false` alongside `max-size`/`max-file`), so no host default can produce an invalid combination.
- **`services/platform`** — every spawner call goes through one `spawnerFetch` door that composes the URL, signs the request, and wraps a transport failure in `SpawnerUnreachableError`: method, path, target URL and the syscall, with the original kept as `cause`. Only a `TypeError` is wrapped — an abort (a caller's signal, the turn-ended cut) and a timeout are control flow the resilient drain branches on, so they pass through untouched. Credentials embedded in `SANDBOX_URL` are stripped, because this message reaches the error tracker.
- **`services/platform`** — `requireSpawnerToken()` replaces the silent unsigned path and throws before the first network call, mirroring `requireGatewayAdminPassword` for the gateway's management plane.
- Two comments the change makes false are corrected (the retired `spawner_client.ts` reference; "empty in unsigned dev mode" for the runnerd token the spawner always derives).

## Proof

- `bun test` in `services/sandbox`: 292 pass, including a new argv gate asserting the log-opt list is exactly `max-size=10m, max-file=1, compress=false` — the ordering the daemon-default trap needs.
- `vitest` on the spawner-client suites: 209 pass across 20 files, including four new cases — an unreachable spawner names target + call + syscall; a deliberate abort is *not* reported as unreachable; a missing token fails with zero requests sent; `SANDBOX_URL` credentials never reach the message.
- `oxfmt`, `oxlint --type-aware`, `tsc --noEmit` for both workspaces, and `lint:sast` (467 rules, 0 findings).
- Observed on demo05 after the matching ops fixes: spawner up (`tokenAuth=on`), the sandbox watchdog reclaimed the 7 sessions stranded by the outage — a real signed round trip — and `docker run` for a session no longer hits the logging driver.

## Not in this change

- The deployment-side gap that caused it is fixed in ops (`tale-project/ops@9b37fc6` mints `SANDBOX_TOKEN` + `TALE_AUDIT_PEPPER` into demo05's env and waits on the spawner's health route before reporting success; `@6e01a19` drops the daemon-wide log `compress` default). `tale deploy` already minted the token — only the hand-written env file did not.
- `llm_gateway_admin` has the same bare-transport-error shape in the same lane (agent turn start). It has its own `require*` precondition and no observed failure, so it stays a separate follow-up rather than doubling this diff.
