### PR TITLE
fix(ui): restore overlay motion and interaction taste

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -134,6 +134,7 @@
         "remark-math": "6.0.0",
         "shiki": "3.2.0",
         "tailwind-merge": "3.5.0",
+        "tw-animate-css": "^1.4.0",
         "unist-util-visit": "5.1.0",
         "vaul": "1.1.2",
         "yaml": "2.8.3",
@@ -4408,6 +4409,8 @@
     "turbo": ["turbo@2.10.11", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.11", "@turbo/darwin-arm64": "2.10.11", "@turbo/linux-64": "2.10.11", "@turbo/linux-arm64": "2.10.11", "@turbo/windows-64": "2.10.11", "@turbo/windows-arm64": "2.10.11" }, "bin": { "turbo": "bin/turbo" } }, "sha512-yQfwQVoRXwOuyX1LxiJFBFNg6VfuYh+/RyZLd82+isgyLkBXw3S5XRRzvcck1FAjSCG5sVyLd+O1eDMvYa3J7g=="],
 
     "turndown": ["turndown@7.2.0", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A=="],
+
+    "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "type-fest": ["type-fest@5.8.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -223,6 +223,7 @@
     "remark-math": "6.0.0",
     "shiki": "3.2.0",
     "tailwind-merge": "3.5.0",
+    "tw-animate-css": "^1.4.0",
     "unist-util-visit": "5.1.0",
     "vaul": "1.1.2",
     "yaml": "2.8.3"

--- a/packages/ui/src/app-shell.tsx
+++ b/packages/ui/src/app-shell.tsx
@@ -7,6 +7,11 @@ import type { ReactNode } from 'react';
 import { I18nextProvider } from 'react-i18next';
 
 import './fonts';
+import {
+  TooltipProvider,
+  TOOLTIP_DELAY_MS,
+  TOOLTIP_SKIP_DELAY_MS,
+} from './components/overlays/tooltip';
 import { type Theme, ThemeProvider } from './theme';
 
 interface ClientLocaleConfig {
@@ -70,8 +75,8 @@ function ClientLocaleBridge() {
  * Standardized provider shell every Tale frontend service uses. Owns the
  * cross-cutting theme + locale + i18n stack in the order that matters:
  *
- *   `<ThemeProvider>` → `<LocaleProvider>` → `<I18nextProvider>`
- *     → `<LocaleSync>` → children
+ *   `<ThemeProvider>` → `<TooltipProvider>` → `<LocaleProvider>` →
+ *     `<I18nextProvider>` → `<LocaleSync>` → children
  *
  * The ordering inside the i18n+locale block is load-bearing:
  * `<I18nextProvider>` contains a bridge that reads `useLocale()`, so
@@ -114,6 +119,17 @@ export function AppShell({ i18n, locale, theme, children }: AppShellProps) {
       </LocaleProvider>
     );
   }
+
+  // One provider for the whole tree so skip-delay works across toolbars.
+  // Nested per-tip Providers reset the skip timer — do not reintroduce them.
+  tree = (
+    <TooltipProvider
+      delayDuration={TOOLTIP_DELAY_MS}
+      skipDelayDuration={TOOLTIP_SKIP_DELAY_MS}
+    >
+      {tree}
+    </TooltipProvider>
+  );
 
   if (theme) {
     const themeConfig = theme === true ? undefined : theme;

--- a/packages/ui/src/components/overlays/disabled-reason.tsx
+++ b/packages/ui/src/components/overlays/disabled-reason.tsx
@@ -63,13 +63,11 @@ export function DisabledReasonTooltip({
 }: DisabledReasonTooltipProps): ReactElement {
   if (!active || !hasDisabledReason(reason)) return children;
   return (
-    <TooltipPrimitive.Provider delayDuration={300}>
-      <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Portal>
-          <TooltipContent side={side}>{reason}</TooltipContent>
-        </TooltipPrimitive.Portal>
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+    <TooltipPrimitive.Root>
+      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Portal>
+        <TooltipContent side={side}>{reason}</TooltipContent>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
   );
 }

--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -245,7 +245,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
               sideOffset={13}
               collisionPadding={16}
               className={cn(
-                'bg-card text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-lg border p-1 shadow-lg motion-reduce:animate-none',
+                'bg-card text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden rounded-lg border p-1 shadow-lg duration-[var(--duration-short)] motion-reduce:animate-none',
                 item.contentClassName,
               )}
             >
@@ -393,20 +393,18 @@ export function DropdownMenu({
         // Radix's documented composition for "tooltip on a menu trigger":
         // both `asChild` triggers collapse onto the same button so the menu
         // still opens on click while the tooltip shows on hover/focus.
-        <TooltipPrimitive.Provider delayDuration={300}>
-          <TooltipPrimitive.Root>
-            <TooltipPrimitive.Trigger asChild>
-              {triggerEl}
-            </TooltipPrimitive.Trigger>
-            <TooltipPrimitive.Portal>
-              {/* collisionPadding keeps the tooltip off the viewport edge so it
-                  can't visually overlap adjacent controls in dense toolbars. */}
-              <TooltipContent side={tooltipSide} collisionPadding={8}>
-                {tooltip}
-              </TooltipContent>
-            </TooltipPrimitive.Portal>
-          </TooltipPrimitive.Root>
-        </TooltipPrimitive.Provider>
+        <TooltipPrimitive.Root>
+          <TooltipPrimitive.Trigger asChild>
+            {triggerEl}
+          </TooltipPrimitive.Trigger>
+          <TooltipPrimitive.Portal>
+            {/* collisionPadding keeps the tooltip off the viewport edge so it
+                can't visually overlap adjacent controls in dense toolbars. */}
+            <TooltipContent side={tooltipSide} collisionPadding={8}>
+              {tooltip}
+            </TooltipContent>
+          </TooltipPrimitive.Portal>
+        </TooltipPrimitive.Root>
       ) : (
         triggerEl
       )}
@@ -418,7 +416,7 @@ export function DropdownMenu({
           collisionPadding={collisionPadding ?? 16}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'bg-card text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) max-w-(--radix-dropdown-menu-content-available-width) min-w-[max(10rem,var(--radix-dropdown-menu-trigger-width))] overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md motion-reduce:animate-none',
+            'bg-card text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) max-w-(--radix-dropdown-menu-content-available-width) min-w-[max(10rem,var(--radix-dropdown-menu-trigger-width))] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-lg border p-1 shadow-md duration-[var(--duration-short)] motion-reduce:animate-none',
             contentClassName,
           )}
         >

--- a/packages/ui/src/components/overlays/popover.tsx
+++ b/packages/ui/src/components/overlays/popover.tsx
@@ -19,7 +19,7 @@ interface PopoverProps {
 }
 
 const CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
+  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[var(--radix-popover-content-transform-origin)] duration-[var(--duration-short)] motion-reduce:animate-none';
 
 export function Popover({
   trigger,

--- a/packages/ui/src/components/overlays/tooltip.tsx
+++ b/packages/ui/src/components/overlays/tooltip.tsx
@@ -3,6 +3,11 @@ import { type ComponentPropsWithoutRef, forwardRef } from 'react';
 
 import { cn } from '../../lib/cn';
 
+/** First-open delay before a tip appears (accidental-hover guard). */
+export const TOOLTIP_DELAY_MS = 200;
+/** After one tip is open, subsequent tips in the same provider skip this wait. */
+export const TOOLTIP_SKIP_DELAY_MS = 300;
+
 export const TooltipProvider = TooltipPrimitive.Provider;
 export const Tooltip = TooltipPrimitive.Root;
 export const TooltipTrigger = TooltipPrimitive.Trigger;
@@ -16,7 +21,7 @@ export const TooltipContent = forwardRef<
     sideOffset={sideOffset}
     className={cn(
       'z-50 max-w-xs overflow-hidden rounded-md bg-[color:var(--color-accent-base)] px-3 py-1.5 text-xs text-wrap text-[color:var(--color-accent-fg)] shadow-md',
-      'animate-in fade-in-0 motion-reduce:animate-none',
+      'animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 duration-[var(--duration-short)] motion-reduce:animate-none',
       className,
     )}
     {...props}

--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -321,7 +321,7 @@ describe('Button', () => {
     it('has press animation classes', () => {
       render(<Button>Press me</Button>);
       const button = screen.getByRole('button');
-      expect(button.className).toContain('active:scale-[0.97]');
+      expect(button.className).toContain('active:scale-[var(--scale-pressed)]');
     });
 
     it('disabled button does not scale on press', () => {

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -11,7 +11,7 @@ import { hasDisabledReason } from '../overlays/disabled-reason';
 import { TooltipContent } from '../overlays/tooltip';
 
 export const buttonVariants = cva(
-  'focus-visible:ring-ring ring-offset-background inline-flex cursor-pointer items-center justify-center rounded-lg text-sm leading-none font-medium whitespace-nowrap transition-all duration-150 focus-visible:ring-1 focus-visible:outline-none active:scale-[0.97] active:duration-75 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:opacity-50 disabled:active:scale-100 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:opacity-50 aria-disabled:active:scale-100 motion-reduce:transition-none motion-reduce:active:scale-100',
+  'focus-visible:ring-ring ring-offset-background inline-flex cursor-pointer items-center justify-center rounded-lg text-sm leading-none font-medium whitespace-nowrap transition-all duration-[var(--duration-short)] focus-visible:ring-1 focus-visible:outline-none active:scale-[var(--scale-pressed)] active:duration-[var(--duration-micro)] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:opacity-50 disabled:active:scale-100 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:opacity-50 aria-disabled:active:scale-100 motion-reduce:transition-none motion-reduce:active:scale-100',
   {
     variants: {
       // One height fits all (`h-9`), with a single smaller variant (`h-8`) for
@@ -312,17 +312,15 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       tip == null || props.asChild ? (
         base
       ) : (
-        <TooltipPrimitive.Provider delayDuration={300}>
-          <TooltipPrimitive.Root
-            open={tooltipOpen}
-            onOpenChange={onTooltipOpenChange}
-          >
-            <TooltipPrimitive.Trigger asChild>{base}</TooltipPrimitive.Trigger>
-            <TooltipPrimitive.Portal>
-              <TooltipContent side={tooltipSide}>{tip}</TooltipContent>
-            </TooltipPrimitive.Portal>
-          </TooltipPrimitive.Root>
-        </TooltipPrimitive.Provider>
+        <TooltipPrimitive.Root
+          open={tooltipOpen}
+          onOpenChange={onTooltipOpenChange}
+        >
+          <TooltipPrimitive.Trigger asChild>{base}</TooltipPrimitive.Trigger>
+          <TooltipPrimitive.Portal>
+            <TooltipContent side={tooltipSide}>{tip}</TooltipContent>
+          </TooltipPrimitive.Portal>
+        </TooltipPrimitive.Root>
       );
     return <SkeletonBox fullWidth={props.fullWidth}>{withTooltip}</SkeletonBox>;
   },

--- a/packages/ui/src/components/search/search-result-row.tsx
+++ b/packages/ui/src/components/search/search-result-row.tsx
@@ -86,7 +86,7 @@ export function SearchResultRow({
         onFocus={onHover}
         onClick={onSelect}
         className={cn(
-          'group relative flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors',
+          'group relative flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left',
           'focus-visible:outline-none',
           isActive
             ? 'bg-bg-elevated text-fg-base'
@@ -95,7 +95,7 @@ export function SearchResultRow({
       >
         <span
           className={cn(
-            'mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border transition-colors',
+            'mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border',
             isActive
               ? 'border-border-strong bg-bg-base text-fg-base'
               : 'border-border-base/70 bg-bg-base/50 text-fg-muted',

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'tw-animate-css';
 
 /* Inter webfont bundled locally (GDPR + air-gapped: no Google Fonts CDN). The
    @fontsource `@font-face` rules + woff2 files are loaded from `./fonts.ts` as a

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -64,6 +64,8 @@ export {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  TOOLTIP_DELAY_MS,
+  TOOLTIP_SKIP_DELAY_MS,
 } from './components/overlays/tooltip';
 
 export { TaleLogo, type TaleLogoProps } from './logo/tale-logo';

--- a/packages/ui/tests/utils/render.tsx
+++ b/packages/ui/tests/utils/render.tsx
@@ -1,12 +1,31 @@
+import {
+  TooltipProvider,
+  TOOLTIP_DELAY_MS,
+  TOOLTIP_SKIP_DELAY_MS,
+} from '@tale/ui/tooltip';
 import type { RenderOptions } from '@testing-library/react';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
-function customRender(ui: ReactElement, options?: RenderOptions) {
+function AllProviders({ children }: { children: ReactNode }) {
+  return (
+    <TooltipProvider
+      delayDuration={TOOLTIP_DELAY_MS}
+      skipDelayDuration={TOOLTIP_SKIP_DELAY_MS}
+    >
+      {children}
+    </TooltipProvider>
+  );
+}
+
+function customRender(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) {
   return {
     user: userEvent.setup(),
-    ...render(ui, options),
+    ...render(ui, { wrapper: AllProviders, ...options }),
   };
 }
 

--- a/services/platform/app/components/organization-button.tsx
+++ b/services/platform/app/components/organization-button.tsx
@@ -76,26 +76,24 @@ export function OrganizationButton({
   }
 
   return (
-    <TooltipPrimitive.Provider delayDuration={300}>
-      <TooltipPrimitive.Root>
-        <DropdownMenu
-          trigger={
-            <TooltipPrimitive.Trigger asChild>
-              {triggerContent}
-            </TooltipPrimitive.Trigger>
-          }
-          items={menuItems}
-          align={align}
-          contentClassName="w-80"
-        />
-        <TooltipPrimitive.Content
-          side="right"
-          sideOffset={4}
-          className={tooltipContentClassName}
-        >
-          {accessibleLabel}
-        </TooltipPrimitive.Content>
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+    <TooltipPrimitive.Root>
+      <DropdownMenu
+        trigger={
+          <TooltipPrimitive.Trigger asChild>
+            {triggerContent}
+          </TooltipPrimitive.Trigger>
+        }
+        items={menuItems}
+        align={align}
+        contentClassName="w-80"
+      />
+      <TooltipPrimitive.Content
+        side="right"
+        sideOffset={4}
+        className={tooltipContentClassName}
+      >
+        {accessibleLabel}
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Root>
   );
 }

--- a/services/platform/app/components/ui/data-display/copyable-field.tsx
+++ b/services/platform/app/components/ui/data-display/copyable-field.tsx
@@ -80,7 +80,9 @@ const CopyableFieldBase = React.memo(function CopyableFieldBase({
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
       {label && <Label id={labelId}>{label}</Label>}
-      <TooltipPrimitive.Provider delayDuration={300} disableHoverableContent>
+      {/* Nested Provider only for disableHoverableContent — a single tip, so
+          skip-delay across the app is unaffected. */}
+      <TooltipPrimitive.Provider delayDuration={200} disableHoverableContent>
         {/* Uncontrolled on purpose: gating happens by withholding the CONTENT
           below — flipping Radix between controlled and uncontrolled on the
           first hover leaves it stuck closed. */}

--- a/services/platform/app/components/ui/dialog/confirm-dialog.tsx
+++ b/services/platform/app/components/ui/dialog/confirm-dialog.tsx
@@ -137,6 +137,7 @@ export function ConfirmDialog({
           onConfirm();
         }}
         disabled={isLoading || disableConfirm || !phraseSatisfied}
+        isLoading={isLoading}
         className={cn(confirmButtonVariants({ variant }))}
       >
         {isLoading

--- a/services/platform/app/components/ui/dialog/form-dialog.tsx
+++ b/services/platform/app/components/ui/dialog/form-dialog.tsx
@@ -172,7 +172,11 @@ export function FormDialog({
       >
         {cancelText ?? tCommon('actions.cancel')}
       </Button>
-      <Button type="submit" disabled={isSubmitting || !isDirty || !isValid}>
+      <Button
+        type="submit"
+        disabled={isSubmitting || !isDirty || !isValid}
+        isLoading={isSubmitting}
+      >
         {isSubmitting
           ? (submittingText ?? tCommon('actions.saving'))
           : (submitText ?? tCommon('actions.save'))}

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -439,31 +439,29 @@ function SearchableSelectBase({
         // Radix's documented "tooltip on a popover trigger" composition: both
         // `asChild` triggers collapse onto the same node, so the popover opens
         // on click while the tooltip shows on hover/focus.
-        <TooltipPrimitive.Provider delayDuration={300}>
-          <TooltipPrimitive.Root
-            // Controlled so the tooltip is forced shut while the popover is
-            // open and during the focus-restore that follows its close.
-            open={tooltipOpen && !isOpen}
-            onOpenChange={(next) => {
-              if (next && suppressTooltipRef.current) {
-                suppressTooltipRef.current = false;
-                return;
-              }
-              setTooltipOpen(next);
-            }}
-          >
-            <TooltipPrimitive.Trigger asChild>
-              {popoverTrigger}
-            </TooltipPrimitive.Trigger>
-            <TooltipPrimitive.Portal>
-              {/* collisionPadding keeps the tooltip off the viewport edge so it
-                  can't visually overlap adjacent controls in dense toolbars. */}
-              <TooltipContent side={tooltipSide} collisionPadding={8}>
-                {tooltip}
-              </TooltipContent>
-            </TooltipPrimitive.Portal>
-          </TooltipPrimitive.Root>
-        </TooltipPrimitive.Provider>
+        <TooltipPrimitive.Root
+          // Controlled so the tooltip is forced shut while the popover is
+          // open and during the focus-restore that follows its close.
+          open={tooltipOpen && !isOpen}
+          onOpenChange={(next) => {
+            if (next && suppressTooltipRef.current) {
+              suppressTooltipRef.current = false;
+              return;
+            }
+            setTooltipOpen(next);
+          }}
+        >
+          <TooltipPrimitive.Trigger asChild>
+            {popoverTrigger}
+          </TooltipPrimitive.Trigger>
+          <TooltipPrimitive.Portal>
+            {/* collisionPadding keeps the tooltip off the viewport edge so it
+                can't visually overlap adjacent controls in dense toolbars. */}
+            <TooltipContent side={tooltipSide} collisionPadding={8}>
+              {tooltip}
+            </TooltipContent>
+          </TooltipPrimitive.Portal>
+        </TooltipPrimitive.Root>
       ) : (
         popoverTrigger
       )}
@@ -710,7 +708,7 @@ function SearchableSelectOptionItem({
       onClick={() => !option.disabled && onSelect(option.value)}
       onMouseEnter={() => onMouseEnter(index)}
       className={cn(
-        'group/option relative flex w-full cursor-default gap-2 text-left text-sm transition-colors',
+        'group/option relative flex w-full cursor-default gap-2 text-left text-sm',
         isSwitcher
           ? 'border-border rounded-none border-b px-3 py-2 last:border-b-0'
           : 'rounded-md p-2',
@@ -738,7 +736,7 @@ function SearchableSelectOptionItem({
         >
           <span
             className={cn(
-              'border-border bg-background flex size-4 items-center justify-center rounded-full border transition-colors duration-150',
+              'border-border bg-background flex size-4 items-center justify-center rounded-full border',
               isSelected && 'border-blue-600',
             )}
           >
@@ -797,20 +795,18 @@ function SearchableSelectOptionItem({
   // `align="start"` anchors it to the row top so long descriptions don't
   // float into the row above.
   return (
-    <TooltipPrimitive.Provider delayDuration={250}>
-      <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger asChild>{row}</TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Portal>
-          <TooltipContent
-            side="right"
-            align="start"
-            collisionPadding={8}
-            className="max-w-xs text-xs leading-relaxed"
-          >
-            {tooltipContent}
-          </TooltipContent>
-        </TooltipPrimitive.Portal>
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+    <TooltipPrimitive.Root delayDuration={250}>
+      <TooltipPrimitive.Trigger asChild>{row}</TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Portal>
+        <TooltipContent
+          side="right"
+          align="start"
+          collisionPadding={8}
+          className="max-w-xs text-xs leading-relaxed"
+        >
+          {tooltipContent}
+        </TooltipContent>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
   );
 }

--- a/services/platform/app/components/ui/overlays/sheet.tsx
+++ b/services/platform/app/components/ui/overlays/sheet.tsx
@@ -41,7 +41,7 @@ const sheetVariants = cva(
   // an interactive control, so the browser's default focus outline reads as a
   // stray blue ring around the whole panel — suppress it. Focusable controls
   // inside the panel keep their own `focus-visible` rings.
-  'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 gap-4 overflow-y-auto p-6 pr-[calc(1.5rem+var(--safe-right))] pl-[calc(1.5rem+var(--safe-left))] shadow-lg transition ease-in-out focus:outline-none data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 gap-4 overflow-y-auto p-6 pr-[calc(1.5rem+var(--safe-right))] pl-[calc(1.5rem+var(--safe-left))] shadow-lg transition ease-out focus:outline-none data-[state=closed]:duration-[var(--duration-short)] data-[state=open]:duration-[var(--duration-standard)] motion-reduce:animate-none motion-reduce:transition-none',
   {
     variants: {
       side: {

--- a/services/platform/app/components/ui/overlays/tooltip.test.tsx
+++ b/services/platform/app/components/ui/overlays/tooltip.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
+import { TooltipProvider } from '@tale/ui/tooltip';
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
@@ -34,9 +35,11 @@ describe('Tooltip', () => {
       'Runs in a sandbox on the harness chosen when the agent was created, pre-equipped with its skills, connectors, and instructions.';
 
     render(
-      <Tooltip content={longCopy} open onOpenChange={() => {}}>
-        <button type="button">Info</button>
-      </Tooltip>,
+      <TooltipProvider>
+        <Tooltip content={longCopy} open onOpenChange={() => {}}>
+          <button type="button">Info</button>
+        </Tooltip>
+      </TooltipProvider>,
     );
 
     const content = document.querySelector(

--- a/services/platform/app/components/ui/overlays/tooltip.tsx
+++ b/services/platform/app/components/ui/overlays/tooltip.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils/cn';
 
 /** Shared surface for every platform tooltip — one place for width/wrap rules. */
 export const tooltipContentClassName =
-  'bg-foreground text-background animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 z-[60] max-w-xs overflow-hidden rounded-lg border p-2 py-1 text-xs text-wrap shadow-md';
+  'bg-foreground text-background animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 z-[60] max-w-xs overflow-hidden rounded-lg border p-2 py-1 text-xs text-wrap shadow-md duration-[var(--duration-short)] motion-reduce:animate-none';
 
 interface TooltipProps {
   content: ReactNode;
@@ -21,19 +21,28 @@ interface TooltipProps {
    * toolbars (e.g. the composer's attach button) — #1461.
    */
   collisionPadding?: number;
+  /**
+   * Per-tip override for open delay. Prefer the app-shell TooltipProvider
+   * defaults so skip-delay works across a toolbar; only set this for tips that
+   * must differ (e.g. denser chrome).
+   */
   delayDuration?: number;
   contentClassName?: string;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
 
+/**
+ * Platform tooltip. Relies on the AppShell TooltipProvider for delay and
+ * skip-delay — do not wrap each instance in its own Provider.
+ */
 export function Tooltip({
   content,
   children,
   side,
   sideOffset = 4,
   collisionPadding = 8,
-  delayDuration = 300,
+  delayDuration,
   contentClassName,
   open,
   onOpenChange,
@@ -41,20 +50,22 @@ export function Tooltip({
   if (!content) return <>{children}</>;
 
   return (
-    <TooltipPrimitive.Provider delayDuration={delayDuration}>
-      <TooltipPrimitive.Root open={open} onOpenChange={onOpenChange}>
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Portal>
-          <TooltipPrimitive.Content
-            side={side}
-            sideOffset={sideOffset}
-            collisionPadding={collisionPadding}
-            className={cn(tooltipContentClassName, contentClassName)}
-          >
-            {content}
-          </TooltipPrimitive.Content>
-        </TooltipPrimitive.Portal>
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+    <TooltipPrimitive.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      delayDuration={delayDuration}
+    >
+      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          side={side}
+          sideOffset={sideOffset}
+          collisionPadding={collisionPadding}
+          className={cn(tooltipContentClassName, contentClassName)}
+        >
+          {content}
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
   );
 }

--- a/services/platform/app/components/user-button.tsx
+++ b/services/platform/app/components/user-button.tsx
@@ -690,37 +690,35 @@ export function UserButton({
 
   return (
     <>
-      <TooltipPrimitive.Provider delayDuration={300}>
-        <TooltipPrimitive.Root>
-          <DropdownMenu
-            trigger={
-              <TooltipPrimitive.Trigger asChild>
-                {triggerContent}
-              </TooltipPrimitive.Trigger>
-            }
-            items={menuItems}
-            // On the rail the menu opens beside the tile: 16px offset = the
-            // tile's 8px inset to the rail edge + an 8px gap to the nav
-            // (matches the notification popover).
-            align={isSidebarVariant ? (align ?? 'end') : align}
-            side={isSidebarVariant ? 'right' : undefined}
-            sideOffset={isSidebarVariant ? 16 : undefined}
-            // The rail's own 8px inset: any more and Radix shifts the menu up,
-            // off the trigger's bottom edge the bell panel aligns with.
-            collisionPadding={isSidebarVariant ? 8 : undefined}
-            open={open}
-            onOpenChange={handleOpenChange}
-            contentClassName={contentClassName}
-          />
-          <TooltipPrimitive.Content
-            side="right"
-            sideOffset={4}
-            className={tooltipContentClassName}
-          >
-            {t('userButton.manageAccount')}
-          </TooltipPrimitive.Content>
-        </TooltipPrimitive.Root>
-      </TooltipPrimitive.Provider>
+      <TooltipPrimitive.Root>
+        <DropdownMenu
+          trigger={
+            <TooltipPrimitive.Trigger asChild>
+              {triggerContent}
+            </TooltipPrimitive.Trigger>
+          }
+          items={menuItems}
+          // On the rail the menu opens beside the tile: 16px offset = the
+          // tile's 8px inset to the rail edge + an 8px gap to the nav
+          // (matches the notification popover).
+          align={isSidebarVariant ? (align ?? 'end') : align}
+          side={isSidebarVariant ? 'right' : undefined}
+          sideOffset={isSidebarVariant ? 16 : undefined}
+          // The rail's own 8px inset: any more and Radix shifts the menu up,
+          // off the trigger's bottom edge the bell panel aligns with.
+          collisionPadding={isSidebarVariant ? 8 : undefined}
+          open={open}
+          onOpenChange={handleOpenChange}
+          contentClassName={contentClassName}
+        />
+        <TooltipPrimitive.Content
+          side="right"
+          sideOffset={4}
+          className={tooltipContentClassName}
+        >
+          {t('userButton.manageAccount')}
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Root>
       {overlays}
     </>
   );

--- a/services/platform/app/features/notifications/components/notification-bell.tsx
+++ b/services/platform/app/features/notifications/components/notification-bell.tsx
@@ -27,7 +27,7 @@ interface NotificationBellProps {
  * asChild>` from reaching the button and quietly dropped the click handler.
  */
 const POPOVER_CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none';
+  'z-50 min-w-[14.5rem] max-w-64 w-auto p-4 rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[var(--radix-popover-content-transform-origin)] duration-[var(--duration-short)] motion-reduce:animate-none';
 
 export function NotificationBell({ organizationId }: NotificationBellProps) {
   const { t: tNav } = useT('navigation');
@@ -67,33 +67,32 @@ export function NotificationBell({ organizationId }: NotificationBellProps) {
   // to land both `asChild` triggers on the same `<button>`. Going through the
   // `@tale/ui` `Popover` wrapper buries its `<PopoverPrimitive.Trigger
   // asChild>` one level deep — passing a Tooltip-wrapped trigger then meets
-  // a non-DOM intermediary (`TooltipPrimitive.Provider`/`Root`), Radix's
-  // `Slot` can't merge the `onClick` through, and the panel never opens.
-  // Nested `asChild` Triggers via Slot, in contrast, merge cleanly: each
-  // wraps the next, and the innermost child (the button) ends up with both
-  // sets of event listeners + refs.
+  // a non-DOM intermediary (`TooltipPrimitive.Root`), Radix's `Slot` can't
+  // merge the `onClick` through, and the panel never opens. Nested `asChild`
+  // Triggers via Slot, in contrast, merge cleanly: each wraps the next, and
+  // the innermost child (the button) ends up with both sets of event
+  // listeners + refs. Delay/skip-delay come from AppShell's TooltipProvider —
+  // do not wrap a per-tip Provider here.
   return (
     <>
       <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-        <TooltipPrimitive.Provider delayDuration={300}>
-          <TooltipPrimitive.Root>
-            <PopoverPrimitive.Trigger asChild>
-              <TooltipPrimitive.Trigger asChild>
-                {buttonNode}
-              </TooltipPrimitive.Trigger>
-            </PopoverPrimitive.Trigger>
-            <TooltipPrimitive.Portal>
-              <TooltipPrimitive.Content
-                side="right"
-                sideOffset={8}
-                collisionPadding={8}
-                className={tooltipContentClassName}
-              >
-                {tNav('notifications')}
-              </TooltipPrimitive.Content>
-            </TooltipPrimitive.Portal>
-          </TooltipPrimitive.Root>
-        </TooltipPrimitive.Provider>
+        <TooltipPrimitive.Root>
+          <PopoverPrimitive.Trigger asChild>
+            <TooltipPrimitive.Trigger asChild>
+              {buttonNode}
+            </TooltipPrimitive.Trigger>
+          </PopoverPrimitive.Trigger>
+          <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+              side="right"
+              sideOffset={8}
+              collisionPadding={8}
+              className={tooltipContentClassName}
+            >
+              {tNav('notifications')}
+            </TooltipPrimitive.Content>
+          </TooltipPrimitive.Portal>
+        </TooltipPrimitive.Root>
         <PopoverPrimitive.Portal>
           <PopoverPrimitive.Content
             align="end"

--- a/services/platform/app/features/settings/sandboxes/sandboxes-settings.tsx
+++ b/services/platform/app/features/settings/sandboxes/sandboxes-settings.tsx
@@ -1,11 +1,6 @@
 import { Badge } from '@tale/ui/badge';
 import { Row, Stack } from '@tale/ui/layout';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@tale/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@tale/ui/tooltip';
 import type { ColumnDef } from '@tanstack/react-table';
 import { Box, Pin, PinOff, Square, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -281,33 +276,27 @@ export function SandboxesSettings({ organizationId }: SandboxesSettingsProps) {
   return (
     <SettingsSection title={t('title')} description={t('description')}>
       {quotaRows.length > 0 && (
-        <TooltipProvider delayDuration={300}>
-          <Row gap={2} wrap className="mb-4">
-            {quotaRows.map((b) => (
-              <Tooltip key={b.budget}>
-                {/* The chip itself is the trigger; tabIndex makes it
-                  keyboard-reachable so the hint opens on focus too. */}
-                <TooltipTrigger asChild>
-                  <Badge
-                    tabIndex={0}
-                    variant={
-                      b.atLimit
-                        ? 'destructive'
-                        : b.nearLimit
-                          ? 'yellow'
-                          : 'slate'
-                    }
-                  >
-                    {t(`quota.budgets.${b.budget}`)}: {b.used} / {b.cap}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs">
-                  {t(`quota.budgetHints.${b.budget}`)}
-                </TooltipContent>
-              </Tooltip>
-            ))}
-          </Row>
-        </TooltipProvider>
+        <Row gap={2} wrap className="mb-4">
+          {quotaRows.map((b) => (
+            <Tooltip key={b.budget}>
+              {/* The chip itself is the trigger; tabIndex makes it
+                keyboard-reachable so the hint opens on focus too. */}
+              <TooltipTrigger asChild>
+                <Badge
+                  tabIndex={0}
+                  variant={
+                    b.atLimit ? 'destructive' : b.nearLimit ? 'yellow' : 'slate'
+                  }
+                >
+                  {t(`quota.budgets.${b.budget}`)}: {b.used} / {b.cap}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                {t(`quota.budgetHints.${b.budget}`)}
+              </TooltipContent>
+            </Tooltip>
+          ))}
+        </Row>
       )}
       <DataTable<SandboxRow>
         columns={columns}


### PR DESCRIPTION
## Summary
- Mount a single AppShell `TooltipProvider` (`delay` 200ms / `skipDelay` 300ms) and stop wrapping every tip in its own Provider so toolbar tips open instantly after the first.
- Restore `tw-animate-css` so `animate-in` / slide / fade classes actually run again on dialogs, sheets, menus, and tooltips.
- Cap sheet open at `--duration-standard` (200ms) with ease-out; wire button press to `--scale-pressed` / duration tokens; origin-aware menus/popovers via Radix transform-origin vars.
- Form/Confirm primary actions use `Button` `isLoading` (spinner); drop `transition-colors` on keyboard-highlighted search/select rows.

## Follow-ups (not in this PR)
- Collapse dual platform vs `@tale/ui` dialog/tooltip skins into one vocabulary.
- Marketing web tip Providers (isolated tiles) can stay intentional for now.

## Test plan
- [ ] Hover adjacent toolbar tips (rail user/org/bell, composer icons) — first tip delays, subsequent tips are instant.
- [ ] Open settings sheet / dialog / dropdown — enter/exit animate; sheet feels snappy (&lt;300ms).
- [ ] Submit a form dialog / confirm dialog — spinner on primary while pending.
- [ ] Arrow through command palette / searchable select — highlight has no color transition lag.
- [ ] `prefers-reduced-motion: reduce` — overlays do not animate.
- [ ] `bun run --filter @tale/ui test` / platform `test:ui` for touched files.