### PR TITLE
fix(ui): close remaining interaction taste gaps

### DIFF
--- a/packages/ui/src/components/data-display/chart-card.tsx
+++ b/packages/ui/src/components/data-display/chart-card.tsx
@@ -5,12 +5,7 @@ import { type ComponentType, type ReactNode } from 'react';
 
 import { cn } from '../../lib/cn';
 import { EmptyState } from '../feedback/empty-state';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '../overlays/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../overlays/tooltip';
 
 interface ChartCardProps {
   /**
@@ -90,18 +85,16 @@ export function ChartCard({
               </h3>
             ) : null}
             {tooltip ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger
-                    type="button"
-                    aria-label={tooltip}
-                    className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex size-6 shrink-0 items-center justify-center rounded focus-visible:ring-2 focus-visible:outline-none"
-                  >
-                    <Info className="size-4" aria-hidden />
-                  </TooltipTrigger>
-                  <TooltipContent side="top">{tooltip}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger
+                  type="button"
+                  aria-label={tooltip}
+                  className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex size-6 shrink-0 items-center justify-center rounded focus-visible:ring-2 focus-visible:outline-none"
+                >
+                  <Info className="size-4" aria-hidden />
+                </TooltipTrigger>
+                <TooltipContent side="top">{tooltip}</TooltipContent>
+              </Tooltip>
             ) : null}
           </div>
           {toolbar ? <div className="shrink-0">{toolbar}</div> : null}

--- a/packages/ui/src/components/feedback/progress-bar.tsx
+++ b/packages/ui/src/components/feedback/progress-bar.tsx
@@ -3,12 +3,7 @@
 import * as React from 'react';
 
 import { cn } from '../../lib/cn';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '../overlays/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../overlays/tooltip';
 
 interface ProgressBarProps {
   value: number;
@@ -50,7 +45,7 @@ export function ProgressBar({
       >
         <div
           className={cn(
-            'bg-primary h-full w-full flex-1 transition-all duration-300 ease-in-out',
+            'bg-primary h-full w-full flex-1 transition-transform duration-[var(--duration-medium)] ease-out motion-reduce:transition-none',
             clampedPercentage === 100 && 'bg-green-500',
             indicatorClassName,
           )}
@@ -67,11 +62,9 @@ export function ProgressBar({
   if (!tooltipContent) return body;
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>{body}</TooltipTrigger>
-        <TooltipContent>{tooltipContent}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>{body}</TooltipTrigger>
+      <TooltipContent>{tooltipContent}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/ui/src/components/overlays/dropdown-menu.tsx
+++ b/packages/ui/src/components/overlays/dropdown-menu.tsx
@@ -164,7 +164,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
           // for grouped settings dropdowns.
           onSelect={(e) => e.preventDefault()}
           className={cn(
-            'focus:bg-accent focus:text-accent-foreground relative flex min-h-11 cursor-default items-center gap-2 rounded-md px-2 py-2 text-base transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+            'focus:bg-accent focus:text-accent-foreground relative flex min-h-11 cursor-default items-center gap-2 rounded-md px-2 py-2 text-base outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
             item.className,
           )}
         >
@@ -267,7 +267,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
             <DropdownMenuPrimitive.RadioItem
               key={option.value}
               value={option.value}
-              className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+              className="focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
             >
               <RadioIndicator />
               {option.label}
@@ -282,7 +282,7 @@ function renderItem(item: DropdownMenuItem, key: number) {
       const menuItem = (
         <DropdownMenuPrimitive.Item
           className={cn(
-            'focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+            'focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
             item.destructive && 'text-destructive focus:text-destructive',
             item.className,
           )}

--- a/packages/ui/src/components/overlays/responsive-dialog.tsx
+++ b/packages/ui/src/components/overlays/responsive-dialog.tsx
@@ -120,7 +120,7 @@ export const ResponsiveDialogContent = forwardRef<
     if (isMobile) {
       return (
         <DrawerPrimitive.Portal>
-          <DrawerPrimitive.Overlay className="bg-bg-overlay fixed inset-0 z-50" />
+          <DrawerPrimitive.Overlay className="bg-bg-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 duration-[var(--duration-short)] motion-reduce:animate-none" />
           <DrawerPrimitive.Content
             ref={ref}
             aria-modal="true"
@@ -131,7 +131,7 @@ export const ResponsiveDialogContent = forwardRef<
             className={cn(
               'bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex max-h-[92dvh] flex-col rounded-t-2xl',
               'pr-(--safe-right) pb-(--safe-bottom) pl-(--safe-left)',
-              'data-[state=open]:animate-in data-[state=closed]:animate-out',
+              'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4 data-[state=closed]:slide-out-to-bottom-4 duration-[var(--duration-standard)]',
               'motion-reduce:animate-none',
               className,
             )}
@@ -151,7 +151,7 @@ export const ResponsiveDialogContent = forwardRef<
         <DialogPrimitive.Overlay
           className={cn(
             'bg-bg-overlay fixed inset-0 z-50',
-            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 duration-[var(--duration-short)]',
             'motion-reduce:animate-none',
           )}
         />
@@ -168,7 +168,7 @@ export const ResponsiveDialogContent = forwardRef<
             // tall dialog (long form, comment/activity feeds) stays fully usable
             // instead of overflowing off-screen.
             'max-h-[90dvh] overflow-x-hidden overflow-y-auto',
-            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 duration-[var(--duration-standard)]',
             'motion-reduce:animate-none',
             className,
           )}

--- a/services/platform/app/components/ui/data-display/copyable-field.tsx
+++ b/services/platform/app/components/ui/data-display/copyable-field.tsx
@@ -80,75 +80,71 @@ const CopyableFieldBase = React.memo(function CopyableFieldBase({
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
       {label && <Label id={labelId}>{label}</Label>}
-      {/* Nested Provider only for disableHoverableContent — a single tip, so
-          skip-delay across the app is unaffected. */}
-      <TooltipPrimitive.Provider delayDuration={200} disableHoverableContent>
+      {/* AppShell owns TooltipProvider. Overflow tips stay on the trigger —
+          hovering the tip body is not required for a truncated value. */}
+      <TooltipPrimitive.Root>
         {/* Uncontrolled on purpose: gating happens by withholding the CONTENT
           below — flipping Radix between controlled and uncontrolled on the
           first hover leaves it stuck closed. */}
-        <TooltipPrimitive.Root>
-          <TooltipPrimitive.Trigger asChild>
-            <button
-              id={valueId}
-              type="button"
-              onClick={onClick}
-              onPointerEnter={syncOverflow}
-              onFocus={syncOverflow}
-              aria-labelledby={
-                label ? `${labelId} ${valueTextId}` : valueTextId
-              }
-              aria-label={copyAriaLabel}
-              aria-describedby={
-                [description ? descriptionId : null, copied ? statusId : null]
-                  .filter(Boolean)
-                  .join(' ') || undefined
-              }
+        <TooltipPrimitive.Trigger asChild>
+          <button
+            id={valueId}
+            type="button"
+            onClick={onClick}
+            onPointerEnter={syncOverflow}
+            onFocus={syncOverflow}
+            aria-labelledby={label ? `${labelId} ${valueTextId}` : valueTextId}
+            aria-label={copyAriaLabel}
+            aria-describedby={
+              [description ? descriptionId : null, copied ? statusId : null]
+                .filter(Boolean)
+                .join(' ') || undefined
+            }
+            className={cn(
+              'ring-border bg-muted/40 hover:bg-muted/60',
+              'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+              'flex w-full cursor-pointer items-center gap-2 rounded-lg border px-3 py-2.25 text-left transition-colors',
+              inputClassName,
+            )}
+          >
+            <span
+              id={valueTextId}
+              ref={valueTextRef}
               className={cn(
-                'ring-border bg-muted/40 hover:bg-muted/60',
-                'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-                'flex w-full cursor-pointer items-center gap-2 rounded-lg border px-3 py-2.25 text-left transition-colors',
-                inputClassName,
+                'text-muted-foreground flex-1 truncate text-sm',
+                mono && 'font-mono',
               )}
             >
-              <span
-                id={valueTextId}
-                ref={valueTextRef}
-                className={cn(
-                  'text-muted-foreground flex-1 truncate text-sm',
-                  mono && 'font-mono',
-                )}
-              >
-                {value}
-              </span>
-              {copied ? (
-                <Check
-                  className="size-4 shrink-0 text-green-600 dark:text-green-400"
-                  aria-hidden="true"
-                />
-              ) : (
-                <Copy
-                  className="text-muted-foreground size-4 shrink-0"
-                  aria-hidden="true"
-                />
+              {value}
+            </span>
+            {copied ? (
+              <Check
+                className="size-4 shrink-0 text-green-600 dark:text-green-400"
+                aria-hidden="true"
+              />
+            ) : (
+              <Copy
+                className="text-muted-foreground size-4 shrink-0"
+                aria-hidden="true"
+              />
+            )}
+          </button>
+        </TooltipPrimitive.Trigger>
+        {overflowing && (
+          <TooltipPrimitive.Portal>
+            <TooltipContent
+              side="top"
+              collisionPadding={8}
+              className={cn(
+                'max-w-[min(90vw,40rem)] break-all',
+                mono && 'font-mono',
               )}
-            </button>
-          </TooltipPrimitive.Trigger>
-          {overflowing && (
-            <TooltipPrimitive.Portal>
-              <TooltipContent
-                side="top"
-                collisionPadding={8}
-                className={cn(
-                  'max-w-[min(90vw,40rem)] break-all',
-                  mono && 'font-mono',
-                )}
-              >
-                {value}
-              </TooltipContent>
-            </TooltipPrimitive.Portal>
-          )}
-        </TooltipPrimitive.Root>
-      </TooltipPrimitive.Provider>
+            >
+              {value}
+            </TooltipContent>
+          </TooltipPrimitive.Portal>
+        )}
+      </TooltipPrimitive.Root>
       {description && (
         <Description id={descriptionId}>{description}</Description>
       )}

--- a/services/platform/app/components/ui/dialog/dialog.tsx
+++ b/services/platform/app/components/ui/dialog/dialog.tsx
@@ -29,7 +29,7 @@ const dialogContentVariants = cva(
   // while the middle section scrolls. `overflow-hidden` + `min-h-0` make
   // `max-h` win: without them a flex item's `min-height: auto` grows the
   // shell past the viewport, and `top-1/2 -translate-y-1/2` clips both ends.
-  'ring-border bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed z-50 flex min-h-0 flex-col gap-4 overflow-hidden border-none shadow-lg ring-1 duration-200 motion-reduce:animate-none ' +
+  'ring-border bg-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed z-50 flex min-h-0 flex-col gap-4 overflow-hidden border-none shadow-lg ring-1 duration-[var(--duration-standard)] motion-reduce:animate-none ' +
     // Mobile: bottom sheet
     'data-[state=open]:slide-in-from-bottom-4 data-[state=closed]:slide-out-to-bottom-4 inset-x-0 top-auto right-0 bottom-0 left-0 max-h-[88dvh] w-full max-w-full rounded-t-2xl rounded-b-none p-4 pb-[calc(env(safe-area-inset-bottom,0px)+1rem)] ' +
     // md+: centered dialog. `md:left-1/2 md:right-auto` is the correct
@@ -199,7 +199,7 @@ export function Dialog({
         <DialogDepthContext.Provider value={parentDepth + 1}>
           {!isNested && (
             <DialogPrimitive.Overlay
-              className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80"
+              className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 duration-[var(--duration-short)] motion-reduce:animate-none"
               onClick={(e) => e.stopPropagation()}
             />
           )}

--- a/services/platform/app/components/ui/forms/multi-select.tsx
+++ b/services/platform/app/components/ui/forms/multi-select.tsx
@@ -128,7 +128,7 @@ export interface MultiSelectProps {
 }
 
 const CONTENT_CLASSES =
-  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+  'z-50 min-w-[14.5rem] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[var(--radix-popover-content-transform-origin)] duration-[var(--duration-short)] motion-reduce:animate-none';
 
 function defaultFilterFn(option: MultiSelectOption, query: string) {
   const lower = query.toLowerCase();
@@ -621,7 +621,7 @@ function MultiSelectOptionItem({
       onClick={() => !option.disabled && onToggle(option.value)}
       onMouseEnter={() => onMouseEnter(index)}
       className={cn(
-        'group/option flex w-full cursor-default gap-2 rounded-md p-2 text-left text-sm transition-colors',
+        'group/option flex w-full cursor-default gap-2 rounded-md p-2 text-left text-sm',
         showDescription ? 'items-start' : 'items-center',
         isHighlighted && 'bg-accent',
         option.disabled && 'pointer-events-none opacity-50',

--- a/services/platform/app/components/ui/forms/searchable-select.tsx
+++ b/services/platform/app/components/ui/forms/searchable-select.tsx
@@ -149,7 +149,7 @@ export interface SearchableSelectProps {
 // floor so compact toolbar triggers (agent/model pickers) still open a usable
 // width; content can grow it wider than either bound.
 const CONTENT_CLASSES =
-  'z-50 min-w-[max(14.5rem,var(--radix-popover-trigger-width))] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+  'z-50 min-w-[max(14.5rem,var(--radix-popover-trigger-width))] rounded-lg ring-1 ring-border bg-popover text-popover-foreground dark:bg-muted shadow-md outline-none p-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[var(--radix-popover-content-transform-origin)] duration-[var(--duration-short)] motion-reduce:animate-none';
 
 function defaultFilterFn(option: SearchableSelectOption, query: string) {
   const lower = query.toLowerCase();

--- a/services/platform/app/components/ui/forms/select.tsx
+++ b/services/platform/app/components/ui/forms/select.tsx
@@ -23,7 +23,7 @@ const selectContentVariants = cva(
   // could extend past the edge and clip its first option (e.g. "End workflow")
   // behind the scroll buttons. The `,24rem` fallback keeps the cap for the
   // `item-aligned` position, where Radix does not expose the available-height var.
-  'bg-popover text-popover-foreground dark:bg-muted data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height,24rem))] min-w-[8rem] overflow-hidden rounded-md border shadow-md',
+  'bg-popover text-popover-foreground dark:bg-muted data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height,24rem))] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-hidden rounded-md border shadow-md duration-[var(--duration-short)] motion-reduce:animate-none',
   {
     variants: {
       position: {

--- a/services/platform/app/components/ui/overlays/sheet.tsx
+++ b/services/platform/app/components/ui/overlays/sheet.tsx
@@ -210,7 +210,7 @@ export function Sheet({
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80" />
+        <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 duration-[var(--duration-short)] motion-reduce:animate-none" />
         <DialogPrimitive.Content
           aria-modal="true"
           className={cn(sheetVariants({ side, size }), widthClass, className)}

--- a/services/platform/app/features/automations/components/blank-automation-dialog.tsx
+++ b/services/platform/app/features/automations/components/blank-automation-dialog.tsx
@@ -322,7 +322,7 @@ export function BlankAutomationDialog({
           {t('blank.next')}
         </Button>
       ) : (
-        <Button type="submit" disabled={!canSubmitStep2 || submitting}>
+        <Button type="submit" disabled={!canSubmitStep2} isLoading={submitting}>
           {submitting ? t('blank.submitting') : t('blank.submit')}
         </Button>
       )}

--- a/services/platform/app/features/settings/credentials/credential-add-dialog.tsx
+++ b/services/platform/app/features/settings/credentials/credential-add-dialog.tsx
@@ -208,7 +208,8 @@ export function CredentialAddDialog<
             <Button
               type="submit"
               form={formId}
-              disabled={create.isPending || !isValid}
+              disabled={!isValid}
+              isLoading={create.isPending}
             >
               {create.isPending
                 ? tCommon('actions.saving')

--- a/services/platform/app/features/skills/components/skill-detail-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-detail-pane.tsx
@@ -235,7 +235,8 @@ export function SkillDetailPane({
           {canEdit && (
             <Button
               onClick={() => void save()}
-              disabled={!dirty || teamsMissing || saveSkill.isPending}
+              disabled={!dirty || teamsMissing}
+              isLoading={saveSkill.isPending}
             >
               {saveSkill.isPending
                 ? tCommon('actions.saving')

--- a/services/platform/app/features/skills/components/skill-upload/skill-upload-pane.tsx
+++ b/services/platform/app/features/skills/components/skill-upload/skill-upload-pane.tsx
@@ -120,7 +120,8 @@ export function SkillUploadPane({
               <Button
                 type="button"
                 onClick={() => void submit(false)}
-                disabled={!state.parsedBundle || state.isSubmitting}
+                disabled={!state.parsedBundle}
+                isLoading={state.isSubmitting}
               >
                 {state.isSubmitting
                   ? t('upload.submitting')

--- a/services/platform/app/features/tasks/components/label-editor.tsx
+++ b/services/platform/app/features/tasks/components/label-editor.tsx
@@ -164,7 +164,7 @@ export function LabelEditor({
                   onClick={() => toggleLabel(option.name)}
                   onMouseEnter={() => setHighlighted(index)}
                   className={cn(
-                    'flex w-full cursor-default items-center gap-2 rounded-md p-2 text-left text-sm transition-colors',
+                    'flex w-full cursor-default items-center gap-2 rounded-md p-2 text-left text-sm',
                     highlighted === index && 'bg-accent',
                   )}
                 >

--- a/services/platform/app/features/tasks/components/task-modal.tsx
+++ b/services/platform/app/features/tasks/components/task-modal.tsx
@@ -620,7 +620,7 @@ function TemplateCreateBody({
                 attribute — one action row beside Cancel. (In the auto-height
                 create dialog this row scrolls with the page; only the
                 fixed-height edit dialog truly pins its footer.) */}
-            <Button type="submit" form={SETUP_FORM_ID} disabled={setupSaving}>
+            <Button type="submit" form={SETUP_FORM_ID} isLoading={setupSaving}>
               {tAutomations('settings.saveAndContinue')}
             </Button>
           </Row>
@@ -667,7 +667,8 @@ function TemplateCreateBody({
             {cancelButton}
             <Button
               onClick={() => void submit()}
-              disabled={submitting || !nameOk}
+              disabled={!nameOk}
+              isLoading={submitting}
             >
               {t('actions.create')}
             </Button>
@@ -945,7 +946,8 @@ function CreateTaskBody({
             </Button>
             <Button
               onClick={() => void submit()}
-              disabled={submitting || title.trim().length === 0}
+              disabled={title.trim().length === 0}
+              isLoading={submitting}
             >
               {t('actions.create')}
             </Button>

--- a/services/platform/app/routes/2fa-enroll.tsx
+++ b/services/platform/app/routes/2fa-enroll.tsx
@@ -195,7 +195,11 @@ export function TwoFactorEnrollPage() {
                     errorMessage={error ?? undefined}
                     disabled={submitting}
                   />
-                  <Button type="submit" disabled={!password || submitting}>
+                  <Button
+                    type="submit"
+                    disabled={!password}
+                    isLoading={submitting}
+                  >
                     {t('enrollment.enableButton')}
                   </Button>
                 </Stack>
@@ -255,7 +259,8 @@ export function TwoFactorEnrollPage() {
                 />
                 <Button
                   type="submit"
-                  disabled={!/^\d{6}$/.test(code) || submitting}
+                  disabled={!/^\d{6}$/.test(code)}
+                  isLoading={submitting}
                 >
                   {t('setup.verifyButton')}
                 </Button>

--- a/services/platform/app/routes/_auth/2fa.tsx
+++ b/services/platform/app/routes/_auth/2fa.tsx
@@ -168,7 +168,7 @@ function TwoFactorVerifyPage() {
           </FormSection>
 
           <Stack gap={3} className="pt-2">
-            <Button type="submit" disabled={!canSubmit || submitting}>
+            <Button type="submit" disabled={!canSubmit} isLoading={submitting}>
               {submitting
                 ? t('verify.submitButton') + '…'
                 : t('verify.submitButton')}

--- a/services/platform/app/routes/_auth/log-in.tsx
+++ b/services/platform/app/routes/_auth/log-in.tsx
@@ -540,7 +540,12 @@ export function LogInPage() {
               </div>
             )}
 
-            <Button type="submit" fullWidth disabled={isSubmitting || !isValid}>
+            <Button
+              type="submit"
+              fullWidth
+              disabled={!isValid}
+              isLoading={isSubmitting}
+            >
               {isSubmitting ? t('login.signingIn') : t('login.loginButton')}
             </Button>
           </Form>


### PR DESCRIPTION
## Summary
Follow-up to #3276 (stack on that branch). Closes the leftovers from the Emil taste audit:

- Remove nested `TooltipProvider`s from ChartCard, ProgressBar, and CopyableField so AppShell skip-delay works across analytics + credentials UI.
- Select / searchable-select / multi-select popovers get origin-aware transform, `--duration-short`, and `motion-reduce`.
- Drop `transition-colors` on multi-select, label-editor, and dropdown menu keyboard/focus rows.
- Wire `Button isLoading` on log-in, 2FA, credential create, skill save/upload, blank automation, and task create/setup submits.
- Dialog/Sheet overlays + ResponsiveDialog enter/exit get fade + tokenized duration + reduced-motion.

## Test plan
- [ ] Hover chart info tip then a rail tip — skip-delay still works (no extra wait).
- [ ] Open Select / MultiSelect / SearchableSelect — fade/slide, origin feels attached to trigger.
- [ ] Arrow through multi-select / dropdown / label editor — highlight jumps with no color fade lag.
- [ ] Log in / 2FA / create credential / save skill / create automation / create task — spinner on primary while pending.
- [ ] Open task modal (ResponsiveDialog) and settings sheet — overlay fades; reduce-motion disables motion.
- [ ] Merge/land only after #3276 (this PR targets that branch).