### PR TITLE
feat(platform): open routing Add rule from Auto assign prefilled

### DIFF
--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
@@ -53,6 +53,7 @@ vi.mock('@tanstack/react-router', () => ({
     to,
     hash,
     params,
+    search,
     onClick,
     className,
   }: {
@@ -60,18 +61,29 @@ vi.mock('@tanstack/react-router', () => ({
     to: string;
     hash?: string;
     params?: { id: string };
+    search?: { openRoutingRule?: string; routingAddress?: string };
     onClick?: () => void;
     className?: string;
-  }) => (
-    <a
-      href={`${to}${hash ? `#${hash}` : ''}`}
-      data-org={params?.id}
-      className={className}
-      onClick={onClick}
-    >
-      {children}
-    </a>
-  ),
+  }) => {
+    const qs = new URLSearchParams();
+    if (search?.openRoutingRule) {
+      qs.set('openRoutingRule', search.openRoutingRule);
+    }
+    if (search?.routingAddress) {
+      qs.set('routingAddress', search.routingAddress);
+    }
+    const query = qs.toString();
+    return (
+      <a
+        href={`${to}${query ? `?${query}` : ''}${hash ? `#${hash}` : ''}`}
+        data-org={params?.id}
+        className={className}
+        onClick={onClick}
+      >
+        {children}
+      </a>
+    );
+  },
 }));
 
 vi.mock('@/app/components/ui/forms/searchable-select', () => ({
@@ -95,6 +107,8 @@ function makeConversation(
   overrides: {
     assigneeUserId?: string;
     assigneeTeamId?: string;
+    direction?: 'inbound' | 'outbound';
+    metadata?: Record<string, unknown>;
   } = {},
 ) {
   return {
@@ -167,9 +181,27 @@ describe('ConversationAssigneePicker', () => {
     const link = screen.getByRole('link', { name: /auto assign/i });
     expect(link).toHaveAttribute(
       'href',
-      '/dashboard/$id/settings/governance/policies-limits#conversation-routing',
+      '/dashboard/$id/settings/governance/policies-limits?openRoutingRule=1#conversation-routing',
     );
     expect(link).toHaveAttribute('data-org', 'org-1');
+  });
+
+  it('prefills Auto assign with the inbound mailbox address', () => {
+    render(
+      <ConversationAssigneePicker
+        conversation={makeConversation({
+          direction: 'inbound',
+          metadata: { to: [{ address: 'billing@acme.test' }] },
+        })}
+        organizationId="org-1"
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /auto assign/i });
+    expect(link).toHaveAttribute(
+      'href',
+      '/dashboard/$id/settings/governance/policies-limits?openRoutingRule=1&routingAddress=billing%40acme.test#conversation-routing',
+    );
   });
 
   it('shows Unassign and Auto assign together when a person is assigned', () => {

--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
@@ -53,7 +53,7 @@ vi.mock('@tanstack/react-router', () => ({
     to,
     hash,
     params,
-    search,
+    state,
     onClick,
     className,
   }: {
@@ -61,29 +61,20 @@ vi.mock('@tanstack/react-router', () => ({
     to: string;
     hash?: string;
     params?: { id: string };
-    search?: { openRoutingRule?: string; routingAddress?: string };
+    state?: { openRoutingRule?: boolean; routingAddress?: string };
     onClick?: () => void;
     className?: string;
-  }) => {
-    const qs = new URLSearchParams();
-    if (search?.openRoutingRule) {
-      qs.set('openRoutingRule', search.openRoutingRule);
-    }
-    if (search?.routingAddress) {
-      qs.set('routingAddress', search.routingAddress);
-    }
-    const query = qs.toString();
-    return (
-      <a
-        href={`${to}${query ? `?${query}` : ''}${hash ? `#${hash}` : ''}`}
-        data-org={params?.id}
-        className={className}
-        onClick={onClick}
-      >
-        {children}
-      </a>
-    );
-  },
+  }) => (
+    <a
+      href={`${to}${hash ? `#${hash}` : ''}`}
+      data-org={params?.id}
+      data-state={state ? JSON.stringify(state) : undefined}
+      className={className}
+      onClick={onClick}
+    >
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('@/app/components/ui/forms/searchable-select', () => ({
@@ -181,12 +172,16 @@ describe('ConversationAssigneePicker', () => {
     const link = screen.getByRole('link', { name: /auto assign/i });
     expect(link).toHaveAttribute(
       'href',
-      '/dashboard/$id/settings/governance/policies-limits?openRoutingRule=1#conversation-routing',
+      '/dashboard/$id/settings/governance/policies-limits#conversation-routing',
     );
     expect(link).toHaveAttribute('data-org', 'org-1');
+    expect(link).toHaveAttribute(
+      'data-state',
+      JSON.stringify({ openRoutingRule: true }),
+    );
   });
 
-  it('prefills Auto assign with the inbound mailbox address', () => {
+  it('passes the inbound mailbox address via location state, not the URL', () => {
     render(
       <ConversationAssigneePicker
         conversation={makeConversation({
@@ -200,7 +195,15 @@ describe('ConversationAssigneePicker', () => {
     const link = screen.getByRole('link', { name: /auto assign/i });
     expect(link).toHaveAttribute(
       'href',
-      '/dashboard/$id/settings/governance/policies-limits?openRoutingRule=1&routingAddress=billing%40acme.test#conversation-routing',
+      '/dashboard/$id/settings/governance/policies-limits#conversation-routing',
+    );
+    expect(link.getAttribute('href')).not.toContain('routingAddress');
+    expect(link).toHaveAttribute(
+      'data-state',
+      JSON.stringify({
+        openRoutingRule: true,
+        routingAddress: 'billing@acme.test',
+      }),
     );
   });
 

--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
@@ -14,8 +14,8 @@ import { useOrgTeams } from '@/app/features/settings/teams/hooks/queries';
 import { AssigneeAvatar } from '@/app/features/tasks/components/assignee-avatar';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { toast } from '@/app/hooks/use-toast';
-import { mailboxSideAddress } from '@/backend/core/conversations/reply_from';
 import { useT } from '@/lib/i18n/client';
+import { mailboxSideAddress } from '@/lib/shared/conversations/reply-from';
 import { isRecord } from '@/lib/utils/type-utils';
 
 import {
@@ -314,11 +314,11 @@ export function ConversationAssigneePicker({
           <Link
             to="/dashboard/$id/settings/governance/policies-limits"
             params={{ id: organizationId }}
-            search={{
-              openRoutingRule: '1',
+            hash="conversation-routing"
+            state={{
+              openRoutingRule: true,
               ...(routingAddress ? { routingAddress } : {}),
             }}
-            hash="conversation-routing"
             className="hover:bg-muted flex w-full items-center gap-1.5 rounded-md px-3 py-1.5 text-sm"
             onClick={() => setOpen(false)}
           >

--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
@@ -14,7 +14,9 @@ import { useOrgTeams } from '@/app/features/settings/teams/hooks/queries';
 import { AssigneeAvatar } from '@/app/features/tasks/components/assignee-avatar';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { toast } from '@/app/hooks/use-toast';
+import { mailboxSideAddress } from '@/backend/core/conversations/reply_from';
 import { useT } from '@/lib/i18n/client';
+import { isRecord } from '@/lib/utils/type-utils';
 
 import {
   useAssignConversation,
@@ -68,6 +70,10 @@ export function ConversationAssigneePicker({
   const assigneeName = assignee?.displayName ?? assignee?.email;
   const team = teams.find((tm) => tm.id === assigneeTeamId);
   const teamName = team?.name;
+  const routingAddress = mailboxSideAddress(
+    isRecord(conversation.metadata) ? conversation.metadata : undefined,
+    conversation.direction,
+  );
 
   // Trigger content for the assign control.
   //
@@ -308,6 +314,10 @@ export function ConversationAssigneePicker({
           <Link
             to="/dashboard/$id/settings/governance/policies-limits"
             params={{ id: organizationId }}
+            search={{
+              openRoutingRule: '1',
+              ...(routingAddress ? { routingAddress } : {}),
+            }}
             hash="conversation-routing"
             className="hover:bg-muted flex w-full items-center gap-1.5 rounded-md px-3 py-1.5 text-sm"
             onClick={() => setOpen(false)}

--- a/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.test.tsx
@@ -1,8 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { render, screen } from '@/tests/utils/render';
+import { render, screen, waitFor } from '@/tests/utils/render';
 
 import { ConversationRoutingPolicyEditor } from './conversation-routing-policy-editor';
+
+const navigate = vi.fn();
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
 
 vi.mock('@/app/hooks/use-organization-id', () => ({
   useOrganizationId: () => 'org-1',
@@ -78,5 +88,43 @@ describe('ConversationRoutingPolicyEditor', () => {
     render(<ConversationRoutingPolicyEditor organizationId="org-1" />);
     expect(screen.getByRole('button', { name: /add rule/i })).toBeDisabled();
     ability.cannot = () => false;
+  });
+
+  it('opens Add rule prefilled from a deep-link and clears the search params', async () => {
+    navigate.mockClear();
+    state.isLoading = false;
+    state.config = { enabled: true, rules: [] };
+    render(
+      <ConversationRoutingPolicyEditor
+        organizationId="org-1"
+        openAddRule
+        initialAddress="billing@acme.test"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('billing@acme.test')).toBeInTheDocument();
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/dashboard/$id/settings/governance/policies-limits',
+        params: { id: 'org-1' },
+        hash: 'conversation-routing',
+        replace: true,
+      }),
+    );
+    const call = navigate.mock.calls[0]?.[0] as {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(
+      call.search({
+        openRoutingRule: '1',
+        routingAddress: 'billing@acme.test',
+      }),
+    ).toEqual({
+      openRoutingRule: undefined,
+      routingAddress: undefined,
+    });
   });
 });

--- a/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.test.tsx
@@ -90,7 +90,7 @@ describe('ConversationRoutingPolicyEditor', () => {
     ability.cannot = () => false;
   });
 
-  it('opens Add rule prefilled from a deep-link and clears the search params', async () => {
+  it('opens Add rule prefilled from location state and clears that state', async () => {
     navigate.mockClear();
     state.isLoading = false;
     state.config = { enabled: true, rules: [] };
@@ -115,16 +115,16 @@ describe('ConversationRoutingPolicyEditor', () => {
       }),
     );
     const call = navigate.mock.calls[0]?.[0] as {
-      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+      state: (prev: {
+        openRoutingRule?: boolean;
+        routingAddress?: string;
+      }) => Record<string, unknown>;
     };
     expect(
-      call.search({
-        openRoutingRule: '1',
+      call.state({
+        openRoutingRule: true,
         routingAddress: 'billing@acme.test',
       }),
-    ).toEqual({
-      openRoutingRule: undefined,
-      routingAddress: undefined,
-    });
+    ).toEqual({});
   });
 });

--- a/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
@@ -413,8 +413,8 @@ export function ConversationRoutingPolicyEditor({
     setDialogOpen(true);
   }, []);
 
-  // Inbox Auto assign deep link: open Add rule once with the thread address,
-  // then strip the search params so refresh/back does not reopen the dialog.
+  // Inbox Auto assign handoff: open Add rule once with the thread address from
+  // history state, then clear that state so refresh/back does not reopen.
   useEffect(() => {
     if (!openAddRule) return;
     setEditingIndex(null);
@@ -423,12 +423,13 @@ export function ConversationRoutingPolicyEditor({
     void navigate({
       to: '/dashboard/$id/settings/governance/policies-limits',
       params: { id: organizationId },
-      search: (prev) => ({
-        ...prev,
-        openRoutingRule: undefined,
-        routingAddress: undefined,
-      }),
       hash: 'conversation-routing',
+      state: (prev) => {
+        const next = { ...prev };
+        delete next.openRoutingRule;
+        delete next.routingAddress;
+        return next;
+      },
       replace: true,
     });
   }, [openAddRule, initialAddress, navigate, organizationId]);

--- a/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
@@ -14,6 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from '@tale/ui/table';
+import { useNavigate } from '@tanstack/react-router';
 import { Check, ChevronDown, Signpost, Trash2, Users } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -292,6 +293,10 @@ function RuleDialog({
 
 interface ConversationRoutingPolicyEditorProps {
   organizationId: string;
+  /** One-shot deep link: open the Add rule dialog (from inbox Auto assign). */
+  openAddRule?: boolean;
+  /** Prefill for the Address field when `openAddRule` is set. */
+  initialAddress?: string;
 }
 
 /**
@@ -303,10 +308,13 @@ interface ConversationRoutingPolicyEditorProps {
  */
 export function ConversationRoutingPolicyEditor({
   organizationId,
+  openAddRule = false,
+  initialAddress,
 }: ConversationRoutingPolicyEditorProps) {
   const { t } = useT('governance');
   const { toast } = useToast();
   const ability = useAbility();
+  const navigate = useNavigate();
 
   const { data: policy, isLoading } = useGovernancePolicy(
     organizationId,
@@ -404,6 +412,26 @@ export function ConversationRoutingPolicyEditor({
     setDialogRule(emptyRule());
     setDialogOpen(true);
   }, []);
+
+  // Inbox Auto assign deep link: open Add rule once with the thread address,
+  // then strip the search params so refresh/back does not reopen the dialog.
+  useEffect(() => {
+    if (!openAddRule) return;
+    setEditingIndex(null);
+    setDialogRule({ address: initialAddress?.trim() ?? '' });
+    setDialogOpen(true);
+    void navigate({
+      to: '/dashboard/$id/settings/governance/policies-limits',
+      params: { id: organizationId },
+      search: (prev) => ({
+        ...prev,
+        openRoutingRule: undefined,
+        routingAddress: undefined,
+      }),
+      hash: 'conversation-routing',
+      replace: true,
+    });
+  }, [openAddRule, initialAddress, navigate, organizationId]);
 
   const openEditDialog = useCallback(
     (index: number) => {

--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -98,4 +98,10 @@ declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;
   }
+
+  /** One-shot handoffs that must not land in the URL (see Auto assign → routing). */
+  interface HistoryState {
+    openRoutingRule?: boolean;
+    routingAddress?: string;
+  }
 }

--- a/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
 import { EditorGroup } from '@/app/components/ui/editor';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
@@ -12,9 +13,16 @@ import { UploadPolicyEditor } from '@/app/features/settings/governance/component
 import { VoiceOutputPolicyEditor } from '@/app/features/settings/governance/components/voice-output-policy-editor';
 import { ensureGovernancePolicies } from '@/app/lib/loader-preload';
 
+/** Deep-link from the inbox Auto assign control: open Add rule + optional address. */
+const searchSchema = z.object({
+  openRoutingRule: z.string().optional(),
+  routingAddress: z.string().optional(),
+});
+
 export const Route = createFileRoute(
   '/dashboard/$id/settings/governance/policies-limits',
 )({
+  validateSearch: searchSchema,
   // Warm every policy the editors on this page read, so they paint real
   // content on first render (no skeleton flash, no staggered reveal).
   loader: ({ context, params }) =>
@@ -36,6 +44,7 @@ export const Route = createFileRoute(
 
 function PoliciesLimitsRoute() {
   const { id: organizationId } = Route.useParams();
+  const { openRoutingRule, routingAddress } = Route.useSearch();
 
   return (
     <SettingsPage>
@@ -47,7 +56,11 @@ function PoliciesLimitsRoute() {
         <PersonalizationPolicyEditor organizationId={organizationId} />
         <VoiceOutputPolicyEditor organizationId={organizationId} />
         <SandboxQuotaEditor organizationId={organizationId} />
-        <ConversationRoutingPolicyEditor organizationId={organizationId} />
+        <ConversationRoutingPolicyEditor
+          organizationId={organizationId}
+          openAddRule={Boolean(openRoutingRule)}
+          initialAddress={routingAddress}
+        />
       </EditorGroup>
     </SettingsPage>
   );

--- a/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
@@ -1,5 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router';
-import { z } from 'zod';
+import { createFileRoute, useRouterState } from '@tanstack/react-router';
 
 import { EditorGroup } from '@/app/components/ui/editor';
 import { SettingsPage } from '@/app/features/settings/components/settings-page';
@@ -13,16 +12,9 @@ import { UploadPolicyEditor } from '@/app/features/settings/governance/component
 import { VoiceOutputPolicyEditor } from '@/app/features/settings/governance/components/voice-output-policy-editor';
 import { ensureGovernancePolicies } from '@/app/lib/loader-preload';
 
-/** Deep-link from the inbox Auto assign control: open Add rule + optional address. */
-const searchSchema = z.object({
-  openRoutingRule: z.string().optional(),
-  routingAddress: z.string().optional(),
-});
-
 export const Route = createFileRoute(
   '/dashboard/$id/settings/governance/policies-limits',
 )({
-  validateSearch: searchSchema,
   // Warm every policy the editors on this page read, so they paint real
   // content on first render (no skeleton flash, no staggered reveal).
   loader: ({ context, params }) =>
@@ -44,7 +36,11 @@ export const Route = createFileRoute(
 
 function PoliciesLimitsRoute() {
   const { id: organizationId } = Route.useParams();
-  const { openRoutingRule, routingAddress } = Route.useSearch();
+  // Inbox Auto assign passes open + address via history state (not search), so
+  // the mailbox address never appears in the URL / logs / Referer.
+  const { openRoutingRule, routingAddress } = useRouterState({
+    select: (s) => s.location.state,
+  });
 
   return (
     <SettingsPage>


### PR DESCRIPTION
## Summary
- Deep-link the conversation Assign picker's **Auto assign** control to Policies & limits with `?openRoutingRule=1&routingAddress=…`
- Open the conversation-routing **Add rule** dialog on arrival, prefilled with the thread's mailbox address (`mailboxSideAddress`)
- Clear the search params after opening so refresh/back does not reopen the dialog

## Test plan
- [ ] Open an inbound conversation with a known To address; open Assign → **Auto assign**
- [ ] Confirm you land on Settings → Governance → Policies & limits, scrolled to Conversation routing
- [ ] Confirm the Add rule modal is open with that address prefilled
- [ ] Close the modal and refresh — dialog should stay closed
- [ ] **Add rule** / edit / empty-table flows still work without search params
- [ ] UI tests: `bun run --filter @tale/platform test:ui -- conversation-assignee-picker.test.tsx conversation-routing-policy-editor.test.tsx`