### PR TITLE
feat(platform): orient Auto assign with return to conversation

### DIFF
--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.test.tsx
@@ -61,7 +61,11 @@ vi.mock('@tanstack/react-router', () => ({
     to: string;
     hash?: string;
     params?: { id: string };
-    state?: { openRoutingRule?: boolean; routingAddress?: string };
+    state?: {
+      openRoutingRule?: boolean;
+      routingAddress?: string;
+      returnToConversation?: { id: string; status: string };
+    };
     onClick?: () => void;
     className?: string;
   }) => (
@@ -177,7 +181,10 @@ describe('ConversationAssigneePicker', () => {
     expect(link).toHaveAttribute('data-org', 'org-1');
     expect(link).toHaveAttribute(
       'data-state',
-      JSON.stringify({ openRoutingRule: true }),
+      JSON.stringify({
+        openRoutingRule: true,
+        returnToConversation: { id: 'conv-1', status: 'open' },
+      }),
     );
   });
 
@@ -203,6 +210,7 @@ describe('ConversationAssigneePicker', () => {
       JSON.stringify({
         openRoutingRule: true,
         routingAddress: 'billing@acme.test',
+        returnToConversation: { id: 'conv-1', status: 'open' },
       }),
     );
   });

--- a/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
+++ b/services/platform/app/features/conversations/components/conversation-assignee-picker.tsx
@@ -74,6 +74,12 @@ export function ConversationAssigneePicker({
     isRecord(conversation.metadata) ? conversation.metadata : undefined,
     conversation.direction,
   );
+  const inboxStatus =
+    conversation.status === 'closed' ||
+    conversation.status === 'spam' ||
+    conversation.status === 'archived'
+      ? conversation.status
+      : 'open';
 
   // Trigger content for the assign control.
   //
@@ -318,6 +324,10 @@ export function ConversationAssigneePicker({
             state={{
               openRoutingRule: true,
               ...(routingAddress ? { routingAddress } : {}),
+              returnToConversation: {
+                id: conversation.id,
+                status: inboxStatus,
+              },
             }}
             className="hover:bg-muted flex w-full items-center gap-1.5 rounded-md px-3 py-1.5 text-sm"
             onClick={() => setOpen(false)}

--- a/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.test.tsx
@@ -11,6 +11,33 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
   return {
     ...actual,
     useNavigate: () => navigate,
+    Link: ({
+      children,
+      to,
+      params,
+      search,
+      className,
+    }: {
+      children: React.ReactNode;
+      to: string;
+      params?: { id: string; status?: string };
+      search?: { conversation?: string };
+      className?: string;
+    }) => {
+      const qs = search?.conversation
+        ? `?conversation=${search.conversation}`
+        : '';
+      const status = params?.status ? `/${params.status}` : '';
+      return (
+        <a
+          href={`${to}${status}${qs}`}
+          data-org={params?.id}
+          className={className}
+        >
+          {children}
+        </a>
+      );
+    },
   };
 });
 
@@ -90,7 +117,7 @@ describe('ConversationRoutingPolicyEditor', () => {
     ability.cannot = () => false;
   });
 
-  it('opens Add rule prefilled from location state and clears that state', async () => {
+  it('opens Add rule prefilled from a handoff and keeps the return target', async () => {
     navigate.mockClear();
     state.isLoading = false;
     state.config = { enabled: true, rules: [] };
@@ -99,6 +126,7 @@ describe('ConversationRoutingPolicyEditor', () => {
         organizationId="org-1"
         openAddRule
         initialAddress="billing@acme.test"
+        returnToConversation={{ id: 'conv-1', status: 'open' }}
       />,
     );
 
@@ -106,25 +134,43 @@ describe('ConversationRoutingPolicyEditor', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
     expect(screen.getByDisplayValue('billing@acme.test')).toBeInTheDocument();
-    expect(navigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: '/dashboard/$id/settings/governance/policies-limits',
-        params: { id: 'org-1' },
-        hash: 'conversation-routing',
-        replace: true,
-      }),
-    );
+    expect(
+      screen.getByText(/these rules live here under conversation routing/i),
+    ).toBeInTheDocument();
+    // Back link sits under the dialog (aria-hidden while modal is open).
+    expect(
+      screen.getByText('Back to conversation', { selector: 'a' }),
+    ).toBeInTheDocument();
+
     const call = navigate.mock.calls[0]?.[0] as {
       state: (prev: {
         openRoutingRule?: boolean;
         routingAddress?: string;
+        returnToConversation?: { id: string; status: string };
       }) => Record<string, unknown>;
     };
     expect(
       call.state({
         openRoutingRule: true,
         routingAddress: 'billing@acme.test',
+        returnToConversation: { id: 'conv-1', status: 'open' },
       }),
-    ).toEqual({});
+    ).toEqual({
+      returnToConversation: { id: 'conv-1', status: 'open' },
+    });
+  });
+
+  it('shows Back to conversation when a return target is present', () => {
+    state.isLoading = false;
+    state.config = { enabled: true, rules: [] };
+    render(
+      <ConversationRoutingPolicyEditor
+        organizationId="org-1"
+        returnToConversation={{ id: 'conv-9', status: 'closed' }}
+      />,
+    );
+
+    const back = screen.getByRole('link', { name: /back to conversation/i });
+    expect(back).toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
+++ b/services/platform/app/features/settings/governance/components/conversation-routing-policy-editor.tsx
@@ -14,8 +14,15 @@ import {
   TableHeader,
   TableRow,
 } from '@tale/ui/table';
-import { useNavigate } from '@tanstack/react-router';
-import { Check, ChevronDown, Signpost, Trash2, Users } from 'lucide-react';
+import { useNavigate, Link } from '@tanstack/react-router';
+import {
+  ArrowLeft,
+  Check,
+  ChevronDown,
+  Signpost,
+  Trash2,
+  Users,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ConfirmDialog } from '@/app/components/ui/dialog/confirm-dialog';
@@ -79,6 +86,8 @@ interface RuleDialogProps {
   rule: ConversationRoutingRule;
   onSave: (rule: ConversationRoutingRule) => void;
   title: string;
+  /** Orient handoff visitors: why this page, where rules live. */
+  description?: string;
   cannotManage: boolean;
   teamOptions: Option[];
   memberOptions: Option[];
@@ -90,6 +99,7 @@ function RuleDialog({
   rule: initialRule,
   onSave,
   title,
+  description,
   cannotManage,
   teamOptions,
   memberOptions,
@@ -172,6 +182,7 @@ function RuleDialog({
       open={open}
       onOpenChange={onOpenChange}
       title={title}
+      description={description}
       onSubmit={handleSubmit}
       submitText={t('conversationRouting.confirm')}
       isValid={isValid}
@@ -297,6 +308,11 @@ interface ConversationRoutingPolicyEditorProps {
   openAddRule?: boolean;
   /** Prefill for the Address field when `openAddRule` is set. */
   initialAddress?: string;
+  /** Return target while the Auto assign handoff is in flight. */
+  returnToConversation?: {
+    id: string;
+    status: 'open' | 'closed' | 'spam' | 'archived';
+  };
 }
 
 /**
@@ -310,6 +326,7 @@ export function ConversationRoutingPolicyEditor({
   organizationId,
   openAddRule = false,
   initialAddress,
+  returnToConversation,
 }: ConversationRoutingPolicyEditorProps) {
   const { t } = useT('governance');
   const { toast } = useToast();
@@ -349,6 +366,10 @@ export function ConversationRoutingPolicyEditor({
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [dialogRule, setDialogRule] = useState(emptyRule());
   const [deletingIndex, setDeletingIndex] = useState<number | null>(null);
+  // True for the Add rule open that came from inbox Auto assign — drives the
+  // orienting dialog description so visitors learn this page is the home of
+  // the feature.
+  const [fromHandoff, setFromHandoff] = useState(false);
 
   if (!isLoading && !initializedRef.current) {
     initializedRef.current = true;
@@ -409,15 +430,18 @@ export function ConversationRoutingPolicyEditor({
 
   const openAddDialog = useCallback(() => {
     setEditingIndex(null);
+    setFromHandoff(false);
     setDialogRule(emptyRule());
     setDialogOpen(true);
   }, []);
 
   // Inbox Auto assign handoff: open Add rule once with the thread address from
-  // history state, then clear that state so refresh/back does not reopen.
+  // history state, strip open/address so refresh does not reopen, but keep
+  // `returnToConversation` until Back is clicked.
   useEffect(() => {
     if (!openAddRule) return;
     setEditingIndex(null);
+    setFromHandoff(true);
     setDialogRule({ address: initialAddress?.trim() ?? '' });
     setDialogOpen(true);
     void navigate({
@@ -433,6 +457,11 @@ export function ConversationRoutingPolicyEditor({
       replace: true,
     });
   }, [openAddRule, initialAddress, navigate, organizationId]);
+
+  const handleDialogOpenChange = useCallback((open: boolean) => {
+    setDialogOpen(open);
+    if (!open) setFromHandoff(false);
+  }, []);
 
   const openEditDialog = useCallback(
     (index: number) => {
@@ -498,6 +527,20 @@ export function ConversationRoutingPolicyEditor({
           />
         }
       >
+        {returnToConversation ? (
+          <Link
+            to="/dashboard/$id/conversations/$status"
+            params={{
+              id: organizationId,
+              status: returnToConversation.status,
+            }}
+            search={{ conversation: returnToConversation.id }}
+            className="text-muted-foreground hover:text-foreground mb-4 inline-flex w-fit items-center gap-1.5 text-sm"
+          >
+            <ArrowLeft className="size-4 shrink-0" aria-hidden="true" />
+            {t('conversationRouting.backToConversation')}
+          </Link>
+        ) : null}
         {/* The rules table exists only while the section is on — a toggle
             hides its content rather than showing rules nothing applies. It
             stays mounted (masked) while loading so the skeleton keeps the
@@ -604,13 +647,18 @@ export function ConversationRoutingPolicyEditor({
         {dialogOpen && (
           <RuleDialog
             open={dialogOpen}
-            onOpenChange={setDialogOpen}
+            onOpenChange={handleDialogOpenChange}
             rule={dialogRule}
             onSave={handleDialogSave}
             title={
               editingIndex === null
                 ? t('conversationRouting.addRule')
                 : t('conversationRouting.editRule')
+            }
+            description={
+              fromHandoff && editingIndex === null
+                ? t('conversationRouting.handoffAddRuleDescription')
+                : undefined
             }
             cannotManage={cannotManage}
             teamOptions={teamOptions}

--- a/services/platform/app/router.tsx
+++ b/services/platform/app/router.tsx
@@ -103,5 +103,9 @@ declare module '@tanstack/react-router' {
   interface HistoryState {
     openRoutingRule?: boolean;
     routingAddress?: string;
+    returnToConversation?: {
+      id: string;
+      status: 'open' | 'closed' | 'spam' | 'archived';
+    };
   }
 }

--- a/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
+++ b/services/platform/app/routes/dashboard/$id/settings/governance/policies-limits.tsx
@@ -36,11 +36,13 @@ export const Route = createFileRoute(
 
 function PoliciesLimitsRoute() {
   const { id: organizationId } = Route.useParams();
-  // Inbox Auto assign passes open + address via history state (not search), so
-  // the mailbox address never appears in the URL / logs / Referer.
-  const { openRoutingRule, routingAddress } = useRouterState({
-    select: (s) => s.location.state,
-  });
+  // Inbox Auto assign passes open + address + return target via history state
+  // (not search), so the mailbox address never appears in the URL / logs /
+  // Referer. `returnToConversation` stays until Back is clicked.
+  const { openRoutingRule, routingAddress, returnToConversation } =
+    useRouterState({
+      select: (s) => s.location.state,
+    });
 
   return (
     <SettingsPage>
@@ -56,6 +58,7 @@ function PoliciesLimitsRoute() {
           organizationId={organizationId}
           openAddRule={Boolean(openRoutingRule)}
           initialAddress={routingAddress}
+          returnToConversation={returnToConversation}
         />
       </EditorGroup>
     </SettingsPage>

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -4027,6 +4027,11 @@ governance:
     noAssignees: Keine Personen oder Teams gefunden
     removePerson: Person entfernen
     removeTeam: Team entfernen
+    handoffAddRuleDescription:
+      Neue Post an diese Adresse wird automatisch zugewiesen. Die Regeln liegen
+      hier unter Konversations-Routing — du erreichst diese Seite jederzeit über
+      Einstellungen.
+    backToConversation: Zurück zur Konversation
 metrics:
   title: Metriken
   groups:

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -3882,6 +3882,11 @@ governance:
     noAssignees: No people or teams found
     removePerson: Remove person
     removeTeam: Remove team
+    handoffAddRuleDescription:
+      New mail sent to this address will be assigned automatically. These rules
+      live here under Conversation routing — open this page anytime from
+      Settings.
+    backToConversation: Back to conversation
 metrics:
   title: Metrics
   groups:

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -4101,6 +4101,11 @@ governance:
     noAssignees: Aucune personne ou équipe trouvée
     removePerson: Retirer la personne
     removeTeam: Retirer l'équipe
+    handoffAddRuleDescription:
+      Les nouveaux courriers envoyés à cette adresse seront assignés
+      automatiquement. Ces règles vivent ici sous Routage des conversations —
+      tu ouvres cette page à tout moment depuis Paramètres.
+    backToConversation: Retour à la conversation
 metrics:
   title: Métriques
   groups:


### PR DESCRIPTION
## Summary
- Keep Auto assign landing on Policies & limits so users learn where Conversation routing lives
- Add a handoff description on the Add rule dialog explaining that rules live on this page
- Pass `returnToConversation` in history state and show **Back to conversation** on the routing section

Follow-up to #3281 (address already travels via location state, not the URL).

## Test plan
- [ ] From an inbound conversation, Assign → **Auto assign**
- [ ] Land on Conversation routing with Add rule open, address prefilled, and orienting description
- [ ] See **Back to conversation**; click it and return to the same thread
- [ ] Manual **Add rule** (no handoff) has no handoff description and no back link
- [ ] UI tests: `bun run --filter @tale/platform test:ui -- conversation-assignee-picker.test.tsx conversation-routing-policy-editor.test.tsx`