### PR TITLE
fix(platform): index the documents a chat attaches

### DIFF
--- a/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
+++ b/services/platform/app/features/chat/hooks/use-file-indexing-status.ts
@@ -8,11 +8,7 @@ import { toast } from '@/app/hooks/use-toast';
 import { fileStatusesQuery } from '@/app/lib/backend/chat';
 import type { BlobRef } from '@/backend/core/lib/storage/blob_ref';
 import { useT } from '@/lib/i18n/client';
-import {
-  isAudioOrVideo,
-  isImage,
-  isRagIndexableFile,
-} from '@/lib/shared/file-types';
+import { shouldRagIndexOnUpload } from '@/lib/shared/file-types';
 
 import { useChatQueryClient } from '../data/chat-backend';
 
@@ -52,12 +48,7 @@ export function useFileIndexingStatus(
   const fileIds = useMemo(
     () =>
       attachments
-        .filter(
-          (a) =>
-            !isImage(a.fileType) &&
-            !isAudioOrVideo(a.fileType) &&
-            isRagIndexableFile(a.fileName, a.fileType),
-        )
+        .filter((a) => shouldRagIndexOnUpload(a.fileName, a.fileType))
         .map((a) => a.fileId),
     [attachments],
   );

--- a/services/platform/app/features/shared/files/use-file-upload.ts
+++ b/services/platform/app/features/shared/files/use-file-upload.ts
@@ -16,8 +16,8 @@ import {
   detectMediaMime,
   getMaxFileSizeForType,
   isAudioOrVideo,
-  isRagIndexableFile,
   resolveFileType,
+  shouldRagIndexOnUpload,
 } from '@/lib/shared/file-types';
 import { compressImage } from '@/lib/utils/compress-image';
 import { isTextBasedFile } from '@/lib/utils/text-file-types';
@@ -506,20 +506,21 @@ export function useFileUpload(config: FileUploadConfig) {
             pendingUploadsRef.current.delete(fileId);
             setAttachments((prev) => [...prev, attachment]);
 
-            // Files that get RAG-indexed (PDFs, docs, text — anything the
-            // backend queues; mirrors `shouldIndex` in saveFileMetadata) are
-            // not "done" once the bytes land: indexing runs asynchronously and
-            // can still fail with an "Index failed" badge. Showing
-            // "uploaded successfully" here would contradict that outcome
-            // (#1457). For those files we defer the success toast until
-            // indexing reaches a terminal state — `useFileIndexingStatus`
-            // fires success on `completed` and an error toast on `failed`.
-            // Non-indexed files (images, audio/video, unsupported types) have
-            // no further processing gate, so they keep the immediate toast.
+            // Files that get RAG-indexed (PDFs, docs, text — the set
+            // `shouldRagIndexOnUpload` names, which is exactly what
+            // `POST /files/register` queues) are not "done" once the bytes
+            // land: indexing runs asynchronously and can still fail with an
+            // "Index failed" badge. Showing "uploaded successfully" here
+            // would contradict that outcome (#1457). For those files we
+            // defer the success toast until indexing reaches a terminal
+            // state — `useFileIndexingStatus` fires success on `completed`
+            // and an error toast on `failed`. Non-indexed files (images,
+            // audio/video, unsupported types) have no further processing
+            // gate, so they keep the immediate toast — an image deferred to
+            // an index that never runs simply never gets one.
             const willIndex =
               !config.disableIndexing &&
-              !isAudioOrVideo(resolvedType) &&
-              isRagIndexableFile(
+              shouldRagIndexOnUpload(
                 fileToUpload.name,
                 resolvedType || 'application/octet-stream',
               );

--- a/services/platform/app/lib/backend/documents.ts
+++ b/services/platform/app/lib/backend/documents.ts
@@ -742,6 +742,7 @@ export const documentWriteAdapters: Record<string, WriteAdapter> = {
             ? { threadId: args.threadId }
             : {}),
           ...(typeof args.source === 'string' ? { source: args.source } : {}),
+          ...(args.skipRagIndexing === true ? { skipRagIndexing: true } : {}),
         },
       }).then((body) => body.fileId),
   },

--- a/services/platform/backend/core/chat/turn_action.ts
+++ b/services/platform/backend/core/chat/turn_action.ts
@@ -938,10 +938,21 @@ async function loadDocumentAppendix(
         internal.file_metadata.internal_queries.getByStorageId,
         { storageId: attachment.fileId },
       );
+      // No status at all means nothing ever started indexing this file —
+      // rows an instance carries from before registration queued it. Telling
+      // the model the content is unreadable would make that permanent, since
+      // chat offers no retry: start the run instead, and say so.
+      const ragStatus =
+        meta?.ragStatus ??
+        (await ctx.runMutation(
+          internal.file_metadata.internal_mutations.queueRagIndexIfUnstarted,
+          { storageId: attachment.fileId },
+        )) ??
+        undefined;
       return {
         fileName: attachment.fileName,
         fileId: attachment.fileId,
-        ragStatus: meta?.ragStatus,
+        ragStatus,
       };
     }),
   );

--- a/services/platform/backend/core/lib/handler_names.ts
+++ b/services/platform/backend/core/lib/handler_names.ts
@@ -180,6 +180,7 @@ interface HandlerNames {
       bindFileToConversation: FunctionRef;
       bindStorageIdsToThread: FunctionRef;
       linkDocumentToFile: FunctionRef;
+      queueRagIndexIfUnstarted: FunctionRef;
       releaseTranscriptionLock: FunctionRef;
       saveFileMetadata: FunctionRef;
       updateFileTranscription: FunctionRef;

--- a/services/platform/backend/core/lib/knowledge/extraction/pdf.test.ts
+++ b/services/platform/backend/core/lib/knowledge/extraction/pdf.test.ts
@@ -45,6 +45,7 @@ describe('extractTextFromPdfBytes', () => {
     expect(result.visionUsed).toBe(false);
     expect(result.scannedPagesDetected).toBe(0);
     expect(result.ocrApplied).toBe(false);
+    expect(result.pageCount).toBe(1);
   });
 
   it('prefixes each page with a page marker', async () => {
@@ -63,6 +64,7 @@ describe('extractTextFromPdfBytes', () => {
     expect(typeof result.visionUsed).toBe('boolean');
     expect(typeof result.scannedPagesDetected).toBe('number');
     expect(typeof result.ocrApplied).toBe('boolean');
+    expect(typeof result.pageCount).toBe('number');
   });
 
   it('invokes the progress callback per page', async () => {

--- a/services/platform/backend/core/lib/knowledge/extraction/pdf.ts
+++ b/services/platform/backend/core/lib/knowledge/extraction/pdf.ts
@@ -33,6 +33,9 @@ export interface PdfExtractionResult {
   visionUsed: boolean;
   scannedPagesDetected: number;
   ocrApplied: boolean;
+  /** Pages the document HAS — not the number processed, which {@link
+   * MAX_PAGES} can cap. What the operator sees on the document row. */
+  pageCount: number;
 }
 
 export interface PdfExtractionOptions {
@@ -250,5 +253,6 @@ export async function extractTextFromPdfBytes(
     visionUsed,
     scannedPagesDetected,
     ocrApplied,
+    pageCount: totalPages,
   };
 }

--- a/services/platform/backend/core/lib/knowledge/extraction/router.ts
+++ b/services/platform/backend/core/lib/knowledge/extraction/router.ts
@@ -54,14 +54,46 @@ export interface ExtractTextOptions {
 }
 
 /**
+ * What the extraction learned about the file on the way past. Only the PDF
+ * extractor counts pages and spots scanned ones today; every other format
+ * answers with the text alone, and the caller leaves those columns untouched
+ * rather than stamping a guess.
+ */
+export interface ExtractedDocument {
+  text: string;
+  visionUsed: boolean;
+  pageCount?: number;
+  scannedPagesDetected?: number;
+  ocrApplied?: boolean;
+}
+
+/**
  * Extract text from file bytes, routing to the correct extractor. Returns
  * `[extractedText, visionWasUsed]`. Throws when the file type is unsupported.
+ *
+ * Prefer {@link extractDocument} when the caller records what the file is —
+ * page count, scanned pages, whether OCR ran; this pair form drops them.
  */
 export async function extractText(
   fileBytes: Uint8Array,
   filename: string,
   options: ExtractTextOptions = {},
 ): Promise<[string, boolean]> {
+  const extracted = await extractDocument(fileBytes, filename, options);
+  return [extracted.text, extracted.visionUsed];
+}
+
+/**
+ * The same routing, keeping what the extractor learned. The PDF leg carries
+ * the page count and the scanned-page tally the operator sees on the
+ * document row ("Image pages: 3 — OCR unavailable"); before this the ingest
+ * lane read them and threw them away, so those rows never appeared.
+ */
+export async function extractDocument(
+  fileBytes: Uint8Array,
+  filename: string,
+  options: ExtractTextOptions = {},
+): Promise<ExtractedDocument> {
   const visionClient = options.visionClient ?? null;
   const processImages = options.processImages ?? true;
   const suffix = extname(filename).toLowerCase();
@@ -72,44 +104,64 @@ export async function extractText(
       processImages,
       onProgress: options.onProgress,
     });
-    return [result.text, result.visionUsed];
+    return {
+      text: result.text,
+      visionUsed: result.visionUsed,
+      pageCount: result.pageCount,
+      scannedPagesDetected: result.scannedPagesDetected,
+      ocrApplied: result.ocrApplied,
+    };
   }
 
   if (DOCX_EXTENSIONS.has(suffix)) {
-    const [text, visionUsed] = await extractTextFromDocxBytes(
-      fileBytes,
-      filename,
-      {
+    return pair(
+      await extractTextFromDocxBytes(fileBytes, filename, {
         visionClient,
         processImages,
-      },
+      }),
     );
-    return [text, visionUsed];
   }
 
   if (PPTX_EXTENSIONS.has(suffix)) {
-    return extractTextFromPptxBytes(fileBytes, filename, {
-      visionClient,
-      processImages,
-    });
+    return pair(
+      await extractTextFromPptxBytes(fileBytes, filename, {
+        visionClient,
+        processImages,
+      }),
+    );
   }
 
   if (XLSX_EXTENSIONS.has(suffix)) {
-    return extractTextFromXlsxBytes(fileBytes, filename);
+    return pair(await extractTextFromXlsxBytes(fileBytes, filename));
   }
 
   if (ODT_EXTENSIONS.has(suffix)) {
-    return extractTextFromOdtBytes(fileBytes, filename, { processImages });
+    return pair(
+      await extractTextFromOdtBytes(fileBytes, filename, { processImages }),
+    );
   }
 
   if (SUPPORTED_IMAGE_EXTENSIONS.has(suffix)) {
-    return extractTextFromImageBytes(fileBytes, filename, { visionClient });
+    return pair(
+      await extractTextFromImageBytes(fileBytes, filename, { visionClient }),
+    );
   }
 
   if (SUPPORTED_TEXT_EXTENSIONS.has(suffix)) {
-    return extractTextFromTextBytes(fileBytes, filename);
+    return pair(await extractTextFromTextBytes(fileBytes, filename));
   }
 
   console.warn(`Unsupported file type: ${suffix}`);
   throw new Error(`Unsupported file type: ${suffix}`);
+}
+
+/** The `[text, visionUsed, …]` extractors, in the richer shape. The docx leg
+ * carries a third element (its per-image page indices) that no caller of this
+ * router reads. */
+function pair([text, visionUsed]: readonly [
+  string,
+  boolean,
+  ...unknown[],
+]): ExtractedDocument {
+  return { text, visionUsed };
 }

--- a/services/platform/backend/domains/chat/shim.ts
+++ b/services/platform/backend/domains/chat/shim.ts
@@ -19,7 +19,10 @@ import {
   recordConnectorUsage,
 } from '../governance/service.ts';
 import { governanceShimHandlers } from '../governance/shim.ts';
-import { knowledgeShimHandlers } from '../knowledge/service.ts';
+import {
+  knowledgeShimHandlers,
+  queueRagIndexIfUnstarted,
+} from '../knowledge/service.ts';
 import { listEntriesForAgent } from '../knowledge_entries/service.ts';
 import {
   getProjectAuthContext,
@@ -552,6 +555,18 @@ export function chatShimHandlers(sql: Sql): ShimHandlers {
       return Object.fromEntries(
         Object.entries(row).map(([key, value]) => [key, value ?? undefined]),
       );
+    },
+
+    // Self-heal for an attachment whose upload never started indexing (rows
+    // from before registration queued it, and the backstop for any lane that
+    // binds a file without queueing). Called by the turn that is about to
+    // tell the model where the file's content lives.
+    'file_metadata/internal_mutations:queueRagIndexIfUnstarted': async (
+      raw,
+    ) => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- shim boundary: the 0.4 caller passes exactly this shape
+      const args = raw as { storageId: string };
+      return await queueRagIndexIfUnstarted(sql, args.storageId);
     },
 
     // Bind the sender's OWN still-unbound staging uploads to the thread they

--- a/services/platform/backend/domains/files/routes.register.test.ts
+++ b/services/platform/backend/domains/files/routes.register.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+
+/**
+ * `POST /files/register` is the door every staged upload walks through — the
+ * chat composer's, a task's, the welcome page's. The 0.4 mutation it replaced
+ * queued RAG indexing for documents right here (`shouldIndex`); the port kept
+ * only the audio branch, so a document attached in chat sat with a NULL
+ * `rag_status` forever and every turn told the model the file was "not
+ * machine-readable". These tests pin the enqueue — and the three shapes that
+ * must NOT take it.
+ */
+
+import type { Sql } from 'postgres';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Auth } from '../../auth/auth.ts';
+import { addJobInTx } from '../../jobs/enqueue.ts';
+import { markRagQueued } from '../knowledge/service.ts';
+import { createFileRoutes } from './routes.ts';
+import { registerUpload, stampImageVisionMetadata } from './service.ts';
+import { queueTranscription } from './transcription.ts';
+
+vi.mock('../../auth/session.ts', () => ({
+  requireSession:
+    () =>
+    async (
+      c: { set: (key: string, value: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
+      c.set('sessionBundle', { user: { id: 'user_1' } });
+      await next();
+    },
+}));
+vi.mock('../../auth/org.ts', () => ({
+  requireOrgMember:
+    () =>
+    async (
+      c: { set: (key: string, value: unknown) => void },
+      next: () => Promise<void>,
+    ) => {
+      c.set('orgId', 'org_1');
+      c.set('orgMember', { role: 'member' });
+      await next();
+    },
+}));
+vi.mock('../../lib/rate-limit.ts', () => ({
+  checkUserRateLimit: vi.fn(() => Promise.resolve()),
+  RateLimitExceededError: class RateLimitExceededError extends Error {},
+}));
+vi.mock('@tale/shared/db/serializable', () => ({
+  transactSerializable: vi.fn(
+    (_sql: unknown, run: (tx: unknown) => Promise<unknown>) => run('tx'),
+  ),
+}));
+vi.mock('./service.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./service.ts')>();
+  return {
+    ...actual,
+    registerUpload: vi.fn(() =>
+      Promise.resolve({ fileId: 'file_1', size: 2879 }),
+    ),
+    stampImageVisionMetadata: vi.fn(() => Promise.resolve()),
+  };
+});
+vi.mock('../knowledge/service.ts', () => ({
+  markRagQueued: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../../jobs/enqueue.ts', () => ({
+  addJobInTx: vi.fn(() => Promise.resolve('job_1')),
+}));
+vi.mock('./transcription.ts', () => ({
+  queueTranscription: vi.fn(() => Promise.resolve()),
+  retryTranscription: vi.fn(() => Promise.resolve()),
+  skipTranscription: vi.fn(() => Promise.resolve()),
+  transcribeDictation: vi.fn(() => Promise.resolve()),
+}));
+
+function register(body: Record<string, unknown>) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the mocked middleware never touches either dependency
+  return createFileRoutes({ sql: {} as Sql, auth: {} as Auth }).request(
+    '/register',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        storageRef: 's3:blobs/acme/staged',
+        fileName: 'practice.md',
+        contentType: 'text/markdown',
+        ...body,
+      }),
+    },
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /files/register', () => {
+  it('queues indexing for a document, in the transaction that wrote the row', async () => {
+    const res = await register({ threadId: 'thread_1' });
+
+    expect(res.status).toBe(200);
+    expect(registerUpload).toHaveBeenCalledTimes(1);
+    expect(markRagQueued).toHaveBeenCalledWith('tx', 'file_1');
+    expect(addJobInTx).toHaveBeenCalledWith('tx', 'rag.index_file', {
+      fileId: 'file_1',
+    });
+    expect(queueTranscription).not.toHaveBeenCalled();
+  });
+
+  it('leaves an image unindexed and stamps its page shape instead', async () => {
+    const res = await register({
+      fileName: 'screenshot.png',
+      contentType: 'image/png',
+    });
+
+    expect(res.status).toBe(200);
+    expect(markRagQueued).not.toHaveBeenCalled();
+    expect(addJobInTx).not.toHaveBeenCalled();
+    expect(stampImageVisionMetadata).toHaveBeenCalledWith('tx', 'file_1');
+  });
+
+  it('sends audio to transcription, never to the corpus', async () => {
+    const res = await register({
+      fileName: 'memo.m4a',
+      contentType: 'audio/mp4',
+    });
+
+    expect(res.status).toBe(200);
+    expect(addJobInTx).not.toHaveBeenCalled();
+    expect(stampImageVisionMetadata).not.toHaveBeenCalled();
+    expect(queueTranscription).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours the caller opt-out and writes it onto the row', async () => {
+    const res = await register({ skipRagIndexing: true });
+
+    expect(res.status).toBe(200);
+    expect(registerUpload).toHaveBeenCalledWith(
+      expect.anything(),
+      'tx',
+      { organizationId: 'org_1', userId: 'user_1' },
+      expect.objectContaining({ skipRagIndexing: true }),
+      { kind: 'app', purpose: 'file' },
+    );
+    expect(markRagQueued).not.toHaveBeenCalled();
+    expect(addJobInTx).not.toHaveBeenCalled();
+  });
+});

--- a/services/platform/backend/domains/files/routes.ts
+++ b/services/platform/backend/domains/files/routes.ts
@@ -3,15 +3,21 @@ import { Hono, type Context } from 'hono';
 import type { Sql } from 'postgres';
 import { z } from 'zod';
 
-import { isAudioOrVideo } from '../../../lib/shared/file-types.ts';
+import {
+  isAudioOrVideo,
+  isImage,
+  shouldRagIndexOnUpload,
+} from '../../../lib/shared/file-types.ts';
 import type { Auth } from '../../auth/auth.ts';
 import { requireOrgMember, type OrgEnv } from '../../auth/org.ts';
 import { requireSession } from '../../auth/session.ts';
+import { addJobInTx } from '../../jobs/enqueue.ts';
 import { rateLimitedResponse } from '../../lib/rate-limit-response.ts';
 import {
   checkUserRateLimit,
   RateLimitExceededError,
 } from '../../lib/rate-limit.ts';
+import { markRagQueued } from '../knowledge/service.ts';
 import type { ProjectAuthContext } from '../projects/service.ts';
 import {
   assertFileReadable,
@@ -29,6 +35,7 @@ import {
   getFileUrl,
   putOrgBlobBytes,
   registerUpload,
+  stampImageVisionMetadata,
 } from './service.ts';
 import {
   queueTranscription,
@@ -44,6 +51,9 @@ const registerSchema = z.object({
   contentType: z.string().min(1).max(255),
   threadId: z.string().max(200).optional(),
   source: z.string().max(100).optional(),
+  /** Opt out of indexing for a surface that only needs the bytes (the 0.4
+   * `skipRagIndexing`). Write-once true — a later save never clears it. */
+  skipRagIndexing: z.boolean().optional(),
 });
 
 function handleError<E extends OrgEnv>(
@@ -192,12 +202,38 @@ export function createFileRoutes(deps: { sql: Sql; auth: Auth }): Hono<OrgEnv> {
         organizationId: c.get('orgId'),
         userId: c.get('sessionBundle').user.id,
       };
-      const result = await transactSerializable(deps.sql, (tx) =>
-        registerUpload(deps.sql, tx, scope, body.data, {
-          kind: 'app',
-          purpose: 'file',
-        }),
-      );
+      const result = await transactSerializable(deps.sql, async (tx) => {
+        const registered = await registerUpload(
+          deps.sql,
+          tx,
+          scope,
+          body.data,
+          {
+            kind: 'app',
+            purpose: 'file',
+          },
+        );
+        // Documents index server-side (the 0.4 saveFileMetadata `shouldIndex`
+        // branch): stamp queued + enqueue in the SAME transaction, so a
+        // crash between them can never leave a row `queued` with no job —
+        // the state the watchdog would have to guess about. Without this the
+        // row keeps a NULL status forever, the composer waits on a toast
+        // that never fires, and every chat turn tells the model the file is
+        // "not machine-readable".
+        if (
+          body.data.skipRagIndexing !== true &&
+          shouldRagIndexOnUpload(body.data.fileName, body.data.contentType)
+        ) {
+          await markRagQueued(tx, registered.fileId);
+          await addJobInTx(tx, 'rag.index_file', { fileId: registered.fileId });
+        } else if (isImage(body.data.contentType)) {
+          // An image needs a vision model to be read at all, and the ingest
+          // lane refuses it before any byte is fetched — so the honest page
+          // shape is stamped here instead (0.4 parity).
+          await stampImageVisionMetadata(tx, registered.fileId);
+        }
+        return registered;
+      });
       // Audio/video uploads transcribe server-side (the 0.4 saveFileMetadata
       // audio branch): stamp queued + enqueue the pipeline job.
       if (isAudioOrVideo(body.data.contentType)) {

--- a/services/platform/backend/domains/files/service.ts
+++ b/services/platform/backend/domains/files/service.ts
@@ -149,6 +149,10 @@ export interface RegisterUploadArgs {
   contentType: string;
   threadId?: string;
   source?: string;
+  /** The caller's opt-out from RAG indexing (0.4 `skipRagIndexing`). Every
+   * enqueue gate reads the column, so a row that carries it never indexes,
+   * however it is later re-bound. */
+  skipRagIndexing?: boolean;
 }
 
 /**
@@ -215,11 +219,12 @@ export async function registerUpload(
   const inserted = await tx<{ id: string }[]>`
     INSERT INTO app.file_metadata (
       org_id, storage_ref, file_name, content_type, size, source,
-      uploaded_by, thread_id, created_at_ms
+      uploaded_by, thread_id, skip_rag_indexing, created_at_ms
     ) VALUES (
       ${scope.organizationId}, ${args.storageRef}, ${args.fileName},
       ${args.contentType}, ${head.size}, ${args.source ?? null},
-      ${scope.userId}, ${args.threadId ?? null}, ${Date.now()}
+      ${scope.userId}, ${args.threadId ?? null},
+      ${args.skipRagIndexing === true ? true : null}, ${Date.now()}
     )
     RETURNING id
   `;
@@ -228,6 +233,23 @@ export async function registerUpload(
     throw new FileError('FILE_REGISTER_FAILED', 'Insert failed');
   }
   return { fileId, size: head.size };
+}
+
+/**
+ * The page shape of an uploaded image: one page, nothing scanned to detect,
+ * and vision needed to read it at all (the 0.4 `extractFileMetadata` image
+ * branch). Stamped at registration because the ingest lane refuses images
+ * before it fetches a byte, so nothing downstream would ever fill these in.
+ */
+export async function stampImageVisionMetadata(
+  db: Sql | TransactionSql,
+  fileId: string,
+): Promise<void> {
+  await db`
+    UPDATE app.file_metadata
+    SET page_count = 1, scanned_pages_detected = 0, vision_required = true
+    WHERE id = ${fileId}
+  `;
 }
 
 export interface FileMetadataRow {

--- a/services/platform/backend/domains/knowledge/service.ts
+++ b/services/platform/backend/domains/knowledge/service.ts
@@ -2,6 +2,7 @@ import type { Sql, TransactionSql } from 'postgres';
 
 import { isMessageRef } from '../../../lib/knowledge/message-ref.ts';
 import { PRIVATE_KNOWLEDGE_SCHEMA } from '../../../lib/knowledge/types.ts';
+import { shouldRagIndexOnUpload } from '../../../lib/shared/file-types.ts';
 import { findOrganizationMember, isAdminRole } from '../../auth/membership.ts';
 import { readOrgEmbeddingConfig } from '../../core/knowledge/connection.ts';
 import { applyCorpusSchema } from '../../core/knowledge/ddl.ts';
@@ -29,7 +30,8 @@ import {
   type SearchKnowledgeArgs,
 } from '../../core/knowledge/search.ts';
 import {
-  extractText,
+  extractDocument,
+  type ExtractedDocument,
   isImageFile,
   isSupported,
 } from '../../core/lib/knowledge/extraction/router.ts';
@@ -485,6 +487,37 @@ async function writeRagStatus(
 }
 
 /**
+ * Persist what extraction learned about the file: how many pages it has, how
+ * many of them are scans, and whether OCR actually ran on them. Only the PDF
+ * leg answers these today, so a format that reports nothing leaves the
+ * columns as they are rather than stamping a zero that reads like a measured
+ * one. `vision_required` is the operator's version of the same finding: the
+ * file holds pages no text extractor can read.
+ */
+async function stampExtractionMetadata(
+  sql: Sql,
+  fileId: string,
+  extracted: ExtractedDocument,
+): Promise<void> {
+  if (
+    extracted.pageCount === undefined &&
+    extracted.scannedPagesDetected === undefined
+  ) {
+    return;
+  }
+  const scanned = extracted.scannedPagesDetected;
+  await sql`
+    UPDATE app.file_metadata SET
+      page_count = coalesce(${extracted.pageCount ?? null}, page_count),
+      scanned_pages_detected = coalesce(${scanned ?? null}, scanned_pages_detected),
+      ocr_applied = coalesce(${extracted.ocrApplied ?? null}, ocr_applied),
+      vision_required = coalesce(
+        ${scanned !== undefined ? scanned > 0 : null}, vision_required)
+    WHERE id = ${fileId}
+  `;
+}
+
+/**
  * Index one uploaded file into the org's corpus: extract → PII gate →
  * embed → upsert chunks. Idempotent (re-running replaces the document's
  * chunks); the `rag.index_file` job drives it with retries.
@@ -550,7 +583,14 @@ export async function indexUploadedFile(
     }
     const store = await locateOrgObjectStore(orgSlug, parsed.key);
     const bytes = await s3GetObjectBytes(store, parsed.key);
-    const [text] = await extractText(bytes, file.fileName);
+    const extracted = await extractDocument(bytes, file.fileName);
+    const text = extracted.text;
+    // What the extraction learned about the file itself — the operator reads
+    // it on the document row ("Image pages: 3", the OCR badge). Stamped here,
+    // not on completion: a PDF whose embedding step later fails is still a
+    // scanned PDF, and the answer to "why is this document empty?" is
+    // exactly this pair of numbers.
+    await stampExtractionMetadata(sql, fileId, extracted);
 
     const config = await readOrgEmbeddingConfig(orgSlug);
     const shim = knowledgeShim(sql);
@@ -752,6 +792,44 @@ export async function requeueEmbeddingBlockedDocuments(
       });
     }
     return { requeued: rows.length };
+  });
+}
+
+/**
+ * Start indexing a chat attachment whose upload never queued one, when a turn
+ * reaches for it. Two callers-in-one: the rows an instance carries from
+ * before registration queued indexing itself (they would otherwise stay
+ * unreadable forever, with no retry anywhere in the chat UI), and the safety
+ * net for any future lane that binds a file without queueing it.
+ *
+ * The claim is the UPDATE: one row, `FOR UPDATE`, status still NULL. Two
+ * turns racing the same attachment produce one job, not two embeddings of
+ * one file. A row that is queued, running, done, failed, opted out, or bound
+ * to a document (that lane owns its own retry) is left exactly as it is.
+ */
+export async function queueRagIndexIfUnstarted(
+  sql: Sql,
+  storageRef: string,
+): Promise<'queued' | null> {
+  return await sql.begin(async (tx) => {
+    const rows = await tx<
+      { id: string; fileName: string; contentType: string }[]
+    >`
+      SELECT id, file_name AS "fileName", content_type AS "contentType"
+      FROM app.file_metadata
+      WHERE storage_ref = ${storageRef}
+        AND rag_status IS NULL
+        AND skip_rag_indexing IS DISTINCT FROM true
+        AND document_id IS NULL
+      LIMIT 1
+      FOR UPDATE
+    `;
+    const row = rows[0];
+    if (!row) return null;
+    if (!shouldRagIndexOnUpload(row.fileName, row.contentType)) return null;
+    await markRagQueued(tx, row.id);
+    await addJobInTx(tx, 'rag.index_file', { fileId: row.id });
+    return 'queued';
   });
 }
 

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -2840,6 +2840,150 @@ async function checkFiles(
       blobGone,
     `put → ${put.status}, size=${registered.success ? registered.data.size : 'ERR'}, roundtrip=${roundTrip === payload}, refRoundtrip=${refRoundTrip === payload}, delete → ${deleted.status}, blobGone=${blobGone}`,
   );
+
+  // Registration is where an attachment's indexing starts. The 0.4 mutation
+  // queued it here (`shouldIndex`); the cutover kept only the audio branch,
+  // so a document attached in chat kept a NULL `rag_status` forever — the
+  // composer waited on a toast that never fired and every turn told the
+  // model the file was "not machine-readable". Three shapes, one door: a
+  // document queues exactly one job, an image queues none and gets its page
+  // shape stamped instead (nothing downstream would ever fill those in), and
+  // the caller's opt-out is honoured.
+  const registerStaged = async (
+    fileName: string,
+    contentType: string,
+    body: string,
+    extra: Record<string, unknown> = {},
+  ): Promise<{ fileId: string; ref: string }> => {
+    const staged = z.object({ s3Ref: z.string(), url: z.string() }).safeParse(
+      await (
+        await send('POST', `/api/app/files/blob-upload?orgId=${orgId}`, {
+          contentType,
+        })
+      ).json(),
+    );
+    if (!staged.success) return { fileId: '', ref: '' };
+    await fetch(staged.data.url, {
+      method: 'PUT',
+      headers: { 'content-type': contentType },
+      body,
+    });
+    const row = z.object({ fileId: z.string() }).safeParse(
+      await (
+        await send('POST', `/api/app/files/register?orgId=${orgId}`, {
+          storageRef: staged.data.s3Ref,
+          fileName,
+          contentType,
+          ...extra,
+        })
+      ).json(),
+    );
+    return {
+      fileId: row.success ? row.data.fileId : '',
+      ref: staged.data.s3Ref,
+    };
+  };
+  const attached = await registerStaged(
+    'attached.md',
+    'text/markdown',
+    '# attached\n\nchat attachment body',
+    { threadId: 'itest-attachment-thread' },
+  );
+  const image = await registerStaged(
+    'shot.png',
+    'image/png',
+    'not really a png',
+  );
+  const skipped = await registerStaged(
+    'skipped.md',
+    'text/markdown',
+    '# skipped',
+    { skipRagIndexing: true },
+  );
+  const docFileId = attached.fileId;
+  const imageFileId = image.fileId;
+  const skippedFileId = skipped.fileId;
+  const indexJobsFor = async (fileIdToCount: string): Promise<number> => {
+    const rows = await sql<{ count: string }[]>`
+      SELECT count(*)::text AS count FROM pgboss.job
+      WHERE name = 'rag.index_file' AND data ->> 'fileId' = ${fileIdToCount}
+    `;
+    return Number(rows[0]?.count ?? '0');
+  };
+  const attachmentRow = (
+    await sql<{ ragStatus: string | null; skip: boolean | null }[]>`
+      SELECT rag_status AS "ragStatus", skip_rag_indexing AS skip
+      FROM app.file_metadata WHERE id = ${docFileId} LIMIT 1
+    `
+  )[0];
+  const imageRow = (
+    await sql<
+      {
+        ragStatus: string | null;
+        pageCount: number | null;
+        visionRequired: boolean | null;
+      }[]
+    >`
+      SELECT rag_status AS "ragStatus", page_count AS "pageCount",
+             vision_required AS "visionRequired"
+      FROM app.file_metadata WHERE id = ${imageFileId} LIMIT 1
+    `
+  )[0];
+  const skippedRow = (
+    await sql<{ ragStatus: string | null; skip: boolean | null }[]>`
+      SELECT rag_status AS "ragStatus", skip_rag_indexing AS skip
+      FROM app.file_metadata WHERE id = ${skippedFileId} LIMIT 1
+    `
+  )[0];
+  const docJobs = await indexJobsFor(docFileId);
+  const imageJobs = await indexJobsFor(imageFileId);
+  const skippedJobs = await indexJobsFor(skippedFileId);
+  record(
+    'register queues indexing for a document, never for an image or an opt-out',
+    docFileId !== '' &&
+      attachmentRow?.ragStatus !== null &&
+      attachmentRow?.ragStatus !== undefined &&
+      docJobs === 1 &&
+      imageJobs === 0 &&
+      imageRow?.ragStatus === null &&
+      imageRow?.pageCount === 1 &&
+      imageRow?.visionRequired === true &&
+      skippedJobs === 0 &&
+      skippedRow?.skip === true &&
+      skippedRow?.ragStatus === null,
+    `document: status=${attachmentRow?.ragStatus ?? 'null'} (want any status — the pipeline started) jobs=${docJobs} (want 1); image: jobs=${imageJobs} (want 0) status=${imageRow?.ragStatus ?? 'null'} (want null) pages=${imageRow?.pageCount ?? 'null'} (want 1) vision=${imageRow?.visionRequired ?? 'null'} (want true); opt-out: jobs=${skippedJobs} (want 0) skip=${skippedRow?.skip ?? 'null'} (want true) status=${skippedRow?.ragStatus ?? 'null'} (want null)`,
+  );
+
+  // The rows an instance carries from before registration queued indexing
+  // have no status at all, and chat offers no retry — so the turn that
+  // reaches for one starts the run instead of telling the model the file is
+  // unreadable. Idempotent (a second turn claims nothing), and an opt-out
+  // stays opted out.
+  const { chatShimHandlers: chatShimForHeal } =
+    await import('./domains/chat/shim.ts');
+  const healHandler =
+    chatShimForHeal(sql)[
+      'file_metadata/internal_mutations:queueRagIndexIfUnstarted'
+    ];
+  await sql`
+    UPDATE app.file_metadata SET rag_status = NULL, rag_error = NULL,
+                                 rag_error_code = NULL
+    WHERE id = ${docFileId}
+  `;
+  const restarted = await healHandler?.({ storageId: attached.ref });
+  const restartedAgain = await healHandler?.({ storageId: attached.ref });
+  const optOutRestart = await healHandler?.({ storageId: skipped.ref });
+  const restartedJobs = await indexJobsFor(docFileId);
+  const optOutJobs = await indexJobsFor(skippedFileId);
+  record(
+    'a turn starts indexing for an attachment whose upload never did, once',
+    restarted === 'queued' &&
+      restartedAgain === null &&
+      optOutRestart === null &&
+      restartedJobs === 2 &&
+      optOutJobs === 0,
+    `heal=${String(restarted)} (want queued), second=${String(restartedAgain)} (want null), optOut=${String(optOutRestart)} (want null), jobs=${restartedJobs} (want 2: the register one plus this) optOutJobs=${optOutJobs} (want 0)`,
+  );
 }
 
 /**

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -22481,30 +22481,51 @@ async function checkControlDrain(
     WHERE thread_id = ${threadId}
   `;
 
-  // In-flight counting: a fresh fake generation counts, a stale one not.
+  // In-flight counting, by the rule the drain window sets: a generation that
+  // was already running when the drain began counts (the deploy waits for
+  // it), a heartbeat-stale one does not (that turn is already dead), and one
+  // that STARTED after the drain began does not either — after a colour flip
+  // those rows are the live colour's traffic, and waiting on them would burn
+  // the whole drain budget on a busy deployment. The probe rows are placed
+  // relative to the drain's own clock, never to `Date.now()`: a row stamped
+  // "now" starts AFTER the drain that began a moment earlier, which is the
+  // one shape that must not count.
   const now = Date.now();
-  await sql`
-    INSERT INTO app.generations (thread_id, org_id, message_id,
-                                 started_at_ms, heartbeat_at_ms,
-                                 updated_at_ms)
-    VALUES (${threadId}, ${orgId}, 'itest-drain-msg', ${now}, ${now}, ${now})
-  `;
-  const withFresh = z
-    .object({ inFlight: z.number() })
-    .loose()
-    .safeParse(
-      await (await control('/drain-status', { bearer: token })).json(),
-    );
-  await sql`
-    UPDATE app.generations SET heartbeat_at_ms = ${now - 11 * 60_000}
-    WHERE thread_id = ${threadId}
-  `;
-  const withStale = z
-    .object({ inFlight: z.number() })
-    .loose()
-    .safeParse(
-      await (await control('/drain-status', { bearer: token })).json(),
-    );
+  const drainStartedAt = Number(
+    (
+      await sql<{ startedAt: string | null }[]>`
+        SELECT drain_started_at_ms::text AS "startedAt"
+        FROM app.backend_control WHERE key = 'singleton' LIMIT 1
+      `
+    )[0]?.startedAt ?? now,
+  );
+  const inFlightWith = async (
+    startedAt: number,
+    heartbeatAt: number,
+  ): Promise<z.ZodSafeParseResult<{ inFlight: number }>> => {
+    await sql`
+      INSERT INTO app.generations (thread_id, org_id, message_id,
+                                   started_at_ms, heartbeat_at_ms,
+                                   updated_at_ms)
+      VALUES (${threadId}, ${orgId}, 'itest-drain-msg', ${startedAt},
+              ${heartbeatAt}, ${heartbeatAt})
+      ON CONFLICT (thread_id) DO UPDATE SET
+        started_at_ms = ${startedAt}, heartbeat_at_ms = ${heartbeatAt},
+        updated_at_ms = ${heartbeatAt}
+    `;
+    return z
+      .object({ inFlight: z.number() })
+      .loose()
+      .safeParse(
+        await (await control('/drain-status', { bearer: token })).json(),
+      );
+  };
+  const withFresh = await inFlightWith(drainStartedAt - 1000, now);
+  const withStale = await inFlightWith(
+    drainStartedAt - 1000,
+    now - 11 * 60_000,
+  );
+  const withPostDrain = await inFlightWith(drainStartedAt + 1000, now);
   await sql`DELETE FROM app.generations WHERE thread_id = ${threadId}`;
 
   // End → the send door opens again (the busy gate now decides, not the
@@ -22694,12 +22715,14 @@ async function checkControlDrain(
       withFresh.data.inFlight === 1 &&
       withStale.success &&
       withStale.data.inFlight === 0 &&
+      withPostDrain.success &&
+      withPostDrain.data.inFlight === 0 &&
       ended.status === 200 &&
       statusEnded.success &&
       !statusEnded.data.draining &&
       statusExpired.success &&
       !statusExpired.data.draining,
-    `auth=${noBearer.status}/${wrongBearer.status}/gone=${doorGone.status} (want 401/401/404), begin=${began.success} draining=${statusDraining.success ? statusDraining.data.draining : 'ERR'}, send=${refusedSend.status} (want 503) body=${refusedBody.success ? refusedBody.data.status : 'ERR'} appended=${appended[0]?.count} (want 0), inFlight fresh=${withFresh.success ? withFresh.data.inFlight : 'ERR'}/stale=${withStale.success ? withStale.data.inFlight : 'ERR'} (want 1/0), end=${ended.status} → draining=${statusEnded.success ? statusEnded.data.draining : 'ERR'}, expired=${statusExpired.success ? statusExpired.data.draining : 'ERR'} (want false)`,
+    `auth=${noBearer.status}/${wrongBearer.status}/gone=${doorGone.status} (want 401/401/404), begin=${began.success} draining=${statusDraining.success ? statusDraining.data.draining : 'ERR'}, send=${refusedSend.status} (want 503) body=${refusedBody.success ? refusedBody.data.status : 'ERR'} appended=${appended[0]?.count} (want 0), inFlight fresh=${withFresh.success ? withFresh.data.inFlight : 'ERR'}/stale=${withStale.success ? withStale.data.inFlight : 'ERR'}/started-after-drain=${withPostDrain.success ? withPostDrain.data.inFlight : 'ERR'} (want 1/0/0), end=${ended.status} → draining=${statusEnded.success ? statusEnded.data.draining : 'ERR'}, expired=${statusExpired.success ? statusExpired.data.draining : 'ERR'} (want false)`,
   );
 }
 

--- a/services/platform/lib/shared/file-types.test.ts
+++ b/services/platform/lib/shared/file-types.test.ts
@@ -13,6 +13,7 @@ import {
   mimeToExtension,
   RAG_INDEXABLE_EXTENSIONS,
   resolveFileType,
+  shouldRagIndexOnUpload,
 } from './file-types';
 
 describe('extractExtension', () => {
@@ -389,6 +390,42 @@ describe('mimeToExtension', () => {
   it('handles uppercase MIME types', () => {
     expect(mimeToExtension('IMAGE/JPEG')).toBe('jpg');
     expect(mimeToExtension('Application/PDF')).toBe('pdf');
+  });
+});
+
+describe('shouldRagIndexOnUpload', () => {
+  it.each([
+    ['report.pdf', 'application/pdf'],
+    ['notes.md', 'text/markdown'],
+    ['data.csv', 'text/csv'],
+    [
+      'report.docx',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+    ['README', 'text/plain'],
+  ])('queues indexing for %s', (fileName, contentType) => {
+    expect(shouldRagIndexOnUpload(fileName, contentType)).toBe(true);
+  });
+
+  it.each([
+    // Vision-only: the ingest lane refuses an image before it fetches bytes.
+    ['photo.png', 'image/png'],
+    ['scan.tiff', 'image/tiff'],
+    // The name alone is enough — a picture uploaded as a generic blob.
+    ['photo.jpg', 'application/octet-stream'],
+    // Transcription lane; the transcript is indexed after it lands.
+    ['memo.m4a', 'audio/mp4'],
+    ['clip.mp4', 'video/mp4'],
+    // No extractor exists for these at all.
+    ['archive.zip', 'application/zip'],
+    ['legacy.doc', 'application/msword'],
+  ])('leaves %s out of the corpus queue', (fileName, contentType) => {
+    expect(shouldRagIndexOnUpload(fileName, contentType)).toBe(false);
+  });
+
+  it('is the subset of isRagIndexableFile that is not an image', () => {
+    expect(isRagIndexableFile('photo.png', 'image/png')).toBe(true);
+    expect(shouldRagIndexOnUpload('photo.png', 'image/png')).toBe(false);
   });
 });
 

--- a/services/platform/lib/shared/file-types.ts
+++ b/services/platform/lib/shared/file-types.ts
@@ -1020,3 +1020,36 @@ export function isRagIndexableFile(
   const ext = extractExtension(fileName) ?? mimeToExtension(contentType);
   return ext !== undefined && RAG_INDEXABLE_EXTENSIONS.has(ext);
 }
+
+/** The image extensions inside {@link RAG_INDEXABLE_EXTENSIONS}. */
+const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'tiff',
+  'tif',
+  'webp',
+]);
+
+/**
+ * Does an upload of this file start a RAG indexing run?
+ *
+ * The gate every lane shares: the composer defers its "uploaded" toast for
+ * these files and waits on the indexing status before it lets the turn
+ * start, and `POST /files/register` queues exactly this set. Audio and video
+ * take the transcription lane instead (their transcript is indexed after it
+ * lands), and an image can only be read by a vision model — a lane the 0.5
+ * ingest refuses up front — so queueing one buys an `unsupported` badge and
+ * nothing else.
+ */
+export function shouldRagIndexOnUpload(
+  fileName: string,
+  contentType: string,
+): boolean {
+  if (isAudioOrVideo(contentType) || isImage(contentType)) return false;
+  const ext = extractExtension(fileName) ?? mimeToExtension(contentType);
+  if (ext === undefined || IMAGE_EXTENSIONS.has(ext)) return false;
+  return RAG_INDEXABLE_EXTENSIONS.has(ext);
+}


### PR DESCRIPTION
## The bug

Attach a `.md` (or a PDF, or a `.docx`) to a chat message and the agent answers that it cannot read it:

> 你好！我看到了你上传的 `practice.md` 文件，但很遗憾，这个文件在当前对话中无法被机器读取（索引不可用）

That text is the model repeating what the turn told it — `buildDocumentAppendix`'s fallback line, reached because the attachment has no indexing status at all.

## Why

The Convex→Postgres cutover (#3107) ported `saveFileMetadata`'s audio branch into `POST /files/register`:

```ts
if (isAudioOrVideo(body.data.contentType)) { await queueTranscription(…) }
```

and dropped its twin. The 0.4 mutation queued indexing for documents in the same place:

```ts
const shouldIndex = !skipIndexing && !isAudio && isRagIndexableFile(fileName, contentType);
…
ragStatus: shouldIndex ? 'queued' : undefined,
if (shouldIndex) await maybeDispatchRagIndexing(ctx, args.storageId);
```

Nothing else queues a chat attachment — email attachments, documents, WebDAV, OneDrive, REST and video links all queue in their own lanes, and the chat thread-bind only stamps `thread_id`. On a live instance: the row carries `rag_status = NULL` and pgboss holds zero `rag.index_file` jobs for it, while `private_knowledge.documents` shows the Knowledge-uploaded files indexing fine beside it.

Everything downstream was already built for a status that nothing wrote: `isDeferredSendReady` waits on it, `useFileIndexingStatus` gates the send on it, and `use-file-upload` defers its "uploaded" toast to a terminal state — so a chat-attached document also never confirmed its upload.

The same cutover dropped `extractFileMetadata`, which is why `page_count`, `scanned_pages_detected` and `vision_required` are read by the documents table and the preview sidebar ("Image pages: 3 — OCR unavailable", the OCR badge) and written nowhere in 0.5.

## The fix

- **Registration queues the run**, in the transaction that wrote the row — a crash between them can never leave a `queued` row with no job to drain it.
- **`skipRagIndexing` reaches the door again.** The composer sends it for surfaces that only want the bytes; the 0.5 schema dropped it silently, which mattered the moment registration started queueing.
- **A turn heals a status-less attachment.** Rows an instance already carries (every chat attachment uploaded before this PR) have no retry anywhere in the chat UI, so the turn that reaches for one starts the run and tells the model it is indexing, instead of declaring it unreadable forever. The claim is `SELECT … FOR UPDATE` on a NULL status: two turns racing one file produce one job.
- **One gate, three callers.** `shouldRagIndexOnUpload` in `lib/shared/file-types.ts` is what the route queues, what the composer defers its toast for, and what the status hook tracks — they had drifted apart, which is why an image (indexable by extension, refused by the 0.5 ingest) waited forever for a toast it could never get.
- **Extraction records what the file is.** `extractDocument` keeps what the PDF leg already computed — page count, scanned pages, whether OCR ran — the ingest lane stamps it, and an image gets its one-page vision shape at registration. This lights up UI that has been dark since the cutover.

## The drain probe, while we were here

The integration suite's `deploy drain control plane` check had been failing on `main` since #3277 landed. It inserted a generation stamped `Date.now()` — a moment *after* the drain it had just begun — and expected the door to count it. It never could: `countActiveGenerations` counts only what started at or before `drain_started_at_ms`, exactly so a colour flip's new traffic on the live colour cannot hold the old colour's drain open for its whole budget. The probe rows now sit relative to the drain's own start — one running before it (counts), the same row gone heartbeat-stale (does not), one started after it (does not) — which pins the colour-flip guarantee the old shape was accidentally asserting against. The product code is unchanged.

## Proof

Real-Postgres integration run (`backend:integration`, throwaway db + MinIO): **532/532 across 141/141 lanes**, no failures.

```text
PASS  register queues indexing for a document, never for an image or an opt-out —
      document: status=failed (want any status — the pipeline started) jobs=1 (want 1);
      image: jobs=0 (want 0) status=null (want null) pages=1 (want 1) vision=true (want true);
      opt-out: jobs=0 (want 0) skip=true (want true) status=null (want null)
PASS  a turn starts indexing for an attachment whose upload never did, once —
      heal=queued (want queued), second=null (want null), optOut=null (want null),
      jobs=2 (want 2: the register one plus this) optOutJobs=0 (want 0)
PASS  deploy drain control plane (token door, send gate, expiry) —
      … inFlight fresh=1/stale=0/started-after-drain=0 (want 1/0/0) …
```

(`status=failed` on the first one is the itest environment having no embedding provider — the point of the check is that the pipeline started at all.)

Also: 4 new unit tests on the register door, the shared gate's own cases, `pageCount` on the PDF extractor, `bunx tsc --noEmit` clean, oxlint clean, 382 server tests and 109 UI tests green in the touched areas.

## Not included

Existing rows heal when a turn reaches for them, not in bulk — no backfill job. A document-bound row with a NULL status keeps its own per-document Retry and is left alone here.
