### PR TITLE
fix(platform): reopen the hint stream the browser gives up on

### DIFF
--- a/services/platform/app/lib/backend/use-backend-hints.test.tsx
+++ b/services/platform/app/lib/backend/use-backend-hints.test.tsx
@@ -13,6 +13,8 @@ class FakeEventSource {
   readonly url: string;
   readonly withCredentials: boolean;
   closed = false;
+  /** 0 CONNECTING (the browser is retrying), 1 OPEN, 2 CLOSED (it gave up). */
+  readyState = 1;
   private readonly listeners = new Map<
     string,
     Set<(event: MessageEvent<string>) => void>
@@ -67,11 +69,22 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   delete window.__ENV__;
   reportBackendReachable();
 });
+
+/** The browser abandoned the handshake (non-200) and will not retry. */
+function abandon(source: FakeEventSource | undefined): void {
+  act(() => {
+    if (source !== undefined) {
+      source.readyState = 2;
+      source.emit('error', '');
+    }
+  });
+}
 
 describe('useBackendHints', () => {
   it('subscribes the org stream and invalidates the entity prefix on a hint', () => {
@@ -152,5 +165,124 @@ describe('useBackendHints', () => {
   it('opens nothing without an org scope', () => {
     renderHook(() => useBackendHints(undefined), { wrapper });
     expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
+  it('reopens a stream the browser abandoned on a non-200 handshake', () => {
+    vi.useFakeTimers();
+    renderHook(() => useBackendHints('org1'), { wrapper });
+    const first = FakeEventSource.instances[0];
+
+    // What a rolling deploy does to an open tab: the handshake answers 502,
+    // the browser sets CLOSED and never retries.
+    abandon(first);
+    expect(first?.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1]?.url).toBe('/events?orgId=org1');
+  });
+
+  it('leaves a natively reconnecting stream alone', () => {
+    vi.useFakeTimers();
+    renderHook(() => useBackendHints('org1'), { wrapper });
+    const source = FakeEventSource.instances[0];
+
+    act(() => {
+      // CONNECTING: the browser is already retrying with Last-Event-ID.
+      if (source !== undefined) source.readyState = 0;
+      source?.emit('error', '');
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(source?.closed).toBe(false);
+  });
+
+  it('never reopens after the terminal forbidden event', () => {
+    vi.useFakeTimers();
+    renderHook(() => useBackendHints('org1'), { wrapper });
+    const source = FakeEventSource.instances[0];
+
+    act(() => {
+      source?.emit('forbidden', '');
+    });
+    abandon(source);
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('refetches the org scope on the open that follows a forced reopen', () => {
+    vi.useFakeTimers();
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+    renderHook(() => useBackendHints('org1'), { wrapper });
+
+    // The first open is not a gap — nothing was missed yet.
+    act(() => {
+      FakeEventSource.instances[0]?.emit('open', '');
+    });
+    expect(invalidate).not.toHaveBeenCalled();
+
+    abandon(FakeEventSource.instances[0]);
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    // A reopened source carries no Last-Event-ID, so the hints emitted while
+    // it was down are unrecoverable: the org scope has to refetch.
+    act(() => {
+      FakeEventSource.instances[1]?.emit('open', '');
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['backend', 'org1'] });
+  });
+
+  it('backs off between reopen attempts and resets after one opens', () => {
+    vi.useFakeTimers();
+    renderHook(() => useBackendHints('org1'), { wrapper });
+
+    abandon(FakeEventSource.instances[0]);
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(FakeEventSource.instances).toHaveLength(1);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    // Second failure waits twice as long.
+    abandon(FakeEventSource.instances[1]);
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(FakeEventSource.instances).toHaveLength(2);
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(FakeEventSource.instances).toHaveLength(3);
+
+    // A stream that opens clears the debt: the next failure waits 1s again.
+    act(() => {
+      FakeEventSource.instances[2]?.emit('open', '');
+    });
+    abandon(FakeEventSource.instances[2]);
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(FakeEventSource.instances).toHaveLength(4);
+  });
+
+  it('cancels a pending reopen on unmount', () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useBackendHints('org1'), { wrapper });
+
+    abandon(FakeEventSource.instances[0]);
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(FakeEventSource.instances).toHaveLength(1);
   });
 });

--- a/services/platform/app/lib/backend/use-backend-hints.ts
+++ b/services/platform/app/lib/backend/use-backend-hints.ts
@@ -6,31 +6,56 @@ import { reportBackendReachable } from './connection-state';
 import { backendEntityPrefix, backendOrgPrefix } from './query-keys';
 
 /**
+ * `EventSource.CLOSED` as a literal: the browser has given up on this source
+ * and will not reconnect. Read from the instance rather than the constructor
+ * so a stubbed global cannot change the meaning of the check.
+ */
+const EVENT_SOURCE_CLOSED = 2;
+/** First delay before we reopen a stream the browser abandoned. */
+const RECONNECT_BASE_MS = 1_000;
+/** Ceiling for the backoff — a backend that stays down is polled once a minute. */
+const RECONNECT_MAX_MS = 60_000;
+
+/**
  * The Tier-2 realtime bridge: subscribe the org's `/events` hint stream and
  * invalidate the matching `['backend', orgId, entity]` queries — hints
  * carry identity, never data, so every refetch goes back through the
  * authenticated route the query already uses.
  *
- * One `EventSource` per mounted org scope. Reconnects (with `Last-Event-ID`
- * replay) are the browser's native behavior; the server heartbeats every
- * 15s so proxies keep the lane open. On `error` the source retries on its
- * own — TanStack's refetch-on-reconnect covers anything missed while down,
- * exactly the contract `backend/realtime/sse.ts` documents. When the server
- * cannot replay a resume in full (the cursor is older than the outbox's
- * retention) it sends `resync` first, and the whole org scope refetches.
- * `forbidden` is terminal: the server re-proves membership and the session
- * while the stream is open and ends it once either is gone — the source is
- * closed here instead of reconnecting into a guaranteed 401/403.
+ * One `EventSource` per mounted org scope. A stream that OPENED and then
+ * dropped is the browser's problem: it reconnects natively, replaying from
+ * `Last-Event-ID`, and the server heartbeats every 15s so proxies keep the
+ * lane open. A HANDSHAKE that answered non-200 is ours — per the HTML
+ * spec the browser sets `readyState` to `CLOSED` and never retries, so a
+ * rolling deploy's 502 (or a transient 401) would otherwise leave the tab
+ * silently frozen: every mutation from any other session stops arriving and
+ * nothing on screen says so, until the user reloads by hand. We reopen those
+ * ourselves with a capped backoff.
+ *
+ * A reopened source carries no `Last-Event-ID`, so hints emitted while it was
+ * down are gone for good — the whole org scope refetches on the first open
+ * after a forced reconnect, the same contract `resync` has when the server
+ * cannot replay a cursor. `forbidden` stays terminal: the server re-proves
+ * membership and the session while the stream is open and ends it once
+ * either is gone, so reopening would only meet a guaranteed 401/403.
  */
 export function useBackendHints(orgId: string | undefined): void {
   const queryClient = useQueryClient();
   useEffect(() => {
-    if (orgId === undefined || orgId === '') {
+    // Bound to a const so the narrowing survives into the closures below —
+    // a parameter's narrowing does not.
+    const org = orgId;
+    if (org === undefined || org === '') {
       return undefined;
     }
-    const source = new EventSource(eventsUrl(orgId), {
-      withCredentials: true,
-    });
+    let source: EventSource | undefined;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let attempt = 0;
+    /** Set once the effect is torn down, or `forbidden` ended the stream. */
+    let stopped = false;
+    /** A forced reconnect skipped the cursor: refetch on the next open. */
+    let replayLost = false;
+
     const onHint = (event: MessageEvent<string>): void => {
       try {
         const hint: unknown = JSON.parse(event.data);
@@ -41,43 +66,91 @@ export function useBackendHints(orgId: string | undefined): void {
           typeof hint.entity === 'string'
         ) {
           void queryClient.invalidateQueries({
-            queryKey: backendEntityPrefix(orgId, hint.entity),
+            queryKey: backendEntityPrefix(org, hint.entity),
           });
         }
       } catch (error) {
         console.warn('[backend-hints] unparseable hint event:', error);
       }
     };
-    // `open` is positive evidence the backend answered. `error` is not the
-    // inverse: EventSource emits it on every reconnect and when a proxy
-    // (Vite preview in E2E, Caddy idle timeout) drops the lane — the
-    // browser retries on its own. The offline overlay reasons on HTTP
-    // `fetch` failures in `backendFetch`, not on this stream.
+    // `open` is positive evidence the backend answered, and the point where a
+    // gap in the hint stream has to be paid for with a refetch.
     const onOpen = (): void => {
+      attempt = 0;
       reportBackendReachable();
+      if (replayLost) {
+        replayLost = false;
+        void queryClient.invalidateQueries({
+          queryKey: backendOrgPrefix(org),
+        });
+      }
     };
     // The replay had a hole: hints between the reconnect cursor and now were
     // reclaimed, so nothing the cache holds for this org can be trusted.
     const onResync = (): void => {
-      void queryClient.invalidateQueries({
-        queryKey: backendOrgPrefix(orgId),
-      });
+      void queryClient.invalidateQueries({ queryKey: backendOrgPrefix(org) });
     };
-    // The reader lost the org (or the session): stop, do not auto-reconnect.
-    // The next mount — a fresh sign-in, a re-added member — reopens it.
+    // The reader lost the org (or the session): stop for good. The next mount
+    // — a fresh sign-in, a re-added member — reopens it.
     const onForbidden = (): void => {
-      source.close();
+      stopped = true;
+      detach();
     };
-    source.addEventListener('hint', onHint);
-    source.addEventListener('resync', onResync);
-    source.addEventListener('open', onOpen);
-    source.addEventListener('forbidden', onForbidden);
-    return () => {
+    // Only a source the browser has ABANDONED is ours to reopen; one that is
+    // CONNECTING is already retrying natively and must be left alone, or the
+    // two loops race and open a stream per error.
+    const onError = (): void => {
+      if (stopped || source?.readyState !== EVENT_SOURCE_CLOSED) {
+        return;
+      }
+      detach();
+      replayLost = true;
+      const delay = Math.min(
+        RECONNECT_MAX_MS,
+        RECONNECT_BASE_MS * 2 ** attempt,
+      );
+      attempt += 1;
+      retryTimer = setTimeout(connect, delay);
+    };
+
+    // Arrow consts, not declarations: a hoisted `function` is callable before
+    // the narrowing above, so TypeScript widens `org` back to `undefined`.
+    const detach = (): void => {
+      if (source === undefined) {
+        return;
+      }
       source.removeEventListener('hint', onHint);
       source.removeEventListener('resync', onResync);
       source.removeEventListener('open', onOpen);
       source.removeEventListener('forbidden', onForbidden);
+      source.removeEventListener('error', onError);
       source.close();
+      source = undefined;
+    };
+
+    const connect = (): void => {
+      retryTimer = undefined;
+      if (stopped) {
+        return;
+      }
+      source = new EventSource(eventsUrl(org), {
+        withCredentials: true,
+      });
+      source.addEventListener('hint', onHint);
+      source.addEventListener('resync', onResync);
+      source.addEventListener('open', onOpen);
+      source.addEventListener('forbidden', onForbidden);
+      source.addEventListener('error', onError);
+    };
+
+    connect();
+    return () => {
+      stopped = true;
+      if (retryTimer !== undefined) {
+        clearTimeout(retryTimer);
+        retryTimer = undefined;
+      }
+      detach();
       // A closed stream is not an outage — the next mount reopens it.
       reportBackendReachable();
     };


### PR DESCRIPTION
A tab that loses its `/events` handshake once stops receiving realtime hints **for the rest of its
life**, silently. Found while testing a self-hosted stack; the trigger class is every rolling
deploy.

## What happens

`useBackendHints` subscribes `open`, `hint`, `resync` and `forbidden`, and its comment says the
browser retries on its own. That holds only for a stream that **opened and then dropped**. Per the
[HTML spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model), a
handshake answering anything but 200 (or the wrong content type) puts the source in `CLOSED` and the
browser **never reconnects**. The effect's deps are `[orgId, queryClient]`, so nothing remounts it
either. There is no `error` listener at all — the tab just goes quiet.

## How it showed up

On a hand-rolled stack I recreated `backend-api`. The proxy access log, in full:

```text
02:10:24  200  duration 464.1s   /events?orgId=…     ← opened, ran 7m44s, ended 02:18:08
02:10:27  502  duration   0.1s   /events?orgId=…     ← the recreate
```

Nine minutes later, at 02:19:07, an agent run settled: it attached its deliverable and parked the
task `in_review`. `app_realtime.outbox` holds both hints for that task. No stream was open to carry
them, so the board and the task dialog showed neither — the operator only saw the result after
reloading the page by hand, and read it as two backend bugs (lost deliverable, missed status flip).
Both were fine; nothing had told the tab.

## The fix

- Listen for `error`. Reopen only a source in `CLOSED` — one that is `CONNECTING` is already
  retrying natively with `Last-Event-ID`, and reopening it would race the browser and leak a stream
  per error.
- Capped backoff: 1s doubling to 60s, reset once a stream opens, so a backend that stays down is
  polled once a minute rather than hammered.
- **A reopened source carries no `Last-Event-ID`**, so hints emitted during the outage are gone for
  good. The first `open` after a forced reconnect invalidates the whole org scope — exactly the
  contract `resync` already has for a cursor the server cannot replay. Without this the stream comes
  back but the screen stays stale, which is the same bug wearing a different hat.
- `forbidden` stays terminal, and unmount cancels a pending reopen.

## Tests

Six new cases in `use-backend-hints.test.tsx`; the `FakeEventSource` double grows a `readyState`.
**Three fail on the parent commit** — reopen-after-abandon, the org refetch, and the backoff — the
other three are guards that the old code satisfies by never reconnecting at all.

`vitest --project server app/lib/backend` 12 files / 72 tests green · `tsc --noEmit` clean ·
`oxlint --type-aware` clean.