### PR TITLE
fix(cli): make tale dev work on a host that never built the images

### DIFF
--- a/tools/cli/src/lib/actions/dev.ts
+++ b/tools/cli/src/lib/actions/dev.ts
@@ -27,10 +27,15 @@ import { getProjectId, loadEnv } from '../../utils/load-env';
 import * as logger from '../../utils/logger';
 import { findComposeOverride } from '../compose/find-compose-override';
 import { DEV_VOLUME_NAMES } from '../compose/generators/constants';
-import { generateDevCompose } from '../compose/generators/generate-dev-compose';
+import {
+  generateDevCompose,
+  orgConfigMountTargets,
+} from '../compose/generators/generate-dev-compose';
 import { dockerCompose } from '../docker/docker-compose';
+import { ensureConfigMountpoints } from '../docker/ensure-config-mountpoints';
 import { ensureDocker } from '../docker/ensure-docker';
 import { ensureNetwork, ensureSandboxNetwork } from '../docker/ensure-network';
+import { ensureSandboxRuntimeImage } from '../docker/ensure-sandbox-runtime-image';
 import { ensureVolumes } from '../docker/ensure-volumes';
 import { exec } from '../docker/exec';
 import { getContainerHealth } from '../docker/get-container-health';
@@ -172,6 +177,15 @@ export async function runDev(options: DevOptions): Promise<void> {
         if (!(await ensureVolumes([...DEV_VOLUME_NAMES], devPrefix))) {
           throw new Error('Failed to create dev volumes');
         }
+        // The web tier mounts the config volume read-only and the compose file
+        // nests one bind per `<slug>/<domain>` under it. runc cannot create a
+        // mountpoint inside a read-only mount, and the backend only creates
+        // those directories when it seeds the volume — which races the web
+        // tier on a first bring-up. Creating them here settles it.
+        await ensureConfigMountpoints(
+          `${devPrefix}config-data`,
+          orgConfigMountTargets(projectDir),
+        );
         if (!(await ensureNetwork('internal', devPrefix))) {
           throw new Error('Failed to create dev network');
         }
@@ -188,6 +202,19 @@ export async function runDev(options: DevOptions): Promise<void> {
   const hostAlias = options.host ?? 'localhost';
   const portSuffix = port === 443 ? '' : `:${port}`;
   const url = `${env.SITE_URL.replace(/:443$/, '')}${portSuffix}`;
+
+  // Session containers are `docker run`, not compose services, so `compose up`
+  // never fetches the runtime image. Without it every agent turn and
+  // `Run code` fails with a "pull access denied" that reads like a login
+  // problem. `tale deploy` already does this; only a tag that is missing is
+  // fetched, so a source build stays untouched.
+  await runStep(
+    {
+      active: 'Checking the sandbox runtime image',
+      done: 'Sandbox runtime image ready',
+    },
+    () => ensureSandboxRuntimeImage(env.GHCR_REGISTRY, version),
+  );
 
   const compose = generateDevCompose(
     { version, registry: env.GHCR_REGISTRY },

--- a/tools/cli/src/lib/actions/dev.ts
+++ b/tools/cli/src/lib/actions/dev.ts
@@ -159,6 +159,7 @@ export async function runDev(options: DevOptions): Promise<void> {
   }
   await assertDockerAvailable();
 
+  const imageVersion = pkg.version.includes('-dev') ? 'latest' : pkg.version;
   const devPrefix = `${getProjectId()}-dev_`;
   await runStep(
     {
@@ -185,6 +186,7 @@ export async function runDev(options: DevOptions): Promise<void> {
         await ensureConfigMountpoints(
           `${devPrefix}config-data`,
           orgConfigMountTargets(projectDir),
+          `${env.GHCR_REGISTRY}/tale-platform:${imageVersion}`,
         );
         if (!(await ensureNetwork('internal', devPrefix))) {
           throw new Error('Failed to create dev network');
@@ -197,7 +199,7 @@ export async function runDev(options: DevOptions): Promise<void> {
       }),
   );
 
-  const version = pkg.version.includes('-dev') ? 'latest' : pkg.version;
+  const version = imageVersion;
   const port = options.port ?? 443;
   const hostAlias = options.host ?? 'localhost';
   const portSuffix = port === 443 ? '' : `:${port}`;

--- a/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
+++ b/tools/cli/src/lib/compose/generators/generate-dev-compose.ts
@@ -62,26 +62,53 @@ function orgMountSources(
  *  caller discovers the sources once and warns once when there are none —
  *  this runs per service, so warning here would repeat per invocation
  *  (R31-P2-b). */
+function existingDomainDirs(
+  sources: { slug: string; relBase: string }[],
+  projectDir: string,
+): { slug: string; relBase: string; domain: string }[] {
+  const found: { slug: string; relBase: string; domain: string }[] = [];
+  for (const { slug, relBase } of sources) {
+    for (const domain of ORG_DOMAIN_DIRS) {
+      if (existsSync(join(projectDir, relBase, slug, domain))) {
+        found.push({ slug, relBase, domain });
+      }
+    }
+  }
+  return found;
+}
+
 function existingHostMounts(
   sources: { slug: string; relBase: string }[],
   projectDir: string,
   containerBase: string,
   suffix = '',
 ): string[] {
-  const mounts: string[] = [];
-  for (const { slug, relBase } of sources) {
-    for (const domain of ORG_DOMAIN_DIRS) {
-      const src = join(projectDir, relBase, slug, domain);
-      if (existsSync(src)) {
-        const hostPath =
-          relBase === '.'
-            ? `./${slug}/${domain}`
-            : `./${relBase}/${slug}/${domain}`;
-        mounts.push(`${hostPath}:${containerBase}/${slug}/${domain}${suffix}`);
-      }
-    }
-  }
-  return mounts;
+  return existingDomainDirs(sources, projectDir).map(
+    ({ slug, relBase, domain }) => {
+      const hostPath =
+        relBase === '.'
+          ? `./${slug}/${domain}`
+          : `./${relBase}/${slug}/${domain}`;
+      return `${hostPath}:${containerBase}/${slug}/${domain}${suffix}`;
+    },
+  );
+}
+
+/**
+ * The `<slug>/<domain>` paths this compose file nests INSIDE the read-only
+ * `config-data` mount, relative to the config root.
+ *
+ * runc creates every mountpoint it does not find, and it cannot create one
+ * inside a read-only mount — so on a config volume that does not already hold
+ * the directory, `platform` dies at start with "create mountpoint …:
+ * read-only file system". The directories arrive when the backend seeds the
+ * volume, which races the web tier on a first bring-up. `tale dev` pre-creates
+ * exactly this list so the outcome no longer depends on who wins.
+ */
+export function orgConfigMountTargets(projectDir: string): string[] {
+  return existingDomainDirs(orgMountSources(projectDir), projectDir).map(
+    ({ slug, domain }) => `${slug}/${domain}`,
+  );
 }
 
 export function generateDevCompose(

--- a/tools/cli/src/lib/docker/ensure-config-mountpoints.test.ts
+++ b/tools/cli/src/lib/docker/ensure-config-mountpoints.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, mock, test } from 'bun:test';
 
 import { ensureConfigMountpoints } from './ensure-config-mountpoints';
 
+const IMAGE = 'ghcr.io/tale-project/tale/tale-platform:0.5.11';
+
 function fakeDeps(ok = true) {
   return {
     docker: mock(() =>
@@ -16,39 +18,79 @@ function fakeDeps(ok = true) {
   };
 }
 
+/** The `sh -c` script the helper container runs. */
+function script(deps: ReturnType<typeof fakeDeps>): string {
+  const args = deps.docker.mock.calls[0] as string[];
+  return args[args.length - 1] as string;
+}
+
 describe('ensureConfigMountpoints', () => {
-  test('creates every target inside the volume in one container', async () => {
+  test('creates every target and its slug root in one container', async () => {
     const deps = fakeDeps();
 
     expect(
       await ensureConfigMountpoints(
         'my-project-dev_config-data',
         ['default/agents', 'default/governance'],
+        IMAGE,
         deps,
       ),
     ).toBe(true);
     expect(deps.docker).toHaveBeenCalledTimes(1);
     const args = deps.docker.mock.calls[0] as string[];
-    expect(args).toContain('my-project-dev_config-data:/d');
-    expect(args).toContain('/d/default/agents');
-    expect(args).toContain('/d/default/governance');
-    expect(args).toContain('-p');
+    expect(args).toContain('my-project-dev_config-data:/mnt/config');
+    expect(args).toContain(IMAGE);
+    const sh = script(deps);
+    expect(sh).toContain("'/mnt/config/default'");
+    expect(sh).toContain("'/mnt/config/default/agents'");
+    expect(sh).toContain("'/mnt/config/default/governance'");
+  });
+
+  test('hands the tree to the user the app image runs as', async () => {
+    const deps = fakeDeps();
+
+    await ensureConfigMountpoints('vol', ['default/agents'], IMAGE, deps);
+
+    // runc creates these as root while the app runs unprivileged, and the
+    // backend could then not seed default/object-storage beside them. A fresh
+    // volume is root-owned and empty, so the IMAGE has to answer for it.
+    const sh = script(deps);
+    expect(sh).toContain("stat -c '%u:%g' /app/data");
+    expect(sh).toContain('chown "$owner"');
+    expect(sh.indexOf('mkdir')).toBeLessThan(sh.indexOf('chown'));
   });
 
   test('does nothing when there is nothing to mount', async () => {
     const deps = fakeDeps();
 
-    expect(await ensureConfigMountpoints('vol', [], deps)).toBe(true);
+    expect(await ensureConfigMountpoints('vol', [], IMAGE, deps)).toBe(true);
     expect(deps.docker).not.toHaveBeenCalled();
   });
 
-  test('strips traversal so a slug cannot escape the mount', async () => {
+  test('drops anything that is not a plain slug/domain pair', async () => {
     const deps = fakeDeps();
 
-    await ensureConfigMountpoints('vol', ['../../etc/agents'], deps);
+    expect(
+      await ensureConfigMountpoints(
+        'vol',
+        ['../../etc/agents', 'default/agents; rm -rf /', 'ok/agents'],
+        IMAGE,
+        deps,
+      ),
+    ).toBe(true);
+    const sh = script(deps);
+    expect(sh).toContain("'/mnt/config/ok/agents'");
+    expect(sh).not.toContain('..');
+    expect(sh).not.toContain('rm -rf');
+  });
 
-    const args = deps.docker.mock.calls[0] as string[];
-    expect(args.some((a) => a.includes('..'))).toBe(false);
+  test('returns false with nothing to do when every target is rejected', async () => {
+    const deps = fakeDeps();
+
+    expect(await ensureConfigMountpoints('vol', ['../etc'], IMAGE, deps)).toBe(
+      true,
+    );
+    expect(deps.docker).not.toHaveBeenCalled();
   });
 
   test('warns and reports failure instead of throwing', async () => {
@@ -56,9 +98,11 @@ describe('ensureConfigMountpoints', () => {
 
     // Every bring-up after the first would start fine anyway; failing hard
     // here would block a stack that was going to work.
-    expect(await ensureConfigMountpoints('vol', ['default/agents'], deps)).toBe(
-      false,
-    );
+    expect(
+      await ensureConfigMountpoints('vol', ['default/agents'], IMAGE, deps),
+    ).toBe(false);
     expect(deps.logger.warn).toHaveBeenCalled();
+    const [message] = deps.logger.warn.mock.calls[0] as [string];
+    expect(message).toContain('object store bootstrap failed');
   });
 });

--- a/tools/cli/src/lib/docker/ensure-config-mountpoints.test.ts
+++ b/tools/cli/src/lib/docker/ensure-config-mountpoints.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { ensureConfigMountpoints } from './ensure-config-mountpoints';
+
+function fakeDeps(ok = true) {
+  return {
+    docker: mock(() =>
+      Promise.resolve({
+        success: ok,
+        exitCode: ok ? 0 : 1,
+        stdout: '',
+        stderr: ok ? '' : 'no such volume',
+      }),
+    ),
+    logger: { warn: mock() },
+  };
+}
+
+describe('ensureConfigMountpoints', () => {
+  test('creates every target inside the volume in one container', async () => {
+    const deps = fakeDeps();
+
+    expect(
+      await ensureConfigMountpoints(
+        'my-project-dev_config-data',
+        ['default/agents', 'default/governance'],
+        deps,
+      ),
+    ).toBe(true);
+    expect(deps.docker).toHaveBeenCalledTimes(1);
+    const args = deps.docker.mock.calls[0] as string[];
+    expect(args).toContain('my-project-dev_config-data:/d');
+    expect(args).toContain('/d/default/agents');
+    expect(args).toContain('/d/default/governance');
+    expect(args).toContain('-p');
+  });
+
+  test('does nothing when there is nothing to mount', async () => {
+    const deps = fakeDeps();
+
+    expect(await ensureConfigMountpoints('vol', [], deps)).toBe(true);
+    expect(deps.docker).not.toHaveBeenCalled();
+  });
+
+  test('strips traversal so a slug cannot escape the mount', async () => {
+    const deps = fakeDeps();
+
+    await ensureConfigMountpoints('vol', ['../../etc/agents'], deps);
+
+    const args = deps.docker.mock.calls[0] as string[];
+    expect(args.some((a) => a.includes('..'))).toBe(false);
+  });
+
+  test('warns and reports failure instead of throwing', async () => {
+    const deps = fakeDeps(false);
+
+    // Every bring-up after the first would start fine anyway; failing hard
+    // here would block a stack that was going to work.
+    expect(await ensureConfigMountpoints('vol', ['default/agents'], deps)).toBe(
+      false,
+    );
+    expect(deps.logger.warn).toHaveBeenCalled();
+  });
+});

--- a/tools/cli/src/lib/docker/ensure-config-mountpoints.ts
+++ b/tools/cli/src/lib/docker/ensure-config-mountpoints.ts
@@ -1,6 +1,14 @@
 import * as defaultLogger from '../../utils/logger';
-import { BACKUP_HELPER_IMAGE } from '../backup/constants';
 import { docker as defaultDocker } from './docker';
+
+/** A `<slug>/<domain>` pair, as the compose file nests them. Anything else is
+ *  dropped rather than reaching a shell. */
+const TARGET_PATTERN =
+  /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Where the helper mounts the config volume — NOT `/app/data`, so the image's
+ *  own ownership of that path stays readable underneath. */
+const MOUNT_AT = '/mnt/config';
 
 interface EnsureMountpointsDeps {
   docker: typeof defaultDocker;
@@ -8,54 +16,69 @@ interface EnsureMountpointsDeps {
 }
 
 /**
- * Create the org-config mountpoints inside the config volume.
+ * Create the org-config mountpoints inside the config volume, owned by the
+ * user the app runs as.
  *
- * The web tier mounts `config-data:/app/data:ro` and the dev compose nests one
- * bind per `<slug>/<domain>` underneath it. runc creates a mountpoint it does
- * not find — and cannot, inside a read-only mount — so the container fails to
- * start with "create mountpoint for /app/data/<slug>/<domain>: read-only file
- * system" whenever the volume does not already hold that directory. The
- * backend creates them when it seeds the volume, but it does that while the
- * web tier is starting, so on a first bring-up the two race and the loser is
- * an unrecoverable OCI error rather than a retry.
+ * Two failures, one cause — the compose file nests a bind per
+ * `<slug>/<domain>` inside `config-data`, which every app container mounts:
  *
- * Idempotent and cheap (one short-lived helper container), so it runs on every
- * bring-up rather than trying to detect a first one.
+ *  - runc creates any mountpoint it does not find, and cannot do so inside a
+ *    read-only mount, so `platform` dies at start with "create mountpoint for
+ *    /app/data/default/governance: read-only file system" whenever the volume
+ *    does not already hold that directory.
+ *  - Where runc CAN create it — the backend mounts the same volume
+ *    read-write — it creates it as **root**, while the app process runs
+ *    unprivileged. `/app/data` belongs to the app user but `/app/data/default`
+ *    then does not, so the backend cannot seed
+ *    `default/object-storage/connection.json` (`EACCES … mkdir`) and every
+ *    upload and deliverable harvest afterwards fails with "No object storage
+ *    configured: neither this org nor the deployment default tree has an
+ *    object-storage/connection.json".
  *
- * Best-effort: on a volume that already has the directories — every bring-up
- * after the first — failing here would block a stack that was going to start
- * anyway, so a failure warns and lets compose speak for itself.
+ * The app image is what settles the ownership question: it ships `/app/data`
+ * owned by the user it drops to, so the helper reads that owner rather than
+ * hard-coding a uid that would rot the moment the image changes. A fresh
+ * volume is root-owned and empty, so it cannot answer for itself.
+ *
+ * Idempotent and cheap, so it runs on every bring-up rather than trying to
+ * detect a first one. Best-effort: on a volume that is already correct —
+ * every bring-up after the first — failing here would block a stack that was
+ * going to start anyway, so a failure warns and lets compose speak for itself.
  */
 export async function ensureConfigMountpoints(
   volumeName: string,
   targets: readonly string[],
+  appImage: string,
   {
     docker = defaultDocker,
     logger = defaultLogger,
   }: Partial<EnsureMountpointsDeps> = {},
 ): Promise<boolean> {
-  if (targets.length === 0) {
+  const safe = targets.filter((t) => TARGET_PATTERN.test(t));
+  if (safe.length === 0) {
     return true;
   }
-  // `--` and the `/d/` prefix keep a slug that starts with a dash, or one
-  // carrying a traversal, from being read as an option or escaping the mount.
-  const paths = targets.map((t) => `/d/${t.replace(/\.\./g, '')}`);
+  const dirs = [...new Set(safe.flatMap((t) => [t.split('/')[0] as string, t]))]
+    .sort()
+    .map((d) => `'${MOUNT_AT}/${d}'`)
+    .join(' ');
   const result = await docker(
     'run',
     '--rm',
     '-v',
-    `${volumeName}:/d`,
-    BACKUP_HELPER_IMAGE,
-    'mkdir',
-    '-p',
-    '--',
-    ...paths,
+    `${volumeName}:${MOUNT_AT}`,
+    '--entrypoint',
+    'sh',
+    appImage,
+    '-c',
+    `set -e; owner="$(stat -c '%u:%g' /app/data)"; mkdir -p ${dirs}; chown "$owner" ${dirs}`,
   );
   if (!result.success) {
     logger.warn(
-      `Could not pre-create the org config mountpoints in ${volumeName}: ` +
+      `Could not prepare the org config mountpoints in ${volumeName}: ` +
         `${result.stderr.trim()}. If the web tier fails to start with ` +
-        '"create mountpoint … read-only file system", re-run `tale dev`.',
+        '"create mountpoint … read-only file system", or the backend logs ' +
+        '"default object store bootstrap failed", re-run `tale dev`.',
     );
     return false;
   }

--- a/tools/cli/src/lib/docker/ensure-config-mountpoints.ts
+++ b/tools/cli/src/lib/docker/ensure-config-mountpoints.ts
@@ -1,0 +1,63 @@
+import * as defaultLogger from '../../utils/logger';
+import { BACKUP_HELPER_IMAGE } from '../backup/constants';
+import { docker as defaultDocker } from './docker';
+
+interface EnsureMountpointsDeps {
+  docker: typeof defaultDocker;
+  logger: Pick<typeof defaultLogger, 'warn'>;
+}
+
+/**
+ * Create the org-config mountpoints inside the config volume.
+ *
+ * The web tier mounts `config-data:/app/data:ro` and the dev compose nests one
+ * bind per `<slug>/<domain>` underneath it. runc creates a mountpoint it does
+ * not find — and cannot, inside a read-only mount — so the container fails to
+ * start with "create mountpoint for /app/data/<slug>/<domain>: read-only file
+ * system" whenever the volume does not already hold that directory. The
+ * backend creates them when it seeds the volume, but it does that while the
+ * web tier is starting, so on a first bring-up the two race and the loser is
+ * an unrecoverable OCI error rather than a retry.
+ *
+ * Idempotent and cheap (one short-lived helper container), so it runs on every
+ * bring-up rather than trying to detect a first one.
+ *
+ * Best-effort: on a volume that already has the directories — every bring-up
+ * after the first — failing here would block a stack that was going to start
+ * anyway, so a failure warns and lets compose speak for itself.
+ */
+export async function ensureConfigMountpoints(
+  volumeName: string,
+  targets: readonly string[],
+  {
+    docker = defaultDocker,
+    logger = defaultLogger,
+  }: Partial<EnsureMountpointsDeps> = {},
+): Promise<boolean> {
+  if (targets.length === 0) {
+    return true;
+  }
+  // `--` and the `/d/` prefix keep a slug that starts with a dash, or one
+  // carrying a traversal, from being read as an option or escaping the mount.
+  const paths = targets.map((t) => `/d/${t.replace(/\.\./g, '')}`);
+  const result = await docker(
+    'run',
+    '--rm',
+    '-v',
+    `${volumeName}:/d`,
+    BACKUP_HELPER_IMAGE,
+    'mkdir',
+    '-p',
+    '--',
+    ...paths,
+  );
+  if (!result.success) {
+    logger.warn(
+      `Could not pre-create the org config mountpoints in ${volumeName}: ` +
+        `${result.stderr.trim()}. If the web tier fails to start with ` +
+        '"create mountpoint … read-only file system", re-run `tale dev`.',
+    );
+    return false;
+  }
+  return true;
+}

--- a/tools/cli/src/lib/docker/ensure-sandbox-runtime-image.test.ts
+++ b/tools/cli/src/lib/docker/ensure-sandbox-runtime-image.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import {
+  SANDBOX_RUNTIME_LOCAL_TAG,
+  ensureSandboxRuntimeImage,
+} from './ensure-sandbox-runtime-image';
+
+// Fresh fakes per test, injected directly — `mock.module` is process-global in
+// Bun and leaks across files.
+function fakeDeps(
+  overrides: { inspectOk?: boolean; pullOk?: boolean; tagOk?: boolean } = {},
+) {
+  const { inspectOk = false, pullOk = true, tagOk = true } = overrides;
+  const docker = mock((...args: string[]) => {
+    if (args[0] === 'image' && args[1] === 'inspect') {
+      return Promise.resolve({
+        success: inspectOk,
+        exitCode: inspectOk ? 0 : 1,
+        stdout: '',
+        stderr: inspectOk ? '' : 'No such image',
+      });
+    }
+    if (args[0] === 'tag') {
+      return Promise.resolve({
+        success: tagOk,
+        exitCode: tagOk ? 0 : 1,
+        stdout: '',
+        stderr: tagOk ? '' : 'tag refused',
+      });
+    }
+    return Promise.resolve({
+      success: true,
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+  });
+  return {
+    docker,
+    pullImage: mock(() => Promise.resolve(pullOk)),
+    logger: { info: mock(), warn: mock() },
+  };
+}
+
+const REGISTRY = 'ghcr.io/tale-project/tale';
+
+describe('ensureSandboxRuntimeImage', () => {
+  test('leaves a locally built image alone', async () => {
+    const deps = fakeDeps({ inspectOk: true });
+
+    expect(await ensureSandboxRuntimeImage(REGISTRY, '0.5.11', deps)).toBe(
+      'present',
+    );
+    // Overwriting a contributor's source build with a released image would
+    // silently discard what they are testing.
+    expect(deps.pullImage).not.toHaveBeenCalled();
+    expect(deps.docker).toHaveBeenCalledTimes(1);
+  });
+
+  test('pulls and re-tags when the spawner tag is missing', async () => {
+    const deps = fakeDeps();
+
+    expect(await ensureSandboxRuntimeImage(REGISTRY, '0.5.11', deps)).toBe(
+      'fetched',
+    );
+    expect(deps.pullImage).toHaveBeenCalledWith(
+      `${REGISTRY}/tale-sandbox-runtime:0.5.11`,
+    );
+    expect(deps.docker).toHaveBeenCalledWith(
+      'tag',
+      `${REGISTRY}/tale-sandbox-runtime:0.5.11`,
+      SANDBOX_RUNTIME_LOCAL_TAG,
+    );
+  });
+
+  test('warns instead of throwing when the pull fails', async () => {
+    const deps = fakeDeps({ pullOk: false });
+
+    // The rest of the stack is usable without a sandbox; a registry hiccup
+    // must not block a local bring-up.
+    expect(await ensureSandboxRuntimeImage(REGISTRY, '0.5.11', deps)).toBe(
+      'unavailable',
+    );
+    expect(deps.logger.warn).toHaveBeenCalled();
+    const [message] = deps.logger.warn.mock.calls[0] as [string];
+    expect(message).toContain('Run code');
+  });
+
+  test('warns when the pull lands but the tag does not', async () => {
+    const deps = fakeDeps({ tagOk: false });
+
+    expect(await ensureSandboxRuntimeImage(REGISTRY, '0.5.11', deps)).toBe(
+      'unavailable',
+    );
+    expect(deps.logger.warn).toHaveBeenCalled();
+  });
+
+  test('follows the version it is given', async () => {
+    const deps = fakeDeps();
+
+    await ensureSandboxRuntimeImage(REGISTRY, 'latest', deps);
+
+    expect(deps.pullImage).toHaveBeenCalledWith(
+      `${REGISTRY}/tale-sandbox-runtime:latest`,
+    );
+  });
+});

--- a/tools/cli/src/lib/docker/ensure-sandbox-runtime-image.ts
+++ b/tools/cli/src/lib/docker/ensure-sandbox-runtime-image.ts
@@ -1,0 +1,76 @@
+import * as defaultLogger from '../../utils/logger';
+import { docker as defaultDocker } from './docker';
+import { pullImage as defaultPullImage } from './pull-image';
+
+/**
+ * The tag the spawner falls back to when `SANDBOX_RUNTIME_IMAGE` is unset
+ * (`create-sandbox-service.ts` passes
+ * `${SANDBOX_RUNTIME_IMAGE:-tale-sandbox-runtime:latest}`). It is a LOCAL
+ * build tag — `tale-sandbox-runtime` is not a registry repository, so a
+ * daemon that does not already hold it answers `docker run` with
+ * "pull access denied … repository does not exist", which reads like a
+ * missing `docker login` rather than a missing image.
+ */
+export const SANDBOX_RUNTIME_LOCAL_TAG = 'tale-sandbox-runtime:latest';
+
+export type EnsureRuntimeImageOutcome = 'present' | 'fetched' | 'unavailable';
+
+interface EnsureRuntimeImageDeps {
+  docker: typeof defaultDocker;
+  pullImage: typeof defaultPullImage;
+  logger: Pick<typeof defaultLogger, 'info' | 'warn'>;
+}
+
+/**
+ * Put the sandbox runtime image on the host under the tag the spawner runs.
+ *
+ * Session containers are created with `docker run`, not by compose, so
+ * `compose up` never fetches this image: a host that only ever ran the CLI
+ * has no `tale-sandbox-runtime:latest` and every agent turn, `Run code`, web
+ * render and document generation fails. `tale deploy` already pulls and
+ * re-tags it for exactly this reason; `tale dev` did not.
+ *
+ * Only fetches when the tag is ABSENT. A contributor running the stack from
+ * source builds this tag themselves, and overwriting their build with a
+ * released image would silently discard what they are testing.
+ *
+ * Non-fatal: the rest of the stack — chat, knowledge, documents — works
+ * without a sandbox, and a registry hiccup should not block a local bring-up.
+ * The warning names the consequence so the failure is not discovered later
+ * through the spawner's misleading error.
+ */
+export async function ensureSandboxRuntimeImage(
+  registry: string,
+  version: string,
+  {
+    docker = defaultDocker,
+    pullImage = defaultPullImage,
+    logger = defaultLogger,
+  }: Partial<EnsureRuntimeImageDeps> = {},
+): Promise<EnsureRuntimeImageOutcome> {
+  const present = await docker('image', 'inspect', SANDBOX_RUNTIME_LOCAL_TAG);
+  if (present.success) {
+    return 'present';
+  }
+
+  const remote = `${registry}/tale-sandbox-runtime:${version}`;
+  if (!(await pullImage(remote))) {
+    logger.warn(
+      `Could not fetch ${remote}. The stack still starts, but agent turns, ` +
+        '`Run code`, web render and document generation will fail until it is ' +
+        'available — re-run `tale dev` once the registry is reachable.',
+    );
+    return 'unavailable';
+  }
+
+  const tagged = await docker('tag', remote, SANDBOX_RUNTIME_LOCAL_TAG);
+  if (!tagged.success) {
+    logger.warn(
+      `Fetched ${remote} but could not tag it ${SANDBOX_RUNTIME_LOCAL_TAG}: ` +
+        `${tagged.stderr.trim()}. Agent turns and \`Run code\` will fail until ` +
+        'that tag exists.',
+    );
+    return 'unavailable';
+  }
+  return 'fetched';
+}


### PR DESCRIPTION
Found by running the [quickstart](https://docs.tale.dev/self-hosted/install/quickstart) end to end on
a host with **no tale images, containers or volumes at all** — which is what a new reader's machine
looks like. Three failures live there. All three are invisible on any machine that has run the stack
from source, which is why they survived.

## 1. Every agent turn fails on a CLI-only host

`tale init` → `tale dev` → sign up → assign a task to an agent ends here:

```text
agent: the agent turn could not start: sandbox session create failed (502):
docker run (session) failed: Unable to find image 'tale-sandbox-runtime:latest' locally
docker: Error response from daemon: pull access denied for tale-sandbox-runtime,
repository does not exist or may require 'docker login'.  (after 4 attempts)
```

Session containers are created with `docker run`, not by compose, so `compose up` never fetches that
image — and the spawner's fallback (`create-sandbox-service.ts`:
`${SANDBOX_RUNTIME_IMAGE:-tale-sandbox-runtime:latest}`) is a **local build tag**, present only on a
machine that built it from source. `tale-sandbox-runtime` is not a registry repository, so the
daemon's refusal reads like a missing `docker login` and sends the reader somewhere useless.

`tale deploy` already pulls and re-tags it, with a comment saying exactly why. `tale dev` never did —
`sandbox-runtime` appears 4× in `deploy.ts` and 0× in `dev.ts`.

Two deliberate choices: **fetch only when the tag is absent**, because a contributor builds that tag
themselves and pulling over it would silently discard the image they are testing; and **a failed
fetch warns rather than throws**, because chat, knowledge and documents all work without a sandbox —
but the warning names the consequence, so it is not rediscovered later through the misleading
spawner error.

## 2. The web tier can lose a first-boot race and die unrecoverably

```text
error mounting ".../my-project/default/governance" to rootfs at "/app/data/default/governance":
create mountpoint for /app/data/default/governance mount: read-only file system
[ x ] Tale stopped unexpectedly.
```

`platform` mounts `config-data:/app/data:ro` and the dev compose nests one bind per
`<slug>/<domain>` underneath. runc creates any mountpoint it does not find — and cannot, inside a
read-only mount. Those directories appear when the **backend** seeds the volume, which happens while
the web tier is starting, so on a fresh config volume the two race and the loser is an OCI error with
no retry. Hit once on the cold-pull first run and gone on the retry, which is what a race looks like:
the second run only worked because the first one's backend had already seeded the volume.

## 3. …and where runc *can* create those dirs, it creates them as root

The same nesting decides ownership. `/app/data` belongs to the app user the image drops to;
`/app/data/default`, created by runc, does not — so the backend cannot seed the deployment-default
blob connection beside it:

```text
[backend] default object store bootstrap failed: Error: EACCES: permission denied,
mkdir '/app/data/default/object-storage'
```

Nothing surfaces that at boot. It reappears at the end of the first agent run that produces a file,
as a harvest that quietly drops the deliverable — and every upload fails the same way, for the same
missing file:

```text
Not delivered (the harvest skipped these outputs):
示例软件功能测试报告.docx — not saved to the workspace: No object storage configured:
neither this org nor the deployment default tree has an object-storage/connection.json
```

## The fix

`tale dev` fetches and re-tags the runtime image, and pre-creates the mountpoints the compose file
nests — owned by the right user — inside the step that already holds the project lock for volume
work. `existingHostMounts` and the new `orgConfigMountTargets` share one discovery pass rather than
walking the tree twice.

The owner comes from the **app image**, which ships `/app/data` owned by the user it runs as. A fresh
volume is root-owned and empty so it cannot answer for itself, and a hard-coded uid would rot the
moment the image changes; the helper therefore runs on that image with the volume mounted elsewhere,
so the image's own `/app/data` stays readable underneath.

## Verification

Unit: 11 new tests. `bun test` 432 pass / 0 fail · `tsc --noEmit` clean · `oxlint` clean.

End to end, on a host wiped to zero images/containers/volumes:

| | released CLI 0.5.11 | this branch |
| --- | --- | --- |
| `tale-sandbox-runtime:latest` after `tale dev` | absent | present (fetched + re-tagged) |
| agent turn | `pull access denied` | image resolves |
| bring-up | reached ready on the **second** run | `Tale is running` |
| `default/` owner in the config volume | `root` | `1001:1001` |
| object-store bootstrap | `EACCES … mkdir` | `object store (seeded): bucket "tale-blobs"` |
| `default/object-storage/connection.json` | never written | seeded, correct `publicEndpoint` |
