### PR TITLE
docs: pin the compose examples from one version variable

### DIFF
--- a/docs/de/self-hosted/install/own-compose.md
+++ b/docs/de/self-hosted/install/own-compose.md
@@ -71,7 +71,16 @@ Jedes `tale-*`-Image liegt in der GitHub Container Registry unter demselben Rele
 | `object-store` | `minio/minio:RELEASE.2025-04-22T22-12-26Z` |
 | `bgutil-provider` | `brainicism/bgutil-ytdlp-pot-provider:1.3.1` |
 
-Ein Image ist kein Compose-Service: Der Spawner erzeugt jeden Session-Container aus `ghcr.io/tale-project/tale/tale-sandbox-runtime:<version>`, und sein eingebauter Default ist der lokale Tag, den der Entwicklungs-Stack baut — ein Host, der ihn nie gebaut hat, nennt das Registry-Image in `SANDBOX_RUNTIME_IMAGE`, sonst scheitern `Run code`, Web-Rendering und Dokumentgenerierung an einem fehlenden Image. Zieh dieses Image selbst, bevor du das erste Mal hochfährst. Der Spawner wärmt es beim Boot vor und antwortet auf `:8003` erst, wenn der Pull durch ist — auf einem kalten Host steht die Sandbox also so lange auf `starting`, wie mehrere Gigabyte brauchen; `tale deploy` zieht es genau deshalb vor dem Stack. Die Beispiele unten pinnen den Release, den diese Seite dokumentiert; ersetz den Tag durch den Release, den du installierst.
+Ein Image ist kein Compose-Service: Der Spawner erzeugt jeden Session-Container aus `ghcr.io/tale-project/tale/tale-sandbox-runtime:<version>`, und sein eingebauter Default ist der lokale Tag, den der Entwicklungs-Stack baut — ein Host, der ihn nie gebaut hat, nennt das Registry-Image in `SANDBOX_RUNTIME_IMAGE`, sonst scheitern `Run code`, Web-Rendering und Dokumentgenerierung an einem fehlenden Image. Zieh dieses Image selbst, bevor du das erste Mal hochfährst. Der Spawner wärmt es beim Boot vor und antwortet auf `:8003` erst, wenn der Pull durch ist — auf einem kalten Host steht die Sandbox also so lange auf `starting`, wie mehrere Gigabyte brauchen; `tale deploy` zieht es genau deshalb vor dem Stack.
+
+Jedes Beispiel unten liest seinen Tag aus einer Variablen, damit in einem Stack nie eine 0.5.11-API neben einem 0.5.9-Proxy steht:
+
+```bash
+# .env — the one line that pins all seven tale-* images
+VERSION=0.5.11
+```
+
+`0.5.11` ist der Release, gegen den diese Seite geschrieben wurde, keine Empfehlung. Installier den aktuellen: seine Nummer steht auf der Seite [latest release](https://github.com/tale-project/tale/releases/latest), und genau die gehört in `VERSION`. Compose setzt sie aus der `.env` im Projektverzeichnis ein — derselben Datei, die deine Secrets trägt.
 
 ## Die zustandslosen Services
 
@@ -83,7 +92,7 @@ Unten stehen die drei zustandslosen Rollen — Aliase, `/ping` als Liveness, `TA
 # add depends_on: { db: { condition: service_healthy }, … } as well.
 services:
   platform:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     env_file: [.env]
     volumes: ['config-data:/app/data:ro']
     restart: unless-stopped
@@ -102,7 +111,7 @@ services:
       internal:
         aliases: [platform]
   backend-api:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     environment:
       TALE_ROLE: api
       PORT: '3005'
@@ -127,7 +136,7 @@ services:
       sandbox:
         aliases: [backend-api]
   backend-worker:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     environment:
       TALE_ROLE: worker
       TALE_CONFIG_DIR: /app/data
@@ -267,9 +276,13 @@ Veröffentliche nur `80` und `443` auf `proxy`. Alles andere bleibt im internen 
 Fahr die Stores zuerst hoch, dann die Sandbox-Ebene, dann den App-Tier. Eine API, die startet, bevor `db` und `object-store` healthy sind, crash-loopt auf `ENOTFOUND` und auf einer fehlenden Datenbank. In einer Datei reicht `depends_on` mit `service_healthy`.
 
 ```bash
+# The pull is not a compose command, so it needs the tag .env pins in this
+# shell too.
+VERSION=$(sed -n 's/^VERSION=//p' .env)
+
 # Not a compose service, and the spawner blocks on it at boot — pull it first so
 # the sandbox probe is not waiting on several gigabytes.
-docker pull ghcr.io/tale-project/tale/tale-sandbox-runtime:0.5.11
+docker pull "ghcr.io/tale-project/tale/tale-sandbox-runtime:$VERSION"
 
 docker compose up -d
 # Wait until db, object-store, proxy, sandbox, sandbox-egress, sandbox-llm-gateway

--- a/docs/en/self-hosted/install/own-compose.md
+++ b/docs/en/self-hosted/install/own-compose.md
@@ -71,7 +71,16 @@ Every `tale-*` image is published on the GitHub Container Registry under the sam
 | `object-store` | `minio/minio:RELEASE.2025-04-22T22-12-26Z` |
 | `bgutil-provider` | `brainicism/bgutil-ytdlp-pot-provider:1.3.1` |
 
-One image is not a compose service. The spawner creates every session container from `ghcr.io/tale-project/tale/tale-sandbox-runtime:<version>`, and its built-in default is the local tag the development stack builds — a host that never built it must name the registry image in `SANDBOX_RUNTIME_IMAGE`, or `Run code`, web render, and document generation all fail with an image-not-found. Pull that image yourself before the first `up`. The spawner warms it at boot and does not start answering on `:8003` until the pull finishes, so on a cold host the sandbox sits in `starting` for as long as several gigabytes take to arrive — `tale deploy` pulls it ahead of the stack for exactly this reason. The examples below pin the release this page documents; replace the tag with the release you are installing.
+One image is not a compose service. The spawner creates every session container from `ghcr.io/tale-project/tale/tale-sandbox-runtime:<version>`, and its built-in default is the local tag the development stack builds — a host that never built it must name the registry image in `SANDBOX_RUNTIME_IMAGE`, or `Run code`, web render, and document generation all fail with an image-not-found. Pull that image yourself before the first `up`. The spawner warms it at boot and does not start answering on `:8003` until the pull finishes, so on a cold host the sandbox sits in `starting` for as long as several gigabytes take to arrive — `tale deploy` pulls it ahead of the stack for exactly this reason.
+
+Every example below reads its tag from one variable, so a stack cannot end up with a 0.5.11 api beside a 0.5.9 proxy:
+
+```bash
+# .env — the one line that pins all seven tale-* images
+VERSION=0.5.11
+```
+
+`0.5.11` is the release this page happened to be written against, not a recommendation. Install the current one: its number is on the [latest release](https://github.com/tale-project/tale/releases/latest) page, and that is what belongs in `VERSION`. Compose substitutes it from the `.env` in the project directory — the same file that carries your secrets.
 
 ## The stateless services
 
@@ -83,7 +92,7 @@ Below are the three stateless roles — aliases, `/ping` as liveness, `TALE_ROLE
 # add depends_on: { db: { condition: service_healthy }, … } as well.
 services:
   platform:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     env_file: [.env]
     volumes: ['config-data:/app/data:ro']
     restart: unless-stopped
@@ -102,7 +111,7 @@ services:
       internal:
         aliases: [platform]
   backend-api:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     environment:
       TALE_ROLE: api
       PORT: '3005'
@@ -127,7 +136,7 @@ services:
       sandbox:
         aliases: [backend-api]
   backend-worker:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     environment:
       TALE_ROLE: worker
       TALE_CONFIG_DIR: /app/data
@@ -267,9 +276,13 @@ Publish only `80` and `443` on `proxy`. Everything else stays on the internal ne
 Bring the stores up first, then the sandbox plane, then the app tier. An api that starts before `db` and `object-store` are healthy crash-loops on `ENOTFOUND` and on a missing database. In one file, `depends_on` with `service_healthy` is enough.
 
 ```bash
+# The pull is not a compose command, so it needs the tag .env pins in this
+# shell too.
+VERSION=$(sed -n 's/^VERSION=//p' .env)
+
 # Not a compose service, and the spawner blocks on it at boot — pull it first so
 # the sandbox probe is not waiting on several gigabytes.
-docker pull ghcr.io/tale-project/tale/tale-sandbox-runtime:0.5.11
+docker pull "ghcr.io/tale-project/tale/tale-sandbox-runtime:$VERSION"
 
 docker compose up -d
 # Wait until db, object-store, proxy, sandbox, sandbox-egress, sandbox-llm-gateway

--- a/docs/fr/self-hosted/install/own-compose.md
+++ b/docs/fr/self-hosted/install/own-compose.md
@@ -71,7 +71,16 @@ Chaque image `tale-*` est publiée sur la GitHub Container Registry sous le mêm
 | `object-store` | `minio/minio:RELEASE.2025-04-22T22-12-26Z` |
 | `bgutil-provider` | `brainicism/bgutil-ytdlp-pot-provider:1.3.1` |
 
-Une image n’est pas un service compose : le spawner crée chaque conteneur de session depuis `ghcr.io/tale-project/tale/tale-sandbox-runtime:<version>`, et son défaut intégré est le tag local que construit la stack de développement — un hôte qui ne l’a jamais construit nomme l’image de la registry dans `SANDBOX_RUNTIME_IMAGE`, sinon `Run code`, le rendu web et la génération de documents échouent tous sur une image introuvable. Récupère cette image toi-même avant le premier `up`. Le spawner la préchauffe au boot et ne répond sur `:8003` qu’une fois le pull terminé : sur un hôte froid, la sandbox reste donc en `starting` le temps que plusieurs gigaoctets arrivent — c’est exactement pour ça que `tale deploy` la récupère avant la stack. Les exemples ci-dessous épinglent la release que documente cette page ; remplace le tag par la release que tu installes.
+Une image n’est pas un service compose : le spawner crée chaque conteneur de session depuis `ghcr.io/tale-project/tale/tale-sandbox-runtime:<version>`, et son défaut intégré est le tag local que construit la stack de développement — un hôte qui ne l’a jamais construit nomme l’image de la registry dans `SANDBOX_RUNTIME_IMAGE`, sinon `Run code`, le rendu web et la génération de documents échouent tous sur une image introuvable. Récupère cette image toi-même avant le premier `up`. Le spawner la préchauffe au boot et ne répond sur `:8003` qu’une fois le pull terminé : sur un hôte froid, la sandbox reste donc en `starting` le temps que plusieurs gigaoctets arrivent — c’est exactement pour ça que `tale deploy` la récupère avant la stack.
+
+Chaque exemple ci-dessous lit son tag depuis une seule variable, pour qu’une stack ne finisse jamais avec une api 0.5.11 à côté d’un proxy 0.5.9 :
+
+```bash
+# .env — the one line that pins all seven tale-* images
+VERSION=0.5.11
+```
+
+`0.5.11` est la release contre laquelle cette page a été écrite, pas une recommandation. Installe la courante : son numéro est sur la page [latest release](https://github.com/tale-project/tale/releases/latest), et c’est ce numéro qui va dans `VERSION`. Compose la substitue depuis le `.env` du répertoire projet — le même fichier qui porte tes secrets.
 
 ## Les services sans état
 
@@ -83,7 +92,7 @@ Le fichier ci-dessous, ce sont les trois rôles sans état — alias, `/ping` en
 # add depends_on: { db: { condition: service_healthy }, … } as well.
 services:
   platform:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     env_file: [.env]
     volumes: ['config-data:/app/data:ro']
     restart: unless-stopped
@@ -102,7 +111,7 @@ services:
       internal:
         aliases: [platform]
   backend-api:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     environment:
       TALE_ROLE: api
       PORT: '3005'
@@ -127,7 +136,7 @@ services:
       sandbox:
         aliases: [backend-api]
   backend-worker:
-    image: ghcr.io/tale-project/tale/tale-platform:0.5.11
+    image: ghcr.io/tale-project/tale/tale-platform:${VERSION}
     environment:
       TALE_ROLE: worker
       TALE_CONFIG_DIR: /app/data
@@ -267,9 +276,13 @@ Ne publie que `80` et `443` sur `proxy`. Tout le reste reste sur le réseau inte
 Monte les stores d’abord, puis le plan sandbox, puis l’étage app. Une api qui démarre avant que `db` et `object-store` soient sains crash-loop sur `ENOTFOUND` et sur une base manquante. Dans un seul fichier, `depends_on` avec `service_healthy` suffit.
 
 ```bash
+# The pull is not a compose command, so it needs the tag .env pins in this
+# shell too.
+VERSION=$(sed -n 's/^VERSION=//p' .env)
+
 # Not a compose service, and the spawner blocks on it at boot — pull it first so
 # the sandbox probe is not waiting on several gigabytes.
-docker pull ghcr.io/tale-project/tale/tale-sandbox-runtime:0.5.11
+docker pull "ghcr.io/tale-project/tale/tale-sandbox-runtime:$VERSION"
 
 docker compose up -d
 # Wait until db, object-store, proxy, sandbox, sandbox-egress, sandbox-llm-gateway

--- a/services/docs/tests/image-pins.test.ts
+++ b/services/docs/tests/image-pins.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it } from 'vitest';
+
+import { assertNoFindings, type Finding } from './lib/findings';
+import { CONTENT_ROOT } from './lib/paths';
+import { walkDocs } from './lib/walk';
+
+/**
+ * No page hard-codes a release number onto a `tale-*` image.
+ *
+ * A literal tag in an example is wrong within days of being written: it is
+ * either behind the current release, or — as happened once — ahead of what is
+ * actually published, so the page's own `docker compose up` cannot pull. The
+ * examples therefore substitute one `${VERSION}` variable, which is also the
+ * shape operators should copy: one number pins all seven images, so a stack
+ * cannot end up with a new api beside an old proxy.
+ *
+ * Deliberately narrow — three things this must NOT flag:
+ *
+ *  - **Third-party images.** `minio/minio:RELEASE.…` and
+ *    `brainicism/bgutil-ytdlp-pot-provider:1.3.1` version independently of a
+ *    Tale release and stay pinned by hand.
+ *  - **`:latest` on a tale image.** The environment reference states the
+ *    spawner's built-in default (`tale-sandbox-runtime:latest`) as a fact
+ *    about the software; banning the string would forbid a true sentence.
+ *  - **Prose about a release.** "upgraded from before 0.5.11" is a version
+ *    boundary, not an image pin, so the match is anchored to the registry
+ *    path.
+ */
+const PINNED_TALE_IMAGE =
+  /ghcr\.io\/tale-project\/tale\/[a-z0-9-]+:\d+\.\d+\.\d+/;
+
+describe('image pins', () => {
+  it('no page hard-codes a release tag on a tale image', () => {
+    const findings: Finding[] = [];
+    for (const rel of walkDocs()) {
+      const raw = fs
+        .readFileSync(path.join(CONTENT_ROOT, rel), 'utf8')
+        .replaceAll('\r\n', '\n');
+      raw.split('\n').forEach((line, index) => {
+        const match = PINNED_TALE_IMAGE.exec(line);
+        if (match) {
+          findings.push({
+            file: rel,
+            line: index + 1,
+            rule: 'image-pin-hard-coded',
+            detail: `\`${match[0]}\` hard-codes a release — substitute the tag (\`:\${VERSION}\`) and pin it once in the page's .env example`,
+          });
+        }
+      });
+    }
+    assertNoFindings(findings, 'Hard-coded image pins');
+  });
+});


### PR DESCRIPTION
The `own-compose` examples carried a literal `0.5.11` in **twelve places** (four per locale), and
nothing on the page said it was an example. Two costs, both already paid:

- **The literal goes stale in both directions.** When the page shipped, `0.5.11` was not yet
  published — for a while the page's own `docker compose up` could not pull the images it printed.
  After a release lands, every example trails it instead.
- **A reader cannot tell a version to reproduce from one to replace.** The page prints exact values
  everywhere else, so a literal tag reads like part of the contract.

## What changes

Every example reads its tag from one `VERSION` variable, pinned once in the `.env` the page already
asks for:

```bash
# .env — the one line that pins all seven tale-* images
VERSION=0.5.11
```

…followed by the sentence that was missing: `0.5.11` is what the page happened to be written
against, not a recommendation — install the current release (linked) and put that number here.

This is also the shape operators should copy. The page already promises "one version number pins the
whole stack"; a variable is what makes that true. Twelve hand-edited tags are exactly how a stack
ends up with a new api beside an old proxy — the skew the same page warns about.

The `docker pull` for the sandbox runtime image is **not** a compose command, so it does not get
`.env` substitution for free. It reads the pin out of `.env` explicitly rather than referencing a
shell variable that would be empty:

```bash
VERSION=$(sed -n 's/^VERSION=//p' .env)
docker pull "ghcr.io/tale-project/tale/tale-sandbox-runtime:$VERSION"
```

## The guard

`services/docs/tests/image-pins.test.ts` fails on any `ghcr.io/tale-project/tale/*` reference
carrying a semver tag, so the literals cannot creep back and a release no longer needs a docs edit.

Deliberately narrow — three things it must not flag, each verified against the current tree:

- **Third-party images.** `minio/minio:RELEASE.…` and `brainicism/bgutil-ytdlp-pot-provider:1.3.1`
  version independently of a Tale release and stay pinned by hand.
- **`tale-sandbox-runtime:latest`.** The environment reference states the spawner's built-in default
  as a fact; banning the string would forbid a true sentence.
- **Prose about a release.** "upgraded from before 0.5.11" is a version boundary, not an image pin,
  so the match is anchored to the registry path.

## Verification

`bun run --filter @tale/docs test` — 32 files / 202 tests green. Reintroducing one literal tag fails
the new check with the line and the fix:

```text
Hard-coded image pins (1):
    95: [image-pin-hard-coded] `ghcr.io/tale-project/tale/tale-platform:0.5.11` hard-codes a
        release — substitute the tag (`:${VERSION}`) and pin it once in the page's .env example
```

Against a real daemon: `docker compose config --images` substitutes `${VERSION}` from `.env` into
every ref, the `sed` line yields the same tag in the shell, and an unset variable warns and leaves an
empty tag rather than silently floating to something else. EN/DE/FR updated together.