### PR TITLE
fix(cli): fetch the images tale dev needs under a step that says so

### DIFF
--- a/services/platform/app/features/settings/data-residency/components/embedding-setup-banner.test.tsx
+++ b/services/platform/app/features/settings/data-residency/components/embedding-setup-banner.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/tests/utils/render';
+
+// The banner reports a broken knowledge base, so it must be a polite `status`
+// live region like its dashboard siblings — an assertive `alert` would
+// interrupt screen-reader users on every page of the shell.
+
+const { mockState } = vi.hoisted(() => ({
+  mockState: {
+    canRead: true,
+    abilityLoading: false,
+    embedding: undefined as unknown,
+    embeddingError: false,
+    credentials: undefined as unknown,
+  },
+}));
+
+vi.mock('@/app/hooks/use-ability', () => ({
+  useAbility: () => ({
+    can: () => mockState.canRead,
+    cannot: () => !mockState.canRead,
+  }),
+  useAbilityLoading: () => mockState.abilityLoading,
+}));
+
+vi.mock('../hooks/queries', () => ({
+  useOrgKnowledgeEmbedding: () => ({
+    data: mockState.embedding,
+    isError: mockState.embeddingError,
+  }),
+}));
+
+vi.mock('@/app/features/settings/providers/hooks/queries', () => ({
+  useProviderCredentials: () => ({ data: mockState.credentials }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { EmbeddingSetupBanner } from './embedding-setup-banner';
+
+/** The state the banner exists for: a provider is stored, no model is set. */
+function readyToNudge() {
+  mockState.canRead = true;
+  mockState.abilityLoading = false;
+  mockState.embedding = { configured: false };
+  mockState.embeddingError = false;
+  mockState.credentials = [{ id: 'cred-1' }];
+}
+
+describe('EmbeddingSetupBanner', () => {
+  it('points a provider-configured org at the embedding model it still needs', () => {
+    readyToNudge();
+
+    render(<EmbeddingSetupBanner organizationId="org-1" />);
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Knowledge search is off');
+    const link = screen.getByRole('link', {
+      name: 'Choose an embedding model',
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      '/dashboard/$id/settings/data-residency',
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('goes away once a model is configured', () => {
+    readyToNudge();
+    mockState.embedding = { configured: true };
+
+    render(<EmbeddingSetupBanner organizationId="org-1" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('stays quiet before a provider exists', () => {
+    readyToNudge();
+    // Nothing to choose a model with yet, and the setup wizard is already
+    // asking for a provider — a second nudge here is noise on an empty org.
+    mockState.credentials = [];
+
+    render(<EmbeddingSetupBanner organizationId="org-1" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('stays quiet for a reader who cannot open the settings page', () => {
+    readyToNudge();
+    mockState.canRead = false;
+
+    render(<EmbeddingSetupBanner organizationId="org-1" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('says nothing while the state is still unknown', () => {
+    readyToNudge();
+    // Loading, then failed: neither is evidence of a missing model, and
+    // "knowledge search is off" on an unknown state is worse than silence.
+    mockState.embedding = undefined;
+    render(<EmbeddingSetupBanner organizationId="org-1" />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    mockState.embedding = { configured: false };
+    mockState.embeddingError = true;
+    render(<EmbeddingSetupBanner organizationId="org-2" />);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('waits for the ability to resolve before deciding', () => {
+    readyToNudge();
+    mockState.abilityLoading = true;
+
+    render(<EmbeddingSetupBanner organizationId="org-1" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/services/platform/app/features/settings/data-residency/components/embedding-setup-banner.tsx
+++ b/services/platform/app/features/settings/data-residency/components/embedding-setup-banner.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Row } from '@tale/ui/layout';
+import { Link } from '@tanstack/react-router';
+
+import { useProviderCredentials } from '@/app/features/settings/providers/hooks/queries';
+import { useAbility, useAbilityLoading } from '@/app/hooks/use-ability';
+import { useT } from '@/lib/i18n/client';
+
+import { useOrgKnowledgeEmbedding } from '../hooks/queries';
+
+/**
+ * Dashboard banner for the gap between "this org has an AI provider" and
+ * "this org can use knowledge".
+ *
+ * An embedding model has no working default — `EmbeddingNotConfigured` is a
+ * refusal, never a guess — so an organization that never sets one has a
+ * knowledge base that cannot index or search. Until now the only places that
+ * said so were the settings page itself and the error on a document that had
+ * already failed to index, which is after the reader spent the upload.
+ *
+ * Not dismissible, and deliberately so: the state it reports is a broken
+ * knowledge base, and it clears the moment a model is configured. Two gates
+ * keep it from being noise:
+ *
+ *  - **Only once a provider exists.** With no credential there is nothing to
+ *    choose a model with, and the setup wizard is already asking for one; a
+ *    second nudge at that moment would just be noise on an empty org.
+ *  - **Only for a reader who can act.** Viewing data residency needs
+ *    `read orgSettings`, so a member who cannot open the page never sees it.
+ *
+ * Mirrors `TwoFactorLowBackupCodesBanner`'s structure — same row, same warning
+ * tint, same trailing link — so every dashboard-level nudge reads the same.
+ */
+export function EmbeddingSetupBanner({
+  organizationId,
+}: {
+  organizationId: string;
+}) {
+  const { t } = useT('settings');
+  const ability = useAbility();
+  const abilityLoading = useAbilityLoading();
+  const embeddingQuery = useOrgKnowledgeEmbedding(organizationId);
+  const credentialsQuery = useProviderCredentials(organizationId);
+
+  if (abilityLoading || ability.cannot('read', 'orgSettings')) return null;
+  // A failed or still-loading read is not evidence of a missing model. Saying
+  // "knowledge search is off" on an unknown state is worse than saying nothing.
+  if (embeddingQuery.data === undefined || embeddingQuery.isError) return null;
+  if (embeddingQuery.data.configured) return null;
+  if ((credentialsQuery.data ?? []).length === 0) return null;
+
+  return (
+    <Row
+      role="status"
+      gap={2}
+      wrap
+      className="bg-warning/10 border-warning/30 shrink-0 border-b px-4 py-3 text-sm"
+    >
+      <span className="grow">
+        <span className="font-medium">
+          {t('dataResidency.orgEmbedding.banner.title')}
+        </span>
+        {' — '}
+        {t('dataResidency.orgEmbedding.banner.body')}
+      </span>
+      <Link
+        to="/dashboard/$id/settings/data-residency"
+        params={{ id: organizationId }}
+        className="underline underline-offset-2"
+      >
+        {t('dataResidency.orgEmbedding.banner.link')}
+      </Link>
+    </Row>
+  );
+}

--- a/services/platform/app/routes/dashboard/$id.tsx
+++ b/services/platform/app/routes/dashboard/$id.tsx
@@ -27,6 +27,7 @@ import { TwoFactorGraceBanner } from '@/app/features/auth/components/two-factor-
 import { TwoFactorLowBackupCodesBanner } from '@/app/features/auth/components/two-factor-low-backup-codes-banner';
 import { usePasswordExpiryGate } from '@/app/features/auth/hooks/use-password-expiry-gate';
 import { ChangelogToastTrigger } from '@/app/features/changelog/components/changelog-toast-trigger';
+import { EmbeddingSetupBanner } from '@/app/features/settings/data-residency/components/embedding-setup-banner';
 import { ClockOffsetProvider } from '@/app/hooks/use-clock-offset';
 import { useCurrentMemberContext } from '@/app/hooks/use-current-member-context';
 import { useAuth } from '@/app/hooks/use-session-user';
@@ -277,6 +278,9 @@ function DashboardLayout() {
                       <TwoFactorLowBackupCodesBanner
                         organizationId={organizationId}
                       />
+                    )}
+                    {hasRole && (
+                      <EmbeddingSetupBanner organizationId={organizationId} />
                     )}
                     <div className="flex min-h-0 flex-1 flex-col overflow-hidden md:flex-row">
                       {/* Safe-area inset clears the notch; the inner fixed-height row

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -6182,6 +6182,13 @@ settings:
       notConfiguredWarning:
         Die Wissenssuche ist nicht verfügbar, bis ein Embedding-Modell
         eingerichtet ist.
+      banner:
+        title: Wissenssuche ist aus
+        body:
+          Diese Organisation hat einen KI-Anbieter, aber kein
+          Embedding-Modell — Dokumente lassen sich weder indexieren noch
+          durchsuchen.
+        link: Embedding-Modell wählen
       recommendationBody:
         Dein {provider}-Zugang kann {model} bedienen ({dimensions}-dimensionale
         Vektoren).

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -6282,6 +6282,12 @@ settings:
       notConfiguredWarning:
         Knowledge search is unavailable until an embedding model is
         configured.
+      banner:
+        title: Knowledge search is off
+        body:
+          This organization has an AI provider but no embedding model, so
+          documents cannot be indexed or searched.
+        link: Choose an embedding model
       recommendationBody:
         Your {provider} credential can serve {model} ({dimensions}-dimensional
         vectors).

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -6297,6 +6297,13 @@ settings:
       notConfiguredWarning:
         La recherche de connaissances est indisponible tant qu'aucun modèle
         d'embedding n'est configuré.
+      banner:
+        title: La recherche de connaissances est coupée
+        body:
+          Cette organisation a un fournisseur IA mais aucun modèle
+          d'embedding, donc les documents ne peuvent être ni indexés ni
+          cherchés.
+        link: Choisir un modèle d'embedding
       recommendationBody:
         Ton identifiant {provider} peut servir {model} (vecteurs à {dimensions}
         dimensions).

--- a/tools/cli/src/lib/actions/dev.ts
+++ b/tools/cli/src/lib/actions/dev.ts
@@ -34,6 +34,7 @@ import {
 import { dockerCompose } from '../docker/docker-compose';
 import { ensureConfigMountpoints } from '../docker/ensure-config-mountpoints';
 import { ensureDocker } from '../docker/ensure-docker';
+import { ensureImagePresent } from '../docker/ensure-image-present';
 import { ensureNetwork, ensureSandboxNetwork } from '../docker/ensure-network';
 import { ensureSandboxRuntimeImage } from '../docker/ensure-sandbox-runtime-image';
 import { ensureVolumes } from '../docker/ensure-volumes';
@@ -160,7 +161,25 @@ export async function runDev(options: DevOptions): Promise<void> {
   await assertDockerAvailable();
 
   const imageVersion = pkg.version.includes('-dev') ? 'latest' : pkg.version;
+  const appImage = `${env.GHCR_REGISTRY}/tale-platform:${imageVersion}`;
   const devPrefix = `${getProjectId()}-dev_`;
+
+  // Both images the CLI needs in its own hands before compose runs, fetched
+  // under a label that says so. The spawner's runtime image is a `docker run`
+  // and never a compose service; the app image is what the config-mountpoint
+  // helper runs on, and waiting for that download inside "Preparing volumes &
+  // networks" spends minutes of a first run under a label about neither.
+  await runStep(
+    {
+      active: 'Fetching the sandbox runtime and app images',
+      done: 'Images ready',
+    },
+    async () => {
+      await ensureSandboxRuntimeImage(env.GHCR_REGISTRY, imageVersion);
+      await ensureImagePresent(appImage);
+    },
+  );
+
   await runStep(
     {
       active: 'Preparing volumes & networks',
@@ -186,7 +205,7 @@ export async function runDev(options: DevOptions): Promise<void> {
         await ensureConfigMountpoints(
           `${devPrefix}config-data`,
           orgConfigMountTargets(projectDir),
-          `${env.GHCR_REGISTRY}/tale-platform:${imageVersion}`,
+          appImage,
         );
         if (!(await ensureNetwork('internal', devPrefix))) {
           throw new Error('Failed to create dev network');
@@ -204,19 +223,6 @@ export async function runDev(options: DevOptions): Promise<void> {
   const hostAlias = options.host ?? 'localhost';
   const portSuffix = port === 443 ? '' : `:${port}`;
   const url = `${env.SITE_URL.replace(/:443$/, '')}${portSuffix}`;
-
-  // Session containers are `docker run`, not compose services, so `compose up`
-  // never fetches the runtime image. Without it every agent turn and
-  // `Run code` fails with a "pull access denied" that reads like a login
-  // problem. `tale deploy` already does this; only a tag that is missing is
-  // fetched, so a source build stays untouched.
-  await runStep(
-    {
-      active: 'Checking the sandbox runtime image',
-      done: 'Sandbox runtime image ready',
-    },
-    () => ensureSandboxRuntimeImage(env.GHCR_REGISTRY, version),
-  );
 
   const compose = generateDevCompose(
     { version, registry: env.GHCR_REGISTRY },

--- a/tools/cli/src/lib/docker/ensure-image-present.test.ts
+++ b/tools/cli/src/lib/docker/ensure-image-present.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { ensureImagePresent, imagePresent } from './ensure-image-present';
+
+const IMAGE = 'ghcr.io/tale-project/tale/tale-platform:0.5.12';
+
+function fakeDeps({ present = false, pullOk = true } = {}) {
+  return {
+    docker: mock(() =>
+      Promise.resolve({
+        success: present,
+        exitCode: present ? 0 : 1,
+        stdout: '',
+        stderr: present ? '' : 'No such image',
+      }),
+    ),
+    pullImage: mock(() => Promise.resolve(pullOk)),
+    logger: { warn: mock() },
+  };
+}
+
+describe('ensureImagePresent', () => {
+  test('does not pull an image the daemon already holds', async () => {
+    const deps = fakeDeps({ present: true });
+
+    expect(await ensureImagePresent(IMAGE, deps)).toBe(true);
+    expect(deps.pullImage).not.toHaveBeenCalled();
+  });
+
+  test('pulls a missing image', async () => {
+    const deps = fakeDeps();
+
+    expect(await ensureImagePresent(IMAGE, deps)).toBe(true);
+    expect(deps.pullImage).toHaveBeenCalledWith(IMAGE);
+  });
+
+  test('warns instead of throwing when the pull fails', async () => {
+    const deps = fakeDeps({ pullOk: false });
+
+    // Compose pulls the same image moments later and reports its own failure;
+    // throwing here would surface two errors for one cause.
+    expect(await ensureImagePresent(IMAGE, deps)).toBe(false);
+    expect(deps.logger.warn).toHaveBeenCalled();
+  });
+});
+
+describe('imagePresent', () => {
+  test('asks the daemon and reports what it says', async () => {
+    const deps = fakeDeps({ present: true });
+
+    expect(await imagePresent(IMAGE, deps.docker)).toBe(true);
+    expect(deps.docker).toHaveBeenCalledWith('image', 'inspect', IMAGE);
+  });
+});

--- a/tools/cli/src/lib/docker/ensure-image-present.ts
+++ b/tools/cli/src/lib/docker/ensure-image-present.ts
@@ -1,0 +1,47 @@
+import * as defaultLogger from '../../utils/logger';
+import { docker as defaultDocker } from './docker';
+import { pullImage as defaultPullImage } from './pull-image';
+
+interface EnsureImageDeps {
+  docker: typeof defaultDocker;
+  pullImage: typeof defaultPullImage;
+  logger: Pick<typeof defaultLogger, 'warn'>;
+}
+
+/** Whether the daemon already holds this image. */
+export async function imagePresent(
+  image: string,
+  docker: typeof defaultDocker = defaultDocker,
+): Promise<boolean> {
+  return (await docker('image', 'inspect', image)).success;
+}
+
+/**
+ * Fetch `image` unless the daemon already holds it.
+ *
+ * For an image the CLI runs itself before compose does — the config-mountpoint
+ * helper runs on the app image, and waiting for that download inside a step
+ * labelled "Preparing volumes & networks" spends minutes of a first run under
+ * a label that says nothing about a download.
+ *
+ * Best-effort, like the rest of the pre-compose image work: compose pulls the
+ * same image moments later and reports its own failure, so a warning here
+ * beats a second error message for one cause.
+ */
+export async function ensureImagePresent(
+  image: string,
+  {
+    docker = defaultDocker,
+    pullImage = defaultPullImage,
+    logger = defaultLogger,
+  }: Partial<EnsureImageDeps> = {},
+): Promise<boolean> {
+  if (await imagePresent(image, docker)) {
+    return true;
+  }
+  if (await pullImage(image)) {
+    return true;
+  }
+  logger.warn(`Could not fetch ${image}; compose will try again.`);
+  return false;
+}

--- a/tools/cli/src/lib/docker/ensure-sandbox-runtime-image.ts
+++ b/tools/cli/src/lib/docker/ensure-sandbox-runtime-image.ts
@@ -1,5 +1,6 @@
 import * as defaultLogger from '../../utils/logger';
 import { docker as defaultDocker } from './docker';
+import { imagePresent } from './ensure-image-present';
 import { pullImage as defaultPullImage } from './pull-image';
 
 /**
@@ -48,8 +49,7 @@ export async function ensureSandboxRuntimeImage(
     logger = defaultLogger,
   }: Partial<EnsureRuntimeImageDeps> = {},
 ): Promise<EnsureRuntimeImageOutcome> {
-  const present = await docker('image', 'inspect', SANDBOX_RUNTIME_LOCAL_TAG);
-  if (present.success) {
+  if (await imagePresent(SANDBOX_RUNTIME_LOCAL_TAG, docker)) {
     return 'present';
   }
 

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,9 @@
     "STORYBOOK_DISABLE_TELEMETRY",
     "TELEMETRY_DISABLED",
     "SCARF_ANALYTICS",
-    "SANDBOX_TOKEN"
+    "SANDBOX_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN"
   ],
   "tasks": {
     "setup": {


### PR DESCRIPTION
Two things found while cold-starting **v0.5.12** on a host wiped to zero images, containers and
volumes.

## 1. `tale dev` spent three minutes downloading under a label about volumes

The config-mountpoint helper runs on the app image, so a first bring-up waited for a 2.94 GB pull
inside a step that says nothing about a download. Measured against the released 0.5.12:

```text
[ + ] Volumes & networks ready (3m03s)
[ + ] Sandbox runtime image ready (7m40s)
```

The second wait is more than twice as long and nobody minds it — the label says what is happening.
The first reads as a hang, on the very first run of the quickstart.

Both images the CLI needs in its own hands before compose runs now come from one step that names
them, and the volume work goes back to being instant. The runtime image is the same fetch as before,
moved up; the app image is a plain pull when absent, best-effort, because compose pulls it moments
later and reports its own failure. `imagePresent` is now shared rather than asked in two different
sets of words.

## 2. A provider-only org has a knowledge base that cannot index, and nothing says so

An embedding model has no working default — `EmbeddingNotConfigured` is a refusal, never a guess. An
organization that adds a provider and stops there has knowledge that cannot be indexed or searched,
and until now the only places that said so were the data-residency page itself and the error on a
document that had **already** failed to index, which is after the reader spent the upload.

A dashboard banner closes the gap, in the shell beside the two-factor nudges so it is visible from
chat — where a reader lands after the setup wizard.

Two gates keep it from being a tax on everyone else:

- **Only once a provider credential exists.** Before that there is nothing to choose a model with,
  and the setup wizard is already asking for a provider; a second nudge there is noise on an empty
  org.
- **Only for a reader with `read orgSettings`** — the permission the page it links to requires. A
  member who cannot open it never sees it.

It clears itself the moment a model is configured, so it carries no dismissal. An unknown state stays
silent: a loading or failed read is not evidence of a missing model, and "knowledge search is off" on
an unknown state is worse than saying nothing.

## Verification

- `tools/cli`: `bun test` 436 pass / 0 fail, `tsc --noEmit` clean, `oxlint` clean. Four new cases
  cover fetch-only-when-absent, the pull, and the warn-not-throw path.
- `services/platform`: the touched UI projects run 9 files / 73 tests green; `tsc --noEmit` clean;
  `oxlint --type-aware` clean; i18n parity 50 tests green. Six new cases pin the banner's gates and
  its polite `status` role, asserting the shipped English strings so the catalog wiring is exercised.
- EN/DE/FR updated together.

**Not yet verified end to end:** the "after" run for change 1 needs the app image absent, and it is
currently pinned by the running 0.5.12 stack on this machine. The "before" number above is measured
from that same released binary; I will run the cold comparison once the stack is free.
