### PR TITLE
docs: give own-compose the three facts a reader still had to guess

### DIFF
--- a/docs/de/self-hosted/install/own-compose.md
+++ b/docs/de/self-hosted/install/own-compose.md
@@ -191,6 +191,7 @@ Zwei Docker-Netze tragen jeden Hop. Ein gewöhnliches Compose-Netz reicht für d
 | `sandbox` | Der Sandbox-Spawner | `internal`, `sandbox` |
 | `sandbox-egress` | Der Egress-Proxy | `internal`, `sandbox` |
 | `llm-gateway` | `sandbox-llm-gateway` | `internal`, `sandbox` |
+| `bgutil-provider` | Der YouTube-PO-Token-Sidecar des Workers, den er standardmäßig unter `http://bgutil-provider:4416` erreicht | `internal` |
 | `HOST` (dein öffentlicher Hostname) | `proxy`, damit ein Container zur öffentlichen URL hairpinnen kann | `internal` |
 
 Worker haben keinen geteilten Alias. Nichts adressiert einen Worker per Name; sie holen Jobs nur aus der Queue. Farb-suffigierte Aliase (`backend-api-blue`, `platform-green`) sind nur für ein Blue-Green, während zwei Versionen gleichzeitig oben sind.
@@ -207,7 +208,7 @@ Nenn diese logischen Volumes in deinem Compose. Eine Datei kann Compose sie anle
 | `db-data` | `db` unter `/var/lib/postgresql/data` | `tale_app` und `tale_knowledge` |
 | `db-backup` | `db` unter `/var/lib/postgresql/backup` | Postgres-Backup-Ziel im Container |
 | `object-store-data` | `object-store` unter `/data` | Blobs |
-| `caddy-data`, `caddy-config` | `proxy` | Zertifikate und Caddy-Zustand |
+| `caddy-data`, `caddy-config` | `proxy` unter `/data` und `/config` | Zertifikate und Caddy-Zustand |
 | `llm-gateway-data` | `sandbox-llm-gateway` unter `/app/data` | Virtuelle Keys pro Session |
 
 Instanzen, die vor 0.5.11 upgraded wurden, haben neben `config-data` oft noch ein `convex-data`-Volume. Die CLI kopiert den Store einmal rüber und löscht das alte Volume nie. Ein handgeschriebenes First-Boot auf einem frischen Host braucht `convex-data` nicht.
@@ -267,6 +268,7 @@ Die sehen optional aus und gehen geschlossen kaputt, wenn sie fehlen.
 | `sandbox` | `/var/run/docker.sock` und `/var/lib/tale-sandbox` 1:1 bind-gemountet | Der Spawner kann keine Session-Container anlegen; Workspace-Pfade, die der Daemon mountet, passen nicht. |
 | `db` | `stop_signal: SIGINT`, `stop_grace_period: 60s`, `shm_size: 256mb` | Ein `SIGTERM`-Warten-auf-Clients endet in `SIGKILL` und kann den BM25-Index mit einer genullten Page hinterlassen. |
 | `platform` | `stop_grace_period: 45s` | Dockers Default-Grace von 10s `SIGKILL`t den Web-Tier mitten im Drain und kappt In-flight-HTTP/SSE. |
+| `object-store` | `command: server /data` | Der Entrypoint des Images gibt seine Verwendung aus und endet, der Container serviert also nie und `mc ready local` wird nie grün. |
 | `object-store` | Keine veröffentlichten Ports | Presigned URLs laufen durch den Proxy. MinIO zu veröffentlichen ist eine zusätzliche öffentliche Fläche. |
 
 Veröffentliche nur `80` und `443` auf `proxy`. Alles andere bleibt im internen Netz.

--- a/docs/en/self-hosted/install/own-compose.md
+++ b/docs/en/self-hosted/install/own-compose.md
@@ -191,6 +191,7 @@ Two Docker networks carry every hop. An ordinary compose network is enough for t
 | `sandbox` | The sandbox spawner | `internal`, `sandbox` |
 | `sandbox-egress` | The egress proxy | `internal`, `sandbox` |
 | `llm-gateway` | `sandbox-llm-gateway` | `internal`, `sandbox` |
+| `bgutil-provider` | The worker's YouTube PO-token sidecar, which it reaches at `http://bgutil-provider:4416` by default | `internal` |
 | `HOST` (your public hostname) | `proxy`, so a container can hairpin to the public URL | `internal` |
 
 Workers have no shared alias. Nothing addresses a worker by name; they only claim jobs from the queue. Colour-suffixed aliases (`backend-api-blue`, `platform-green`) are only for a blue-green while two versions are up at once.
@@ -207,7 +208,7 @@ Name these logical volumes in your compose. One file can let compose create them
 | `db-data` | `db` at `/var/lib/postgresql/data` | `tale_app` and `tale_knowledge` |
 | `db-backup` | `db` at `/var/lib/postgresql/backup` | In-container Postgres backup target |
 | `object-store-data` | `object-store` at `/data` | Blobs |
-| `caddy-data`, `caddy-config` | `proxy` | Certificates and Caddy state |
+| `caddy-data`, `caddy-config` | `proxy` at `/data` and `/config` | Certificates and Caddy state |
 | `llm-gateway-data` | `sandbox-llm-gateway` at `/app/data` | Per-session virtual keys |
 
 Instances upgraded from before 0.5.11 may still have a `convex-data` volume beside `config-data`. The CLI copies the store across once and never deletes the old volume. A hand-rolled first boot on a fresh host does not need `convex-data`.
@@ -267,6 +268,7 @@ These look optional and fail closed when they are missing.
 | `sandbox` | `/var/run/docker.sock` and `/var/lib/tale-sandbox` bind-mounted 1:1 | The spawner cannot create session containers; workspace paths the daemon mounts will not match. |
 | `db` | `stop_signal: SIGINT`, `stop_grace_period: 60s`, `shm_size: 256mb` | A `SIGTERM` wait-for-clients stop ends in `SIGKILL` and can leave the BM25 index with a zeroed page. |
 | `platform` | `stop_grace_period: 45s` | Docker's default 10s grace `SIGKILL`s the web tier mid-drain and cuts in-flight HTTP/SSE. |
+| `object-store` | `command: server /data` | The image's entrypoint prints its usage and exits, so the container never serves and `mc ready local` never passes. |
 | `object-store` | No published ports | Presigned URLs go through the proxy. Publishing MinIO is an extra public surface. |
 
 Publish only `80` and `443` on `proxy`. Everything else stays on the internal network.

--- a/docs/fr/self-hosted/install/own-compose.md
+++ b/docs/fr/self-hosted/install/own-compose.md
@@ -191,6 +191,7 @@ Deux réseaux Docker portent chaque saut. Un réseau compose ordinaire suffit po
 | `sandbox` | Le spawner sandbox | `internal`, `sandbox` |
 | `sandbox-egress` | Le proxy d’egress | `internal`, `sandbox` |
 | `llm-gateway` | `sandbox-llm-gateway` | `internal`, `sandbox` |
+| `bgutil-provider` | Le sidecar PO-token YouTube du worker, qu’il joint par défaut sur `http://bgutil-provider:4416` | `internal` |
 | `HOST` (ton hostname public) | `proxy`, pour qu’un conteneur puisse faire un hairpin vers l’URL publique | `internal` |
 
 Les workers n’ont pas d’alias partagé. Rien n’adresse un worker par nom ; ils ne font que prendre des jobs dans la queue. Les alias suffixés par une couleur (`backend-api-blue`, `platform-green`) ne servent que pour un blue-green pendant que deux versions tournent à la fois.
@@ -207,7 +208,7 @@ Nomme ces volumes logiques dans ton compose. Un seul fichier peut laisser compos
 | `db-data` | `db` sous `/var/lib/postgresql/data` | `tale_app` et `tale_knowledge` |
 | `db-backup` | `db` sous `/var/lib/postgresql/backup` | Cible de backup Postgres dans le conteneur |
 | `object-store-data` | `object-store` sous `/data` | Blobs |
-| `caddy-data`, `caddy-config` | `proxy` | Certificats et état Caddy |
+| `caddy-data`, `caddy-config` | `proxy` sous `/data` et `/config` | Certificats et état Caddy |
 | `llm-gateway-data` | `sandbox-llm-gateway` sous `/app/data` | Clés virtuelles par session |
 
 Les instances montées depuis avant 0.5.11 peuvent encore avoir un volume `convex-data` à côté de `config-data`. La CLI copie le magasin une fois et ne supprime jamais l’ancien volume. Un premier boot écrit à la main sur un hôte neuf n’a pas besoin de `convex-data`.
@@ -267,6 +268,7 @@ Ils ont l’air optionnels et échouent fermés quand ils manquent.
 | `sandbox` | `/var/run/docker.sock` et `/var/lib/tale-sandbox` montés en bind 1:1 | Le spawner ne peut pas créer les conteneurs de session ; les chemins workspace que le daemon monte ne correspondent pas. |
 | `db` | `stop_signal: SIGINT`, `stop_grace_period: 60s`, `shm_size: 256mb` | Un arrêt `SIGTERM` qui attend les clients finit en `SIGKILL` et peut laisser l’index BM25 avec une page à zéro. |
 | `platform` | `stop_grace_period: 45s` | La grâce Docker par défaut de 10s envoie `SIGKILL` à l’étage web au milieu du drain et coupe le HTTP/SSE en vol. |
+| `object-store` | `command: server /data` | L’entrypoint de l’image affiche son usage et se termine : le conteneur ne sert jamais et `mc ready local` ne passe jamais. |
 | `object-store` | Aucun port publié | Les URLs présignées passent par le proxy. Publier MinIO est une surface publique en plus. |
 
 Ne publie que `80` et `443` sur `proxy`. Tout le reste reste sur le réseau interne.


### PR DESCRIPTION
Built the stack from the page again on a host wiped to zero images, containers and volumes — this
time on **0.5.12**, with the fixes from #3285 and #3288 live. It came up **in one pass**: ten
containers healthy, `/api/health` `{"status":"ok","version":"0.5.12"}`, `/ping` and `/ready` 200,
`${VERSION}` substituting into all eight image refs, `object store (seeded): bucket "tale-blobs"`
with the right `publicEndpoint`, and the gateway management API answering **200** to the documented
`admin` credential. This morning the same exercise took three fixes to boot at all.

Three things still came from somewhere other than the page.

## `minio/minio` serves nothing without a command

```console
$ docker run --rm minio/minio:RELEASE.2025-04-22T22-12-26Z
NAME:
  minio - High Performance Object Storage
...
exit=0
```

The page names the image and gives `mc ready local` as its probe. A reader who writes the service
from exactly those two facts gets a container that exits immediately and a probe that can never
pass — the same shape as the gateway's missing `curl`: the failure points at the probe, not at the
missing command. `command: server /data` now sits in the table of things that look optional and fail
closed.

## The volumes table skips a path on one row

Every other row says where the volume lands — `db` at `/var/lib/postgresql/data`, `object-store` at
`/data`, `sandbox-llm-gateway` at `/app/data`. `caddy-data` / `caddy-config` said only `proxy`.
Verified against the running proxy: `/data` holds `caddy/certificates` and `instance.uuid`,
`/config` holds the `Caddyfile`. The row now reads like its neighbours.

## `bgutil-provider` is absent from the DNS-names table

Five mentions on the page, zero rows in the table that lists what each process resolves — while the
worker reaches the sidecar at its baked default `http://bgutil-provider:4416`. Name the service
anything else and YouTube ingest degrades silently, because the sidecar is best-effort and nothing
fails loudly enough to point at the alias.

## Verification

`bun run --filter @tale/docs test` — 32 files / 202 tests green. Every claim is checked against the
running 0.5.12 stack this page produced; none of them changes the stack, they only write down what
it already does. EN/DE/FR together.
