### PR TITLE
fix(platform): unred main after craft/copy merge

### DIFF
--- a/services/docs/Dockerfile
+++ b/services/docs/Dockerfile
@@ -38,6 +38,8 @@ FROM workspace-deps AS builder
 WORKDIR /app
 
 COPY tsconfig.base.json ./
+COPY tsconfig.dom.json ./
+COPY tsconfig.vite.json ./
 COPY packages/ui ./packages/ui
 COPY services/docs ./services/docs
 COPY docs ./docs

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -62,6 +62,7 @@ WORKDIR /app
 COPY --from=workspace-deps /app/node_modules ./node_modules
 
 COPY tsconfig.base.json ./tsconfig.base.json
+COPY tsconfig.dom.json ./tsconfig.dom.json
 
 COPY services/platform/vite.config.ts \
      services/platform/tsconfig.json \

--- a/services/platform/Dockerfile
+++ b/services/platform/Dockerfile
@@ -63,6 +63,7 @@ COPY --from=workspace-deps /app/node_modules ./node_modules
 
 COPY tsconfig.base.json ./tsconfig.base.json
 COPY tsconfig.dom.json ./tsconfig.dom.json
+COPY tsconfig.convex.json ./tsconfig.convex.json
 
 COPY services/platform/vite.config.ts \
      services/platform/tsconfig.json \

--- a/services/platform/app/components/ui/data-display/zoom-pan-viewer.test.tsx
+++ b/services/platform/app/components/ui/data-display/zoom-pan-viewer.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+
+import { fireEvent, render, screen, act } from '@/tests/utils/render';
 
 import { ZoomPanViewer } from './zoom-pan-viewer';
 

--- a/services/platform/app/features/conversations/components/message.test.tsx
+++ b/services/platform/app/features/conversations/components/message.test.tsx
@@ -2,8 +2,9 @@
 // outbound row and the visible not-delivered treatment (reason + retry) on a
 // failed one. Fake timers drive the countdown deterministically.
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { act, fireEvent, render, screen } from '@/tests/utils/render';
 
 import type { Message as MessageType } from '../types';
 import { Message } from './message';

--- a/services/platform/app/features/documents/components/document-preview-image.test.tsx
+++ b/services/platform/app/features/documents/components/document-preview-image.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+
+import { fireEvent, render, screen } from '@/tests/utils/render';
 
 import { DocumentPreviewImage } from './document-preview-image';
 

--- a/services/platform/app/features/knowledge-entries/components/knowledge-entry-add-dialog.test.tsx
+++ b/services/platform/app/features/knowledge-entries/components/knowledge-entry-add-dialog.test.tsx
@@ -104,7 +104,7 @@ describe('AddKnowledgeEntryDialog', () => {
     await waitFor(() =>
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: 'Failed to add knowledge entry',
+          title: "Couldn't add knowledge entry",
           variant: 'destructive',
         }),
       ),

--- a/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
+++ b/services/platform/app/features/settings/enterprise-sso/components/enterprise-sso-form.test.tsx
@@ -364,7 +364,7 @@ describe('EnterpriseSsoForm validation + save', () => {
     await waitFor(() => expect(toastMock).toHaveBeenCalledTimes(1));
     expect(toastMock).toHaveBeenCalledWith({
       title: 'Save',
-      description: 'Failed to save',
+      description: "Couldn't save",
       variant: 'destructive',
     });
   });

--- a/services/platform/app/features/settings/governance/components/budget-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/budget-editor.test.tsx
@@ -109,7 +109,7 @@ describe('BudgetEditor', () => {
       setLoaded([]);
       render(<BudgetEditor organizationId="org-1" />);
       expect(
-        screen.getByRole('heading', { name: /budget rules/i }),
+        screen.getByRole('heading', { name: /^budget rules$/i }),
       ).toBeInTheDocument();
     });
 
@@ -131,7 +131,7 @@ describe('BudgetEditor', () => {
       setLoading();
       render(<BudgetEditor organizationId="org-1" />);
       expect(
-        screen.getByRole('heading', { name: /budget rules/i }),
+        screen.getByRole('heading', { name: /^budget rules$/i }),
       ).toBeInTheDocument();
     });
 

--- a/services/platform/app/features/settings/governance/components/login-policy-editor.test.tsx
+++ b/services/platform/app/features/settings/governance/components/login-policy-editor.test.tsx
@@ -172,7 +172,7 @@ describe('LoginPolicyEditor', () => {
       });
 
       expect(rejection).toBeInstanceOf(Error);
-      expect((rejection as Error).message).toBe('Failed to save login policy');
+      expect((rejection as Error).message).toBe("Couldn't save login policy");
       expect(pageToast).not.toHaveBeenCalled();
 
       saveMutateAsync.mockResolvedValue(null);

--- a/services/platform/app/features/websites/components/website-add-dialog.test.tsx
+++ b/services/platform/app/features/websites/components/website-add-dialog.test.tsx
@@ -147,7 +147,7 @@ describe('AddWebsiteDialog', () => {
       await waitFor(() =>
         expect(toast).toHaveBeenCalledWith(
           expect.objectContaining({
-            title: 'Failed to add website',
+            title: "Couldn't add website",
             variant: 'destructive',
           }),
         ),

--- a/services/platform/tests/e2e/specs/return-loops.spec.ts
+++ b/services/platform/tests/e2e/specs/return-loops.spec.ts
@@ -52,7 +52,12 @@ test('notification bell: sorts by priority and expands into a modal', async ({
   await expect(expand).toBeVisible({ timeout: TIMEOUT.VISIBLE });
   await expand.click();
 
-  await expect(page.getByRole('dialog')).toBeVisible({
+  // Expanding closes the popover and opens the modal. The popover's content is
+  // also `role="dialog"` (Radix) and can linger in the DOM with
+  // `data-state=closed` while its exit animation finishes — so an unqualified
+  // `getByRole('dialog')` matches both. Scope to the open modal.
+  const modal = page.locator('[role="dialog"][data-state="open"]');
+  await expect(modal).toBeVisible({
     timeout: TIMEOUT.VISIBLE,
   });
   await expect(
@@ -60,7 +65,7 @@ test('notification bell: sorts by priority and expands into a modal', async ({
   ).toHaveCount(0, { timeout: TIMEOUT.VISIBLE });
   // The modal keeps its own sort control.
   await expect(
-    page.getByRole('button', { name: new RegExp(`^${SORT_LABEL}:`) }),
+    modal.getByRole('button', { name: new RegExp(`^${SORT_LABEL}:`) }),
   ).toBeVisible({ timeout: TIMEOUT.VISIBLE });
 });
 

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -38,6 +38,7 @@ FROM workspace-deps AS builder
 WORKDIR /app
 
 COPY tsconfig.base.json ./
+COPY tsconfig.dom.json ./
 COPY packages/ui ./packages/ui
 COPY services/web ./services/web
 

--- a/tools/plop/templates/service/react/Dockerfile.hbs
+++ b/tools/plop/templates/service/react/Dockerfile.hbs
@@ -27,6 +27,7 @@ FROM workspace-deps AS builder
 WORKDIR /app
 
 COPY tsconfig.base.json ./
+COPY tsconfig.dom.json ./
 COPY packages/ui ./packages/ui
 COPY services/{{kebabCase name}} ./services/{{kebabCase name}}
 


### PR DESCRIPTION
## Summary
Unreds `main` after #3280 (and the prior tsconfig family split).

- **UI tests:** tip-using suites render through AppShell (`TooltipProvider`); toast/copy expectations use `Couldn't …`; budget heading query is exact so it doesn’t clash with the empty state.
- **Docker:** builder stages `COPY` `tsconfig.dom.json` / `tsconfig.vite.json` so platform/web/docs images resolve the new extends chain.
- Commitlint on the squash title (`Emil`) is a one-off merge-title issue — no code fix.

## Test plan
- [x] Previously failing UI files: 122 tests green locally
- [ ] CI Checks → UI green
- [ ] CI Build → platform / web / docs container tests green