### PR TITLE
fix(platform): show the backend warnings bun dev was dropping

### DIFF
--- a/services/platform/lib/pii/data/loader.vetting.test.ts
+++ b/services/platform/lib/pii/data/loader.vetting.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+
+/**
+ * The registry vets every shipped national-ID pattern at boot and DROPS the
+ * ones that fail — a compile error or a safe-regex2 rejection — so one bad
+ * spec cannot take the whole registry down. Fail-open is the right runtime
+ * posture, but it makes a broken spec invisible: the detector simply never
+ * fires, and the only trace is a `console.warn` on a stream the dev loop used
+ * to collapse. `es/co-cc` had been dropped that way, unnoticed.
+ *
+ * The runtime keeps failing open. This is the build-time half: a spec that
+ * would be dropped fails here, where someone is looking. A spec we have
+ * decided to ship dropped has to say so, in `KNOWN_DROPPED`, with its reason.
+ */
+
+import safe from 'safe-regex2';
+import { describe, expect, it } from 'vitest';
+
+import { loadPiiData } from './loader';
+
+/**
+ * Specs the registry drops today, ACCEPTED as dropped until someone decides
+ * otherwise. Every entry is a detector that ships and never fires.
+ *
+ * `es/co-cc` — Colombian cédula, `\b\d{1,3}(?:\.\d{3}){2,3}\b`. safe-regex2
+ * counts the nested bounded repeat and refuses it, though nothing in the
+ * pattern can backtrack catastrophically. It cannot simply be rewritten:
+ *   - the alternation form `(?:\d{1,3}\.\d{3}\.\d{3}\.\d{3}|\d{1,3}\.\d{3}\.\d{3})`
+ *     passes safe-regex2, but it matches `14.159.265` inside a version string
+ *     like `3.14.159.265` — `\b` cannot see the dot to its left;
+ *   - the left boundary needs a lookbehind, and safe-regex2 rejects EVERY
+ *     lookbehind, including `(?<!x)abc`.
+ * So under this gate a correct cédula pattern is not expressible, and masking
+ * version numbers would be worse than the detector staying dark. Resolving it
+ * is a policy call — relax the gate for provably bounded patterns, move to a
+ * real ReDoS analyser, or drop the detector on purpose — not a rewrite.
+ */
+const KNOWN_DROPPED = new Set(['es/co-cc']);
+
+describe('the shipped pii locale data', () => {
+  const { locales } = loadPiiData();
+
+  it('ships at least one locale, so an empty read cannot pass silently', () => {
+    expect(locales.length).toBeGreaterThan(0);
+  });
+
+  it('drops no national-ID pattern we have not accounted for', () => {
+    const dropped: string[] = [];
+    for (const locale of locales) {
+      for (const spec of locale.nationalIds) {
+        const key = `${locale.locale}/${spec.id}`;
+        try {
+          void new RegExp(spec.pattern);
+        } catch {
+          dropped.push(`${key}: does not compile`);
+          continue;
+        }
+        if (!safe(spec.pattern)) dropped.push(`${key}: fails safe-regex2`);
+      }
+    }
+
+    expect(dropped.map((d) => d.split(':')[0])).toEqual([...KNOWN_DROPPED]);
+  });
+
+  it('keeps KNOWN_DROPPED honest — every entry is really still dropped', () => {
+    // An entry that starts passing must be removed from the list, or the list
+    // stops describing the shipped state and starts hiding the next drop.
+    for (const key of KNOWN_DROPPED) {
+      const [code, id] = key.split('/');
+      const spec = locales
+        .find((l) => l.locale === code)
+        ?.nationalIds.find((s) => s.id === id);
+      expect(spec, `${key} is listed but no longer ships`).toBeDefined();
+      expect(
+        safe(spec!.pattern),
+        `${key} passes now — drop it from the list`,
+      ).toBe(false);
+    }
+  });
+});

--- a/services/platform/scripts/dev-engine.ts
+++ b/services/platform/scripts/dev-engine.ts
@@ -975,6 +975,10 @@ export async function runDevFleet() {
         label: 'backend',
         classifier: backendClassifier,
         mode: 'errors',
+        // A plain Node server: console.warn/error go to stderr, log/info to
+        // stdout. Without this the backend's ~430 `console.warn` calls are
+        // dropped as noise, because none of them spell `WARN` in their prose.
+        stderrIsSignal: true,
       });
       backendProcess.on('exit', (code) => {
         if (shuttingDown || restarting) return;

--- a/services/platform/scripts/dev-output.test.ts
+++ b/services/platform/scripts/dev-output.test.ts
@@ -36,9 +36,7 @@ function fakeChild(): {
 } {
   const stdout = new PassThrough();
   const stderr = new PassThrough();
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- pipeChild reads only `stdout`/`stderr` off the child
-  const child = { stdout, stderr } as Parameters<typeof pipeChild>[0];
-  return { child, stdout, stderr };
+  return { child: { stdout, stderr }, stdout, stderr };
 }
 
 /** Write a line and let the stream's data event land. */

--- a/services/platform/scripts/dev-output.test.ts
+++ b/services/platform/scripts/dev-output.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+
+/**
+ * `classifyBackend` reads prose, and the backend's warnings are not written in
+ * prose it can recognise — none of its ~430 `console.warn` calls spell `WARN`.
+ * Every one of them was classified as noise and dropped, so `bun dev` showed a
+ * clean loop while the backend was reporting a stale toolchain, a burned
+ * browser session, or a re-queued job into the void.
+ *
+ * The stream carries the severity the prose does not: for a plain Node server,
+ * `console.warn`/`console.error` go to stderr. `stderrIsSignal` says so.
+ */
+
+import { PassThrough } from 'node:stream';
+
+import { classifyBackend } from '@tale/shared/classify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const sourceLine = vi.fn();
+
+vi.mock('@tale/shared/tux', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tale/shared/tux')>();
+  return {
+    ...actual,
+    sourceLine: (...args: unknown[]) => sourceLine(...args),
+  };
+});
+
+const { pipeChild } = await import('./dev-output.ts');
+
+/** A child whose streams we can write into, shaped like `ChildProcess`. */
+function fakeChild(): {
+  child: Parameters<typeof pipeChild>[0];
+  stdout: PassThrough;
+  stderr: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- pipeChild reads only `stdout`/`stderr` off the child
+  const child = { stdout, stderr } as Parameters<typeof pipeChild>[0];
+  return { child, stdout, stderr };
+}
+
+/** Write a line and let the stream's data event land. */
+async function emit(stream: PassThrough, line: string): Promise<void> {
+  stream.write(`${line}\n`);
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('pipeChild with stderrIsSignal', () => {
+  it('surfaces an unrecognised stderr line as a warning', async () => {
+    const { child, stderr } = fakeChild();
+    pipeChild(child, {
+      label: 'backend',
+      classifier: classifyBackend,
+      mode: 'errors',
+      stderrIsSignal: true,
+    });
+
+    // Verbatim shape of a real backend `console.warn`: no ERROR, no WARN, so
+    // the classifier calls it noise.
+    const warning =
+      '[ytdlp] yt-dlp 2026.03.17 on PATH is older than the 2026.07.04 this image pins.';
+    expect(classifyBackend(warning).kind).toBe('noise');
+
+    await emit(stderr, warning);
+
+    expect(sourceLine).toHaveBeenCalledWith('backend', 'warn', warning);
+  });
+
+  it('leaves stdout alone, however chatty', async () => {
+    const { child, stdout } = fakeChild();
+    pipeChild(child, {
+      label: 'backend',
+      classifier: classifyBackend,
+      mode: 'errors',
+      stderrIsSignal: true,
+    });
+
+    await emit(stdout, 'served GET /api/app/tasks 200 in 3ms');
+
+    expect(sourceLine).not.toHaveBeenCalled();
+  });
+
+  it('does not promote blank stderr lines', async () => {
+    const { child, stderr } = fakeChild();
+    pipeChild(child, {
+      label: 'backend',
+      classifier: classifyBackend,
+      mode: 'errors',
+      stderrIsSignal: true,
+    });
+
+    await emit(stderr, '   ');
+
+    expect(sourceLine).not.toHaveBeenCalled();
+  });
+
+  it('keeps an error an error rather than demoting it to warn', async () => {
+    const { child, stderr } = fakeChild();
+    pipeChild(child, {
+      label: 'backend',
+      classifier: classifyBackend,
+      mode: 'errors',
+      stderrIsSignal: true,
+    });
+
+    await emit(stderr, 'Uncaught TypeError: x is not a function');
+
+    expect(sourceLine).toHaveBeenCalledWith(
+      'backend',
+      'error',
+      'Uncaught TypeError: x is not a function',
+    );
+  });
+
+  it('stays silent on stderr when the caller has not vouched for it', async () => {
+    // Docker and BuildKit put their whole progress feed on stderr; the flag is
+    // opt-in precisely so they keep collapsing.
+    const { child, stderr } = fakeChild();
+    pipeChild(child, {
+      label: 'backend',
+      classifier: classifyBackend,
+      mode: 'errors',
+    });
+
+    await emit(stderr, '[ytdlp] something the classifier cannot name');
+
+    expect(sourceLine).not.toHaveBeenCalled();
+  });
+
+  it('records a promoted line in the failure-dump signal too', async () => {
+    const { child, stderr } = fakeChild();
+    const handle = pipeChild(child, {
+      label: 'backend',
+      classifier: classifyBackend,
+      mode: 'silent',
+      stderrIsSignal: true,
+    });
+
+    await emit(stderr, '[video_link] browser-session claim failed');
+
+    // `silent` prints nothing live, but a later failure dump must still have it.
+    expect(sourceLine).not.toHaveBeenCalled();
+    expect(handle.signal()).toEqual([
+      '[video_link] browser-session claim failed',
+    ]);
+  });
+});

--- a/services/platform/scripts/dev-output.ts
+++ b/services/platform/scripts/dev-output.ts
@@ -104,7 +104,9 @@ export interface PipeChildOptions {
  * spawned with `stdio: ['ignore'|'inherit', 'pipe', 'pipe']`.
  */
 export function pipeChild(
-  child: ChildProcess,
+  // Only the two streams are read — narrower than `ChildProcess` so a test can
+  // hand it a pair of `PassThrough`s without an unsafe assertion.
+  child: Pick<ChildProcess, 'stdout' | 'stderr'>,
   opts: PipeChildOptions,
 ): PipeChildHandle {
   const classify = createStreamClassifier(opts.classifier ?? devStepClassifier);

--- a/services/platform/scripts/dev-output.ts
+++ b/services/platform/scripts/dev-output.ts
@@ -28,6 +28,7 @@ import {
   createStreamClassifier,
 } from '@tale/shared/classify';
 import { pipeNodeStream } from '@tale/shared/process';
+import { stripAnsi } from '@tale/shared/terminal';
 import { sourceLine } from '@tale/shared/tux';
 
 // Re-export the shared reporter UI so the orchestrator pulls its output from one
@@ -78,6 +79,23 @@ export interface PipeChildOptions {
    * duplicate the step completion + the READY view.
    */
   mode?: PipeMode;
+  /**
+   * Treat anything the child writes to STDERR as at least a warning, even when
+   * the classifier could not name it.
+   *
+   * For a plain Node server the stream IS the severity: `console.warn` and
+   * `console.error` go to stderr, `console.log`/`console.info` to stdout. The
+   * regexes cannot see that, so `classifyBackend` surfaced a backend warning
+   * only if its prose happened to carry `ERROR` or `WARN` — which none of the
+   * backend's ~430 `console.warn` calls do. They were dropped as noise: a
+   * stale-toolchain notice, a burned-session report, a re-queued job, all
+   * invisible in `bun dev`.
+   *
+   * OPT-IN, because it is only true of children that separate the streams that
+   * way. Docker and BuildKit write their entire progress feed to stderr; this
+   * flag on those would surface every layer pull.
+   */
+  stderrIsSignal?: boolean;
   ringSize?: number;
 }
 
@@ -95,10 +113,22 @@ export function pipeChild(
   const ring: string[] = [];
   const signalLines: string[] = [];
 
-  const handle = (raw: string): void => {
-    const line = classify(raw);
+  const handle = (raw: string, stream: 'stdout' | 'stderr'): void => {
+    let line = classify(raw);
     ring.push(line.raw);
     if (ring.length > cap) ring.shift();
+
+    // The classifier reads prose; the stream carries severity the prose does
+    // not. A line the classifier could not name, on a stderr the caller has
+    // vouched for, is a warning — shown as the child printed it.
+    if (
+      opts.stderrIsSignal === true &&
+      stream === 'stderr' &&
+      (line.kind === 'noise' || line.kind === 'progress')
+    ) {
+      const text = stripAnsi(line.raw).trimEnd();
+      if (text.trim() !== '') line = { ...line, kind: 'warn', text };
+    }
 
     if ((line.kind === 'error' || line.kind === 'warn') && line.text) {
       signalLines.push(line.text);
@@ -111,8 +141,12 @@ export function pipeChild(
     // info/progress/noise: collapsed — milestones duplicate the READY view.
   };
 
-  if (child.stdout) void pipeNodeStream(child.stdout, handle);
-  if (child.stderr) void pipeNodeStream(child.stderr, handle);
+  if (child.stdout) {
+    void pipeNodeStream(child.stdout, (raw) => handle(raw, 'stdout'));
+  }
+  if (child.stderr) {
+    void pipeNodeStream(child.stderr, (raw) => handle(raw, 'stderr'));
+  }
 
   return {
     tail: (n = cap) => ring.slice(-n),


### PR DESCRIPTION
Chasing a video-link bug turned up a warning the dev loop was throwing away. Fixing that surfaced a PII detector that has been shipping switched off.

## The dev loop was dropping every backend warning

`classifyBackend` decides what `bun dev` shows by reading the line: `ERROR` or `WARN` surfaces, everything else collapses as noise. The backend does not write that way — it writes `console.warn`. None of its ~430 warn sites spell either word, so every one of them was dropped. A stale toolchain, a burned browser session, a re-queued job, a PII rule refused at boot: all invisible in the loop a developer actually watches. Even `console.error` surfaced only by accident, when its payload happened to quote the word.

The stream carries the severity the prose is missing. For a plain Node server, `console.warn`/`console.error` go to stderr and `console.log`/`console.info` to stdout. `pipeChild` now knows which stream a line arrived on, and a caller can vouch for that split with `stderrIsSignal`; a line the classifier could not name, arriving on a vouched stderr, is shown as a warning exactly as the child printed it.

Opt-in on purpose. Docker and BuildKit put their whole progress feed on stderr — this flag on those children would surface every layer pull. Only the backend sets it.

**Measured, not assumed.** A real `bun dev` on this branch: boot plus browsing the dashboard produced 16 lines, the same as before but for one that had been hiding —

```
[ ! ] backend  [pii] dropping unsafe nationalId regex in locale "es": co-cc
```

`pipeChild` also loses its `ChildProcess` parameter for the two fields it actually reads, so the test can hand it a pair of `PassThrough`s with no assertion.

## What that line turned out to mean

The PII registry vets every shipped national-ID pattern at boot and drops the ones that fail — a compile error or a safe-regex2 rejection — so one bad spec cannot take the registry down. Fail-open is right at runtime and wrong everywhere else: the detector ships, loads, and silently never fires. Colombian cédulas have been passing through unmasked in the `es` locale, and the only trace was the line above.

**I am not fixing the pattern, and that is deliberate.** `\b\d{1,3}(?:\.\d{3}){2,3}\b` cannot backtrack catastrophically — every repeat in it is bounded — but safe-regex2 counts the nested bounded repeat and refuses it. Rewriting hits a wall in both directions:

- the alternation form `(?:\d{1,3}\.\d{3}\.\d{3}\.\d{3}|\d{1,3}\.\d{3}\.\d{3})` passes the gate, and then matches `14.159.265` inside a version string like `3.14.159.265`, because `\b` cannot see the dot to its left. I tried it: it turns the frozen corpus red on `manual-neg-en-011`, which is the corpus being right;
- the lookbehind that would fix that left boundary is rejected too — safe-regex2 refuses **every** lookbehind, `(?<!x)abc` included.

Masking version numbers in prose would be worse than the detector staying dark, so the pattern ships exactly as it is. What changes is that it stops being a secret: a test walks every shipped locale, applies the same two checks the registry does, and fails on anything dropped that is not named in `KNOWN_DROPPED` with its reason. A second test removes an entry's cover the moment it starts passing, so the list cannot rot into a place where the next drop hides.

The remaining decision is a policy call and belongs to someone else: relax the gate for provably bounded patterns, move to a real ReDoS analyser, or retire the detector on purpose. It is now a visible decision instead of an accident.

## One more thing, reported not fixed

While tracing the above I found that `collectLocaleSelector` widens the locale union to `'*'` when **any** toggle is a bare `true` — including locale-agnostic ones like `email` or `jwt`. So a scrubber configured `{ email: true, nationalId: { locales: ['en'] } }` runs every locale's national-ID patterns, not just `en`'s. The 43-locale fixture corpus is configured exactly that way, which means it has always been exercising all locales at once rather than the per-locale sets it reads as testing.

That is a real defect with over-masking consequences, and correcting it would move the frozen corpus, so it wants its own change and its own decision. Left alone here.

## Verification

`bun run check` green — 40/40 tasks, and the full UI suite 456 files / 3523 tests. Two files flaked once inside the parallel run (`connectors-settings`, and `dashboard-layout` earlier in the day) with hook timeouts; both pass in isolation and the suite passes green when it is not competing with 39 other turbo tasks. Neither has any overlap with this diff, which touches only `scripts/dev-*` and a new PII test.
