### PR TITLE
fix(platform): give every notification a link to what it names

### DIFF
--- a/services/platform/app/features/notifications/lib/notification-target.parity.test.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.parity.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CASE_ORGANIZATION_ID as ORG,
+  isGenericLanding,
+  notificationTargetPath,
+  ORG_LINK_CASES,
+  PERSONAL_LINK_CASES,
+} from '@/backend/core/notifications/notification_link_cases';
+import { buildPersonalNotificationUrl } from '@/backend/core/notifications/personal_notification_url';
+
+import {
+  orgNotificationTarget,
+  personalNotificationTarget,
+} from './notification-target';
+
+/**
+ * Every notification type opens the thing it names.
+ *
+ * The table is the contract and `Record<NotificationType, …>` is the gate: a
+ * new type cannot ship without declaring where it goes, or saying in writing
+ * why it has nowhere specific to go.
+ *
+ * The third assertion is the one that would have caught the original defect
+ * from either side alone. The bell builder and the email builder are hand-
+ * mirrored twins in different runtimes, and a branch added to one and missed
+ * in the other is invisible until someone opens an email.
+ */
+
+const ORIGIN = 'https://app.example.com';
+
+describe.each(Object.entries(PERSONAL_LINK_CASES))(
+  'personal notification: %s',
+  (type, linkCase) => {
+    const target = personalNotificationTarget({
+      organizationId: ORG,
+      taskId: linkCase.row.taskId,
+      params: linkCase.row.params,
+    });
+
+    it('does not land on a generic page without a written reason', () => {
+      if (!isGenericLanding(target.to)) return;
+      expect(
+        linkCase.genericLanding,
+        `${type} landed on ${target.to} with no declared reason`,
+      ).toBeTruthy();
+    });
+
+    it('the bell opens the declared path', () => {
+      expect(notificationTargetPath(target)).toBe(linkCase.path);
+    });
+
+    it('the email opens the same path', () => {
+      expect(
+        buildPersonalNotificationUrl({
+          organizationId: ORG,
+          ...(linkCase.row.taskId !== undefined
+            ? { taskId: linkCase.row.taskId }
+            : {}),
+          ...(linkCase.row.params !== undefined
+            ? { params: linkCase.row.params }
+            : {}),
+          siteUrl: ORIGIN,
+        }),
+      ).toBe(`${ORIGIN}${linkCase.path}`);
+    });
+  },
+);
+
+describe.each(Object.entries(ORG_LINK_CASES))(
+  'org notification link: %s',
+  (kind, linkCase) => {
+    // Category only decides the landing for a linkless row, and every row
+    // here carries a link; `security` is the stricter of the two.
+    const target = orgNotificationTarget(ORG, linkCase.link, 'security');
+
+    it('does not land on a generic page without a written reason', () => {
+      if (!isGenericLanding(target.to)) return;
+      expect(
+        linkCase.genericLanding,
+        `${kind} landed on ${target.to} with no declared reason`,
+      ).toBeTruthy();
+    });
+
+    it('opens the declared path', () => {
+      expect(notificationTargetPath(target)).toBe(linkCase.path);
+    });
+  },
+);

--- a/services/platform/app/features/notifications/lib/notification-target.test.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { OrgNotificationLink } from '@/backend/core/notifications/org_notification_link';
+
 import {
   orgNotificationTarget,
   personalNotificationTarget,
@@ -144,7 +146,11 @@ describe('personalNotificationTarget', () => {
     });
   });
 
-  it('falls back to the org home when there is no project context (legacy/digest)', () => {
+  // The shape below is no longer writable — `CollabNotificationInput`
+  // requires `params.projectId` beside `taskId` — but rows stored before the
+  // project was stamped still reach this builder, and the client cannot
+  // resolve a project from a task id.
+  it('falls back to the org home for a legacy row written before the project was stamped', () => {
     expect(
       personalNotificationTarget({
         organizationId: ORG,
@@ -152,6 +158,38 @@ describe('personalNotificationTarget', () => {
         params: { title: 'No project here' },
       }),
     ).toEqual({ to: '/dashboard/$id', params: { id: ORG } });
+  });
+
+  // The defect: a deadline row named a task and opened the org home.
+  it('opens the task for a deadline row, which now carries its project', () => {
+    expect(
+      personalNotificationTarget({
+        organizationId: ORG,
+        taskId: 'task_abc',
+        params: { title: 'Redesign side-navigation', projectId: 'proj_xyz' },
+      }),
+    ).toEqual({
+      to: '/dashboard/$id/projects/$projectId/tasks',
+      params: { id: ORG, projectId: 'proj_xyz' },
+      search: { task: 'task_abc' },
+    });
+  });
+
+  it('opens the run for an escalation with no task and no project', () => {
+    expect(
+      personalNotificationTarget({
+        organizationId: ORG,
+        taskId: undefined,
+        params: { name: 'billing/dunning-reminder', runId: 'run_1' },
+      }),
+    ).toEqual({
+      to: '/dashboard/$id/automations/$automationSlug/runs/$runId',
+      params: {
+        id: ORG,
+        automationSlug: 'billing__dunning-reminder',
+        runId: 'run_1',
+      },
+    });
   });
 
   it('falls back to the org home for non-record params (never a dead row)', () => {
@@ -180,16 +218,51 @@ describe('orgNotificationTarget', () => {
     });
   });
 
-  it('maps an agent link to the org home (agents page removed)', () => {
+  // A row stored by a retired producer (the `agent` kind, whose page was
+  // removed) still reaches this switch. It used to return the link OBJECT,
+  // which a `<Link>` spread with no `to` navigates nowhere from.
+  it('lands an unknown stored kind on the category page, not a dead link', () => {
+    const retired = { kind: 'agent', agentSlug: 'researcher' };
+    expect(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a stored row from a producer the union no longer carries
+      orgNotificationTarget(ORG, retired as OrgNotificationLink, 'system'),
+    ).toEqual({ to: '/dashboard/$id/automations', params: { id: ORG } });
+    expect(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- as above, on the security lane
+      orgNotificationTarget(ORG, retired as OrgNotificationLink, 'security'),
+    ).toEqual({
+      to: '/dashboard/$id/settings/governance',
+      params: { id: ORG },
+    });
+  });
+
+  it('opens the request itself for a DSAR alert that names one', () => {
     expect(
       orgNotificationTarget(
         ORG,
-        { kind: 'agent', agentSlug: 'researcher' },
-        'system',
+        { kind: 'dsar', requestId: 'req_1' },
+        'security',
       ),
     ).toEqual({
-      to: '/dashboard/$id',
+      to: '/dashboard/$id/settings/governance/data-subject-requests/$requestId',
+      params: { id: ORG, requestId: 'req_1' },
+    });
+  });
+
+  it('maps a budgets link to the page that grants the credits', () => {
+    expect(orgNotificationTarget(ORG, { kind: 'budgets' }, 'system')).toEqual({
+      to: '/dashboard/$id/settings/governance/policies-limits',
       params: { id: ORG },
+    });
+  });
+
+  it('maps a websites link to the list, filtered to the failing sites', () => {
+    expect(
+      orgNotificationTarget(ORG, { kind: 'websites' }, 'security'),
+    ).toEqual({
+      to: '/dashboard/$id/websites',
+      params: { id: ORG },
+      search: { status: 'error' },
     });
   });
 

--- a/services/platform/app/features/notifications/lib/notification-target.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.ts
@@ -1,4 +1,5 @@
 import type { OrgNotificationLink } from '@/backend/core/notifications/org_notification_link';
+import { automationSlugToParam } from '@/lib/automations/slug';
 import { isRecord } from '@/lib/utils/type-utils';
 
 /**
@@ -45,6 +46,28 @@ export type NotificationTarget =
   | {
       to: '/dashboard/$id/settings/governance/data-subject-requests';
       params: { id: string };
+    }
+  // A DSAR alert names one request and the row carries its id, so open it.
+  | {
+      to: '/dashboard/$id/settings/governance/data-subject-requests/$requestId';
+      params: { id: string; requestId: string };
+    }
+  // The budget editor — where an admin grants the credits a member asked for.
+  | {
+      to: '/dashboard/$id/settings/governance/policies-limits';
+      params: { id: string };
+    }
+  // The websites list, filtered to the status the alert is about.
+  | {
+      to: '/dashboard/$id/websites';
+      params: { id: string };
+      search?: { status?: string };
+    }
+  // An automation run — the landing for an escalation with no task and no
+  // project, whose row carries the run id and its automation's name.
+  | {
+      to: '/dashboard/$id/automations/$automationSlug/runs/$runId';
+      params: { id: string; automationSlug: string; runId: string };
     }
   | {
       to: '/dashboard/$id/settings/governance/security-monitoring';
@@ -166,6 +189,24 @@ export function personalNotificationTarget(args: {
       params: { id, projectId },
     };
   }
+
+  // An agent escalation on an org-scoped run has no task and no project, but
+  // it does name the run. Needs BOTH keys — neither appears in any other
+  // personal row's params, so this cannot swallow another type's row.
+  const runId = typeof params?.runId === 'string' ? params.runId : undefined;
+  const automationName =
+    typeof params?.name === 'string' ? params.name : undefined;
+  if (runId && automationName) {
+    return {
+      to: '/dashboard/$id/automations/$automationSlug/runs/$runId',
+      params: {
+        id,
+        automationSlug: automationSlugToParam(automationName),
+        runId,
+      },
+    };
+  }
+
   return { to: '/dashboard/$id', params: { id } };
 }
 
@@ -176,23 +217,34 @@ export function personalNotificationTarget(args: {
  * Automations. Always returns a target, so an org row is never a dead,
  * unclickable line (#2377).
  */
+function categoryLanding(
+  id: string,
+  category: 'security' | 'system',
+): NotificationTarget {
+  return category === 'security'
+    ? { to: '/dashboard/$id/settings/governance', params: { id } }
+    : { to: '/dashboard/$id/automations', params: { id } };
+}
+
 export function orgNotificationTarget(
   organizationId: string,
   link: OrgNotificationLink | undefined,
   category: 'security' | 'system',
 ): NotificationTarget {
   const id = organizationId;
-  if (!link) {
-    return category === 'security'
-      ? { to: '/dashboard/$id/settings/governance', params: { id } }
-      : { to: '/dashboard/$id/automations', params: { id } };
-  }
+  if (!link) return categoryLanding(id, category);
   switch (link.kind) {
-    case 'agent':
-      // The agents management page was removed; an agent-scoped alert has no
-      // dedicated page to open, so it lands on the org home rather than a dead
-      // link. (The `agent` link kind is kept — producers still stamp it.)
-      return { to: '/dashboard/$id', params: { id } };
+    case 'budgets':
+      return {
+        to: '/dashboard/$id/settings/governance/policies-limits',
+        params: { id },
+      };
+    case 'websites':
+      return {
+        to: '/dashboard/$id/websites',
+        params: { id },
+        search: { status: 'error' },
+      };
     case 'audit-logs':
       return link.logId
         ? {
@@ -202,19 +254,29 @@ export function orgNotificationTarget(
           }
         : { to: '/dashboard/$id/settings/governance/logs', params: { id } };
     case 'dsar':
-      return {
-        to: '/dashboard/$id/settings/governance/data-subject-requests',
-        params: { id },
-      };
+      return link.requestId
+        ? {
+            to: '/dashboard/$id/settings/governance/data-subject-requests/$requestId',
+            params: { id, requestId: link.requestId },
+          }
+        : {
+            to: '/dashboard/$id/settings/governance/data-subject-requests',
+            params: { id },
+          };
     case 'security-monitoring':
       return {
         to: '/dashboard/$id/settings/governance/security-monitoring',
         params: { id },
       };
     default: {
-      // Exhaustiveness guard — a new `kind` must extend this switch.
+      // Exhaustiveness guard — a new `kind` must extend this switch. At
+      // RUNTIME this arm is reached only by a stored row from a retired
+      // producer, so it lands on the category page. Returning `_exhaustive`
+      // handed the link OBJECT back as a target, and a `<Link>` spread with
+      // no `to` navigates nowhere.
       const _exhaustive: never = link;
-      return _exhaustive;
+      void _exhaustive;
+      return categoryLanding(id, category);
     }
   }
 }

--- a/services/platform/app/features/notifications/lib/notification-target.ts
+++ b/services/platform/app/features/notifications/lib/notification-target.ts
@@ -1,3 +1,4 @@
+import type { OrgNotificationLink } from '@/backend/core/notifications/org_notification_link';
 import { isRecord } from '@/lib/utils/type-utils';
 
 /**
@@ -77,16 +78,10 @@ export type NotificationTarget =
     };
 
 /**
- * The org-alert `link` shape. Mirrors `notificationLinkValidator` in
- * `convex/notifications/schema.ts` — keep the two in sync (closed union).
+ * The org-alert `link` shape. Declared once in `backend/core` and re-exported
+ * here so the producer, the wire contract and this router cannot drift.
  */
-export type OrgNotificationLink =
-  | { kind: 'agent'; agentSlug: string }
-  // `logId` deep-links to the specific broken audit row (#1845); optional so a
-  // finding without a concrete row (config/checkpoint) still links to the page.
-  | { kind: 'audit-logs'; logId?: string }
-  | { kind: 'dsar' }
-  | { kind: 'security-monitoring' };
+export type { OrgNotificationLink };
 
 /**
  * Deep-link target for a PERSONAL notification (`userNotifications`). Task-bound

--- a/services/platform/app/lib/backend/contract/notifications.ts
+++ b/services/platform/app/lib/backend/contract/notifications.ts
@@ -7,6 +7,8 @@
  * actually serve them.
  */
 
+import type { OrgNotificationLink } from '@/backend/core/notifications/org_notification_link';
+
 export interface NotificationsContract {
   'notifications/mutations:markAllRead': {
     kind: 'mutation';
@@ -43,12 +45,7 @@ export interface NotificationsContract {
         titleKey: string;
         bodyKey: string;
         params: unknown;
-        link:
-          | undefined
-          | { kind: 'agent'; agentSlug: string }
-          | { logId?: string; kind: 'audit-logs' }
-          | { kind: 'dsar' }
-          | { kind: 'security-monitoring' };
+        link: OrgNotificationLink | undefined;
         createdAt: number;
         readBy: string[];
         read: boolean;

--- a/services/platform/backend/core/notifications/notification_link_cases.ts
+++ b/services/platform/backend/core/notifications/notification_link_cases.ts
@@ -1,0 +1,170 @@
+/**
+ * Where every notification goes — one row per type, and the compile-time
+ * gate that keeps the list complete.
+ *
+ * A notification that names something the reader cannot reach is the defect
+ * this table exists to prevent. The failure was quiet: the link is derived
+ * from an optional `params` bag, so an emitter that omitted a key produced a
+ * row that still rendered, still clicked, and still landed — on the org home,
+ * with the email losing its CTA entirely. No type error, no red test.
+ *
+ * `Record<NotificationType, …>` is the gate. Add a member to the union in
+ * `../collab/types.ts` and this object stops type-checking until the new type
+ * either declares where it goes or says, in writing, why it cannot.
+ *
+ * The suite that drives this table lives beside the in-app builder
+ * (`app/features/notifications/lib/notification-target.parity.test.ts`) —
+ * app-side, because it exercises BOTH hand-mirrored builders from these rows
+ * and only that side can import both.
+ */
+
+import type { NotificationType } from '../collab/types';
+import type { OrgNotificationLink } from './org_notification_link';
+
+/**
+ * Routes that mean "somewhere sensible", not "the thing this is about". A
+ * row landing here has told the reader to go and find it by hand.
+ */
+export const GENERIC_LANDING_ROUTES: readonly string[] = [
+  '/dashboard/$id',
+  '/dashboard/$id/automations',
+  '/dashboard/$id/settings/governance',
+];
+
+export function isGenericLanding(to: string): boolean {
+  return GENERIC_LANDING_ROUTES.includes(to);
+}
+
+export interface NotificationLinkCase {
+  /** The row a live emitter of this type writes. */
+  readonly row: {
+    readonly taskId?: string;
+    readonly params?: Record<string, unknown>;
+  };
+  /** The path BOTH builders must produce for that row, origin-free. */
+  readonly path: string;
+  /**
+   * Set ONLY when this type may land on a generic page. The value is the
+   * reason, and it is required — an opt-out cannot be taken silently.
+   */
+  readonly genericLanding?: string;
+}
+
+export interface OrgLinkCase {
+  readonly link: OrgNotificationLink;
+  readonly path: string;
+  readonly genericLanding?: string;
+}
+
+const ORG = 'org_case';
+
+/** The task every task-bound row in this table points at. */
+const TASK_PATH = `/dashboard/${ORG}/projects/proj_1/tasks?task=task_1`;
+const TASK_ROW = {
+  taskId: 'task_1',
+  params: { title: 'Redesign side-navigation', projectId: 'proj_1' },
+} as const;
+
+export const CASE_ORGANIZATION_ID = ORG;
+
+export const PERSONAL_LINK_CASES: Record<
+  NotificationType,
+  NotificationLinkCase
+> = {
+  task_assigned: { row: TASK_ROW, path: TASK_PATH },
+  task_unassigned: { row: TASK_ROW, path: TASK_PATH },
+  task_status_changed: { row: TASK_ROW, path: TASK_PATH },
+  task_commented: { row: TASK_ROW, path: TASK_PATH },
+  mention: { row: TASK_ROW, path: TASK_PATH },
+  task_deadline: { row: TASK_ROW, path: TASK_PATH },
+  task_review_requested: {
+    row: {
+      taskId: 'task_1',
+      params: { taskId: 'task_1', projectId: 'proj_1', approvalId: 'ap_1' },
+    },
+    path: TASK_PATH,
+  },
+  task_reviewer_assigned: { row: TASK_ROW, path: TASK_PATH },
+  document_review_requested: {
+    row: {
+      params: { documentId: 'doc_1', projectId: 'proj_1', folderId: 'fld_1' },
+    },
+    path: `/dashboard/${ORG}/projects/proj_1/files?doc=doc_1&folderId=fld_1`,
+  },
+  document_review_resolved: {
+    row: { params: { documentId: 'doc_1' } },
+    path: `/dashboard/${ORG}/documents?doc=doc_1`,
+  },
+  // The org-scoped shape: no task and no project, so the run is what the
+  // row names. A task-bound or project-bound ask resolves earlier, on the
+  // task and project rows above.
+  agent_escalation: {
+    row: { params: { name: 'billing/dunning-reminder', runId: 'run_1' } },
+    path: `/dashboard/${ORG}/automations/billing__dunning-reminder/runs/run_1`,
+  },
+  conversation_assigned: {
+    row: { params: { conversationId: 'conv_1', conversationStatus: 'open' } },
+    path: `/dashboard/${ORG}/conversations/open?conversation=conv_1`,
+  },
+  // No emitter today — the 0.4 producer never made the port. Pinned rather
+  // than opted out, so a revived producer inherits a working link by
+  // stamping the same keys `conversation_assigned` uses.
+  conversation_message: {
+    row: { params: { conversationId: 'conv_1', conversationStatus: 'open' } },
+    path: `/dashboard/${ORG}/conversations/open?conversation=conv_1`,
+  },
+  workforce_digest: {
+    row: { params: { title: 'Your week' } },
+    path: `/dashboard/${ORG}`,
+    genericLanding:
+      'A digest summarises many entities and names none, so there is nothing ' +
+      'specific to open. Retired besides: no emitter writes this type, and ' +
+      'the literal survives only so stored rows keep typing.',
+  },
+};
+
+export const ORG_LINK_CASES: Record<OrgNotificationLink['kind'], OrgLinkCase> =
+  {
+    'audit-logs': {
+      link: { kind: 'audit-logs', logId: 'log_1' },
+      path: `/dashboard/${ORG}/settings/governance/logs?logId=log_1`,
+    },
+    dsar: {
+      link: { kind: 'dsar', requestId: 'req_1' },
+      path: `/dashboard/${ORG}/settings/governance/data-subject-requests/req_1`,
+    },
+    'security-monitoring': {
+      link: { kind: 'security-monitoring' },
+      path: `/dashboard/${ORG}/settings/governance/security-monitoring`,
+    },
+    budgets: {
+      link: { kind: 'budgets' },
+      path: `/dashboard/${ORG}/settings/governance/policies-limits`,
+    },
+    websites: {
+      link: { kind: 'websites' },
+      path: `/dashboard/${ORG}/websites?status=error`,
+    },
+  };
+
+/**
+ * Render a router navigate descriptor to the path it navigates to, so the
+ * app's typed `NotificationTarget` and the email's absolute URL compare as
+ * one string. Structurally typed on purpose: this module never imports the
+ * app.
+ */
+export function notificationTargetPath(target: {
+  to: string;
+  params: Record<string, string>;
+  search?: Record<string, string | undefined>;
+}): string {
+  const path = target.to.replaceAll(/\$([A-Za-z]+)/g, (whole, name: string) => {
+    const value = target.params[name];
+    return value === undefined ? whole : encodeURIComponent(value);
+  });
+  const query = Object.entries(target.search ?? {})
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join('&');
+  return query === '' ? path : `${path}?${query}`;
+}

--- a/services/platform/backend/core/notifications/notification_messages.test.ts
+++ b/services/platform/backend/core/notifications/notification_messages.test.ts
@@ -114,6 +114,8 @@ describe('renderInboxMessage', () => {
   });
 });
 
+const LINK = 'https://app.example.com/dashboard/org_1';
+
 describe('renderActionableEmailContent', () => {
   it('includes a deep link and footer in plain text', () => {
     const content = renderActionableEmailContent('en', {
@@ -130,6 +132,20 @@ describe('renderActionableEmailContent', () => {
     expect(content.html).toContain('href="https://app.example.com');
   });
 
+  // A notification that names something the reader cannot reach is the
+  // defect this pins: the CTA block used to be dropped whenever the deep
+  // link came back null, so the email named a task and offered no way in.
+  it('always carries the CTA, in both lanes', () => {
+    const content = renderActionableEmailContent('en', {
+      titleKey: 'taskSlaEscalated',
+      bodyKey: 'taskSlaEscalatedBody',
+      params: { title: 'Redesign side-navigation' },
+      deepLink: LINK,
+    });
+    expect(content.text).toContain(`Open in Tale: ${LINK}`);
+    expect(content.html).toContain(`<a href="${LINK}">Open in Tale</a>`);
+  });
+
   // Regression: the html lane used to re-interpolate the ALREADY-interpolated
   // body, so the escape transform saw no placeholders and external text (task
   // titles, user names, conversation subjects) landed raw in HTML email.
@@ -141,7 +157,7 @@ describe('renderActionableEmailContent', () => {
         actor: '<script>alert(1)</script>',
         title: 'a "quoted" & <b>bold</b> title',
       },
-      deepLink: null,
+      deepLink: LINK,
     });
     expect(content.html).toContain(
       '&lt;script&gt;alert(1)&lt;/script&gt; assigned you to',
@@ -158,7 +174,7 @@ describe('renderActionableEmailContent', () => {
       titleKey: 'taskAssigned',
       bodyKey: 'taskAssignedByBody',
       params: { actor: 'A&B', title: '&amp;<i>' },
-      deepLink: null,
+      deepLink: LINK,
     });
     // The literal string `&amp;<i>` renders as itself in the mail client,
     // never as an entity/tag — i.e. it is escaped to `&amp;amp;&lt;i&gt;`.
@@ -171,7 +187,7 @@ describe('renderActionableEmailContent', () => {
       titleKey: 'taskAssigned',
       bodyKey: 'taskAssignedByBody',
       params: { actor: '<script>alert(1)</script>', title: 'T & Co' },
-      deepLink: null,
+      deepLink: LINK,
     });
     // Plain text is not an HTML context; entities there would show literally.
     expect(content.text).toContain(
@@ -187,7 +203,7 @@ describe('renderActionableEmailContent', () => {
       titleKey: 'taskAssigned',
       bodyKey: 'taskAssignedByBody',
       params: { actor: '{title}', title: 'Real title' },
-      deepLink: null,
+      deepLink: LINK,
     });
     expect(content.html).toContain('{title} assigned you to');
     expect(content.text).toContain('{title} assigned you to');
@@ -198,7 +214,7 @@ describe('renderActionableEmailContent', () => {
       titleKey: 'taskAssigned',
       bodyKey: 'no-such-key <x>',
       params: {},
-      deepLink: null,
+      deepLink: LINK,
     });
     expect(content.html).toContain('no-such-key &lt;x&gt;');
     expect(content.text).toContain('no-such-key <x>');

--- a/services/platform/backend/core/notifications/notification_messages.ts
+++ b/services/platform/backend/core/notifications/notification_messages.ts
@@ -596,7 +596,7 @@ export function renderActionableEmailContent(
     titleKey: string;
     bodyKey: string;
     params?: Record<string, unknown>;
-    deepLink: string | null;
+    deepLink: string;
   },
 ): { subject: string; text: string; html: string } {
   const subject = renderInboxMessage(locale, args.titleKey, args.params);
@@ -604,11 +604,7 @@ export function renderActionableEmailContent(
   const cta = renderInboxMessage(locale, 'email.cta');
   const footer = renderInboxMessage(locale, 'email.footer');
 
-  let text = body;
-  if (args.deepLink) {
-    text += `\n\n${cta}: ${args.deepLink}`;
-  }
-  text += `\n\n${footer}`;
+  const text = `${body}\n\n${cta}: ${args.deepLink}\n\n${footer}`;
 
   // Params enter HTML exactly ONCE, escaped at that single entry point: the
   // template is interpolated one time with the `escapeHtml` transform. The
@@ -623,13 +619,12 @@ export function renderActionableEmailContent(
       : interpolateTemplate(bodyTemplate, args.params, escapeHtml);
   const ctaHtml = escapeHtml(cta);
   const footerHtml = escapeHtml(footer);
-  const linkHtml = args.deepLink ? escapeHtml(args.deepLink) : null;
+  const linkHtml = escapeHtml(args.deepLink);
 
-  let html = `<p>${bodyHtml}</p>`;
-  if (linkHtml) {
-    html += `<p><a href="${linkHtml}">${ctaHtml}</a></p>`;
-  }
-  html += `<p style="color:#666;font-size:12px;">${footerHtml}</p>`;
+  const html =
+    `<p>${bodyHtml}</p>` +
+    `<p><a href="${linkHtml}">${ctaHtml}</a></p>` +
+    `<p style="color:#666;font-size:12px;">${footerHtml}</p>`;
 
   return { subject, text, html };
 }

--- a/services/platform/backend/core/notifications/org_notification_link.ts
+++ b/services/platform/backend/core/notifications/org_notification_link.ts
@@ -12,9 +12,13 @@
  * guard, so adding a member here fails to compile until it has a route.
  */
 export type OrgNotificationLink =
-  | { kind: 'agent'; agentSlug: string }
   // `logId` deep-links to the specific broken audit row (#1845); optional so a
   // finding without a concrete row (config/checkpoint) still links to the page.
   | { kind: 'audit-logs'; logId?: string }
-  | { kind: 'dsar' }
-  | { kind: 'security-monitoring' };
+  // `requestId` opens the request itself; optional so a row stored before the
+  // id was carried still lands on the list.
+  | { kind: 'dsar'; requestId?: string }
+  | { kind: 'security-monitoring' }
+  // The budget editor, where an admin grants the credits the alert asks for.
+  | { kind: 'budgets' }
+  | { kind: 'websites' };

--- a/services/platform/backend/core/notifications/org_notification_link.ts
+++ b/services/platform/backend/core/notifications/org_notification_link.ts
@@ -1,0 +1,20 @@
+/**
+ * The deep-link target stored on an ORG notification (`app.notifications.link`).
+ *
+ * One declaration, imported by all three surfaces that used to spell it out
+ * separately: the producer (`domains/notifications/service.ts`), the wire
+ * contract the app consumes (`app/lib/backend/contract/notifications.ts`), and
+ * the router that turns a stored link into a route
+ * (`app/features/notifications/lib/notification-target.ts`). A producer can no
+ * longer invent a `kind` the router has never heard of.
+ *
+ * A closed union on purpose: the router switches on `kind` with a `never`
+ * guard, so adding a member here fails to compile until it has a route.
+ */
+export type OrgNotificationLink =
+  | { kind: 'agent'; agentSlug: string }
+  // `logId` deep-links to the specific broken audit row (#1845); optional so a
+  // finding without a concrete row (config/checkpoint) still links to the page.
+  | { kind: 'audit-logs'; logId?: string }
+  | { kind: 'dsar' }
+  | { kind: 'security-monitoring' };

--- a/services/platform/backend/core/notifications/personal_notification_url.test.ts
+++ b/services/platform/backend/core/notifications/personal_notification_url.test.ts
@@ -103,7 +103,9 @@ describe('buildPersonalNotificationUrl — routing', () => {
     ).toBe(`${SITE}/dashboard/${ORG}/projects/proj_1/tasks`);
   });
 
-  it('needs the project as well as the task — a task alone does not resolve', () => {
+  // Never null: an email that names something the reader cannot reach is
+  // the defect. A row with no entity context still gets a way in.
+  it('lands on the org dashboard when there is no entity context', () => {
     expect(
       buildPersonalNotificationUrl({
         organizationId: ORG,
@@ -111,7 +113,7 @@ describe('buildPersonalNotificationUrl — routing', () => {
         params: { title: 'No project here' },
         siteUrl: SITE,
       }),
-    ).toBeNull();
+    ).toBe(`${SITE}/dashboard/${ORG}`);
   });
 });
 

--- a/services/platform/backend/core/notifications/personal_notification_url.test.ts
+++ b/services/platform/backend/core/notifications/personal_notification_url.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildPersonalNotificationUrl } from './personal_notification_url';
+
+/**
+ * The email half of the notification deep link. Its in-app twin
+ * (`app/features/notifications/lib/notification-target.ts`) is hand-mirrored,
+ * so every branch here has a counterpart there; the parity suite next to that
+ * file drives both from one table.
+ */
+
+const ENV_KEYS = ['SITE_URL', 'ADDITIONAL_SITE_URLS', 'BASE_PATH'] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+const ORG = 'org_1';
+const SITE = 'https://app.example.com';
+
+describe('buildPersonalNotificationUrl — routing', () => {
+  it('opens a task inside its project', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        taskId: 'task_1',
+        params: { projectId: 'proj_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/projects/proj_1/tasks?task=task_1`);
+  });
+
+  it('opens a chat thread', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { chat: true, threadId: 'thread_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/chat/thread_1`);
+  });
+
+  it('opens a conversation, defaulting the status segment to open', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { conversationId: 'conv_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/conversations/open?conversation=conv_1`);
+  });
+
+  it('carries a non-open conversation status into the segment', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { conversationId: 'conv_1', conversationStatus: 'closed' },
+        siteUrl: SITE,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/conversations/closed?conversation=conv_1`);
+  });
+
+  it('opens a project document in its Files tab, with the folder', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { documentId: 'doc_1', projectId: 'proj_1', folderId: 'f_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(
+      `${SITE}/dashboard/${ORG}/projects/proj_1/files?doc=doc_1&folderId=f_1`,
+    );
+  });
+
+  it('opens a library document in the org-wide list', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { documentId: 'doc_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/documents?doc=doc_1`);
+  });
+
+  it('lands a legacy discussion mention on the project board', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { threadId: 'thread_1', projectId: 'proj_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/projects/proj_1/tasks`);
+  });
+
+  it('needs the project as well as the task — a task alone does not resolve', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        taskId: 'task_1',
+        params: { title: 'No project here' },
+        siteUrl: SITE,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('buildPersonalNotificationUrl — origin', () => {
+  it('prefers an explicit siteUrl over the environment', () => {
+    process.env.SITE_URL = 'https://ignored.example.com';
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { documentId: 'doc_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/documents?doc=doc_1`);
+  });
+
+  it('reads SITE_URL at call time, not at module load', () => {
+    // The regression: SITE_URL used to be captured in a module-level
+    // constant, so a worker importing this before its env was in place
+    // shipped localhost links for the life of the process.
+    process.env.SITE_URL = 'https://first.example.com';
+    const first = buildPersonalNotificationUrl({
+      organizationId: ORG,
+      params: { documentId: 'doc_1' },
+    });
+    process.env.SITE_URL = 'https://second.example.com';
+    const second = buildPersonalNotificationUrl({
+      organizationId: ORG,
+      params: { documentId: 'doc_1' },
+    });
+
+    expect(first).toBe(
+      `https://first.example.com/dashboard/${ORG}/documents?doc=doc_1`,
+    );
+    expect(second).toBe(
+      `https://second.example.com/dashboard/${ORG}/documents?doc=doc_1`,
+    );
+  });
+
+  it('carries BASE_PATH, so a subpath deployment does not 404', () => {
+    process.env.SITE_URL = SITE;
+    process.env.BASE_PATH = '/tale';
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { documentId: 'doc_1' },
+      }),
+    ).toBe(`${SITE}/tale/dashboard/${ORG}/documents?doc=doc_1`);
+  });
+
+  it('trims a trailing slash off the origin', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { documentId: 'doc_1' },
+        siteUrl: `${SITE}/`,
+      }),
+    ).toBe(`${SITE}/dashboard/${ORG}/documents?doc=doc_1`);
+  });
+
+  it('falls back to the local origin when SITE_URL is unset', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { documentId: 'doc_1' },
+      }),
+    ).toBe(`http://127.0.0.1:3000/dashboard/${ORG}/documents?doc=doc_1`);
+  });
+});

--- a/services/platform/backend/core/notifications/personal_notification_url.test.ts
+++ b/services/platform/backend/core/notifications/personal_notification_url.test.ts
@@ -103,6 +103,18 @@ describe('buildPersonalNotificationUrl — routing', () => {
     ).toBe(`${SITE}/dashboard/${ORG}/projects/proj_1/tasks`);
   });
 
+  it('opens the run for an escalation with no task and no project', () => {
+    expect(
+      buildPersonalNotificationUrl({
+        organizationId: ORG,
+        params: { name: 'billing/dunning-reminder', runId: 'run_1' },
+        siteUrl: SITE,
+      }),
+    ).toBe(
+      `${SITE}/dashboard/${ORG}/automations/billing__dunning-reminder/runs/run_1`,
+    );
+  });
+
   // Never null: an email that names something the reader cannot reach is
   // the defect. A row with no entity context still gets a way in.
   it('lands on the org dashboard when there is no entity context', () => {

--- a/services/platform/backend/core/notifications/personal_notification_url.ts
+++ b/services/platform/backend/core/notifications/personal_notification_url.ts
@@ -4,6 +4,7 @@
  * the origin; otherwise it comes from the deployment's `SITE_URL`.
  */
 
+import { automationSlugToParam } from '../../../lib/automations/slug';
 import {
   canonicalOrigin,
   publicBaseUrlFor,
@@ -77,6 +78,14 @@ export function buildPersonalNotificationUrl(args: {
   // `personalNotificationTarget`.
   if (typeof threadId === 'string' && typeof projectId === 'string') {
     return `${base}/dashboard/${args.organizationId}/projects/${projectId}/tasks`;
+  }
+  // An agent escalation on an org-scoped run: no task, no project, but the
+  // row names the run and its automation. Needs BOTH keys.
+  const runId = args.params?.runId;
+  const automationName = args.params?.name;
+  if (typeof runId === 'string' && typeof automationName === 'string') {
+    const slug = encodeURIComponent(automationSlugToParam(automationName));
+    return `${base}/dashboard/${args.organizationId}/automations/${slug}/runs/${encodeURIComponent(runId)}`;
   }
   // Never null: an actionable email always carries a way in. A row with no
   // entity context (a legacy row written before its project was stamped)

--- a/services/platform/backend/core/notifications/personal_notification_url.ts
+++ b/services/platform/backend/core/notifications/personal_notification_url.ts
@@ -37,7 +37,7 @@ export function buildPersonalNotificationUrl(args: {
   taskId?: string;
   params?: Record<string, unknown>;
   siteUrl?: string;
-}): string | null {
+}): string {
   const projectId = args.params?.projectId;
   const threadId = args.params?.threadId;
   const base = notificationBase(args.siteUrl);
@@ -70,7 +70,7 @@ export function buildPersonalNotificationUrl(args: {
     return `${base}/dashboard/${args.organizationId}/documents?${docSearch}`;
   }
   if (args.taskId && typeof projectId === 'string') {
-    return `${base}/dashboard/${args.organizationId}/projects/${projectId}/tasks?task=${args.taskId}`;
+    return `${base}/dashboard/${args.organizationId}/projects/${encodeURIComponent(projectId)}/tasks?task=${encodeURIComponent(args.taskId)}`;
   }
   // Legacy discussion-mention rows (threadId + projectId): their route is
   // gone, so the email lands on the project's Tasks board — parity with
@@ -78,5 +78,9 @@ export function buildPersonalNotificationUrl(args: {
   if (typeof threadId === 'string' && typeof projectId === 'string') {
     return `${base}/dashboard/${args.organizationId}/projects/${projectId}/tasks`;
   }
-  return null;
+  // Never null: an actionable email always carries a way in. A row with no
+  // entity context (a legacy row written before its project was stamped)
+  // lands on the org dashboard rather than shipping a link-less email that
+  // names something the reader then has to go and find by hand.
+  return `${base}/dashboard/${args.organizationId}`;
 }

--- a/services/platform/backend/core/notifications/personal_notification_url.ts
+++ b/services/platform/backend/core/notifications/personal_notification_url.ts
@@ -1,11 +1,35 @@
 /**
  * Deep-link builder for actionable notification email — mirrors the in-app
- * `personalNotificationTarget` routing. Pure (the caller supplies or
- * defaults the site URL), shared by the 0.4 email action and the 0.5
- * backend's email sink.
+ * `personalNotificationTarget` routing. The caller may pass `siteUrl` to pin
+ * the origin; otherwise it comes from the deployment's `SITE_URL`.
  */
 
-const SITE_URL = process.env.SITE_URL ?? 'http://127.0.0.1:3000';
+import {
+  canonicalOrigin,
+  publicBaseUrlFor,
+} from '../lib/helpers/public_origin';
+
+/**
+ * Dev fallback when `SITE_URL` is unset — the local app origin, the same
+ * literal this module has always used. A real deployment always has one:
+ * `backend/env.ts` validates it at boot.
+ */
+const FALLBACK_ORIGIN = 'http://127.0.0.1:3000';
+
+/**
+ * `<origin><BASE_PATH>` for a notification deep link, read at CALL time.
+ * It used to be a module-load constant, which froze whatever the env held at
+ * import — wrong for a worker that imports before the container's env is in
+ * place, and untestable without re-importing the module. `BASE_PATH` was
+ * ignored outright, so every link on a subpath deployment 404'd.
+ */
+function notificationBase(siteUrl?: string): string {
+  const origin = (siteUrl ?? canonicalOrigin() ?? FALLBACK_ORIGIN).replace(
+    /\/$/,
+    '',
+  );
+  return publicBaseUrlFor(origin);
+}
 
 /** Mirrors the in-app personal notification deep-link builder. */
 export function buildPersonalNotificationUrl(args: {
@@ -16,7 +40,7 @@ export function buildPersonalNotificationUrl(args: {
 }): string | null {
   const projectId = args.params?.projectId;
   const threadId = args.params?.threadId;
-  const base = (args.siteUrl ?? SITE_URL).replace(/\/$/, '');
+  const base = notificationBase(args.siteUrl);
 
   if (args.params?.chat === true && typeof threadId === 'string') {
     return `${base}/dashboard/${args.organizationId}/chat/${encodeURIComponent(threadId)}`;

--- a/services/platform/backend/db/migrations/0087_notification_params_project_backfill.sql
+++ b/services/platform/backend/db/migrations/0087_notification_params_project_backfill.sql
@@ -1,0 +1,30 @@
+-- Give stored task notifications the project their deep link needs.
+--
+-- A notification's link is not stored; both builders derive it from the row.
+-- To open a task, `personalNotificationTarget` (the bell) and
+-- `buildPersonalNotificationUrl` (the email) each need `task_id` AND
+-- `params -> 'projectId'`. With only the task id the bell row falls back to
+-- the org dashboard and the email loses its call to action entirely, so the
+-- reader is told a task is overdue and left to go and find it by hand.
+--
+-- All three date rungs wrote `params` without the project, so every start,
+-- due-soon and overdue row already in someone's bell is in that state. New
+-- rows are fixed at the source — the emitters stamp it, the writer resolves
+-- it from the task when a caller omits it, and `CollabNotificationInput`
+-- no longer accepts `taskId` without it — but stored rows need this.
+--
+-- Set-based and idempotent: the `IS NULL` guard means a re-run after a
+-- half-failed deploy touches nothing, and a row whose task has since been
+-- deleted simply does not join. The join carries `org_id` on BOTH sides, so
+-- a notification can never inherit a project from another tenant's task.
+--
+-- Rolling-deploy safe in both directions: the previous image reads `params`
+-- as an opaque bag and ignores the added key, and the new image treats a
+-- row without it exactly as before (the org-dashboard fallback).
+UPDATE app.user_notifications n
+SET params = coalesce(n.params, '{}'::jsonb)
+             || jsonb_build_object('projectId', t.project_id)
+FROM app.tasks t
+WHERE n.task_id = t.id
+  AND n.org_id = t.org_id
+  AND n.params ->> 'projectId' IS NULL;

--- a/services/platform/backend/domains/collab/service.test.ts
+++ b/services/platform/backend/domains/collab/service.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NOTIFICATION_HINT_ENTITY } from '../../../lib/shared/hint-entities.ts';
 import { coalesceKeyFor } from '../../core/collab/coalesce.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
+import type { CollabNotificationInput } from './service.ts';
 import {
   dismissReviewRequestNotifications,
   getMyAttentionSummary,
@@ -25,19 +26,35 @@ type Row = Record<string, unknown>;
 function fakeDb(answer: (text: string) => Row[]): {
   db: Sql;
   statements: string[];
+  calls: { text: string; values: unknown[] }[];
 } {
   const statements: string[] = [];
+  const calls: { text: string; values: unknown[] }[] = [];
   const tag = (
     strings: TemplateStringsArray,
-    ..._values: unknown[]
+    ...values: unknown[]
   ): Promise<Row[]> => {
     const text = strings.join('?').replaceAll(/\s+/g, ' ').trim();
     statements.push(text);
+    calls.push({ text, values });
     return Promise.resolve(answer(text));
   };
   const db = Object.assign(tag, { json: (value: unknown) => value });
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- a two-member stand-in for the postgres.js template function
-  return { db: db as unknown as Sql, statements };
+  return { db: db as unknown as Sql, statements, calls };
+}
+
+/** The `params` bag an INSERT carried, read back off the captured values. */
+function insertedParams(
+  calls: { text: string; values: unknown[] }[],
+): Record<string, unknown> | undefined {
+  const insert = calls.find((c) =>
+    c.text.startsWith('INSERT INTO app.user_notifications'),
+  );
+  return insert?.values.find(
+    (v): v is Record<string, unknown> =>
+      typeof v === 'object' && v !== null && 'to' in v,
+  );
 }
 
 const RECIPIENT = { userId: 'u-recipient', organizationId: 'org-1' };
@@ -48,7 +65,7 @@ const statusBell = {
   type: 'task_status_changed',
   titleKey: 'taskStatusChanged',
   bodyKey: 'taskStatusChangedBody',
-  params: { to: 'in_progress' },
+  params: { to: 'in_progress', projectId: 'proj-1' },
   resourceType: 'task',
   resourceId: 'task-1',
   taskId: 'task-1',
@@ -63,6 +80,76 @@ const twinKey = coalesceKeyFor(
 
 beforeEach(() => {
   vi.mocked(emitHintInTx).mockReset();
+});
+
+/**
+ * A task row that arrived WITHOUT its project — the shape
+ * `CollabNotificationInput` now refuses from a typed caller, and so
+ * reachable only from dynamically built args or from behind a cast. The cast
+ * IS the test: it reproduces what the writer must still repair at runtime.
+ */
+const projectlessBell = {
+  ...statusBell,
+  params: { to: 'in_progress' },
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- deliberately the shape the union forbids
+} as unknown as CollabNotificationInput;
+
+describe('a task-bound row always carries its project', () => {
+  it('resolves the project from the task when the caller left it out', async () => {
+    const { db, calls } = fakeDb((text) => {
+      if (text.startsWith('SELECT project_id')) {
+        return [{ projectId: 'proj-resolved' }];
+      }
+      if (text.startsWith('SELECT id, coalesce_key')) return [];
+      if (text.startsWith('INSERT INTO app.user_notifications')) {
+        return [{ id: 'n-new' }];
+      }
+      return [];
+    });
+
+    await expect(writeCoalescedNotification(db, projectlessBell)).resolves.toBe(
+      'inserted',
+    );
+    expect(insertedParams(calls)).toEqual({
+      to: 'in_progress',
+      projectId: 'proj-resolved',
+    });
+  });
+
+  it('does not look the project up when the caller supplied one', async () => {
+    const { db, statements } = fakeDb((text) => {
+      if (text.startsWith('SELECT id, coalesce_key')) return [];
+      if (text.startsWith('INSERT INTO app.user_notifications')) {
+        return [{ id: 'n-new' }];
+      }
+      return [];
+    });
+
+    await writeCoalescedNotification(db, statusBell);
+    expect(statements.some((s) => s.startsWith('SELECT project_id'))).toBe(
+      false,
+    );
+  });
+
+  it("invents nothing when the task is not in the row's organization", async () => {
+    // The lookup is org-scoped, so a task id belonging to another tenant
+    // answers no row. Leave the bag as it came rather than linking to
+    // something the recipient cannot see.
+    const { db, calls, statements } = fakeDb((text) => {
+      if (text.startsWith('SELECT id, coalesce_key')) return [];
+      if (text.startsWith('INSERT INTO app.user_notifications')) {
+        return [{ id: 'n-new' }];
+      }
+      return [];
+    });
+
+    await writeCoalescedNotification(db, projectlessBell);
+    const lookup = statements.find((s) => s.startsWith('SELECT project_id'));
+    // Tenant isolation is the point: the lookup is keyed by BOTH the task
+    // and the row's organization, so another tenant's task answers no row.
+    expect(lookup).toContain('org_id = ?');
+    expect(insertedParams(calls)).toEqual({ to: 'in_progress' });
+  });
 });
 
 describe('the personal bell hint (wire contract with the web app)', () => {

--- a/services/platform/backend/domains/collab/service.ts
+++ b/services/platform/backend/domains/collab/service.ts
@@ -27,22 +27,39 @@ type Db = Sql | TransactionSql;
 
 export type NotificationActorType = 'user' | 'agent' | 'system';
 
-export interface CollabNotificationInput {
+interface CollabNotificationBase {
   userId: string;
   organizationId: string;
   type: string;
   titleKey: string;
   bodyKey: string;
-  params?: Record<string, unknown>;
   resourceType: string;
   resourceId: string;
-  taskId?: string;
   actorType: NotificationActorType;
   actorId?: string;
   /** This event UNDOES its dimension (an unassignment after an assignment):
    * when the row it would replace is still unread, both drop. */
   undoes?: boolean;
 }
+
+/**
+ * A task-bound row must carry its project. Both deep-link builders — the
+ * bell's `personalNotificationTarget` and the email's
+ * `buildPersonalNotificationUrl` — need `taskId` AND `params.projectId`
+ * together to open the task. With only `taskId` the bell row degrades to the
+ * org home and the email loses its CTA entirely, silently: no type error, no
+ * failing test, and a fallback that reads as deliberate. The two-arm union
+ * makes the pair unwritable apart.
+ */
+export type CollabNotificationInput =
+  | (CollabNotificationBase & {
+      taskId: string;
+      params: Record<string, unknown> & { projectId: string };
+    })
+  | (CollabNotificationBase & {
+      taskId?: undefined;
+      params?: Record<string, unknown>;
+    });
 
 /** The per-type preference column (the 0.4 PREF_FIELD map). The 0.4
  * `automation_alerts` group (automation_failed / budget_alert /
@@ -163,13 +180,46 @@ async function emitBellHints(
 }
 
 /**
+ * Resolve a task-bound row's project when the caller left it out, so the row
+ * can still deep-link. The union above requires the pair from typed callers,
+ * so this is the belt: this writer is also reached from dynamically built
+ * args, and from rows assembled behind a cast.
+ *
+ * Scoped to the row's own organization — a task id that does not resolve
+ * inside it is left alone, so a link is never invented from another tenant's
+ * data. Only queries on the miss path, and uses the caller's handle, so it
+ * joins the open transaction rather than reading around it.
+ *
+ * `coalesceKeyFor` reads `conversationId` and `documentId`, never
+ * `projectId`, so enriching here cannot move a row's collapse identity.
+ */
+async function withTaskProjectContext(
+  db: Db,
+  args: CollabNotificationInput,
+): Promise<CollabNotificationInput> {
+  if (args.taskId === undefined) return args;
+  const params: Record<string, unknown> = args.params;
+  const supplied = params.projectId;
+  if (typeof supplied === 'string' && supplied !== '') return args;
+  const rows = await db<{ projectId: string }[]>`
+    SELECT project_id AS "projectId" FROM app.tasks
+    WHERE id = ${args.taskId} AND org_id = ${args.organizationId}
+    LIMIT 1
+  `;
+  const projectId = rows[0]?.projectId;
+  if (projectId === undefined) return args;
+  return { ...args, params: { ...params, projectId } };
+}
+
+/**
  * Write (or rewrite, or cancel) one notification row. Callers own the
  * preference gate — this is the mechanics of one row.
  */
 export async function writeCoalescedNotification(
   db: Db,
-  args: CollabNotificationInput,
+  input: CollabNotificationInput,
 ): Promise<CoalesceOutcome> {
+  const args = await withTaskProjectContext(db, input);
   const key = coalesceKeyFor(
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the reused pure fn narrows types internally; unknown types simply never collapse
     args as unknown as Parameters<typeof coalesceKeyFor>[0],
@@ -989,17 +1039,33 @@ export async function notifyAgentQuestionAsked(
     args.organizationId,
     projectId,
   );
-  const params: Record<string, unknown> = {
+  const shared = {
     name: args.automationLabel,
     question: questionExcerpt(args.question),
     askId: args.askId,
     runId: args.runId,
-    ...(args.task
-      ? { title: args.task.title, projectId: args.task.projectId }
-      : projectId !== null
-        ? { projectId }
-        : {}),
   };
+  // Two explicit arms rather than one widened bag: a task-bound row has to
+  // carry its project, and `CollabNotificationInput` will not accept a
+  // spread that TypeScript cannot narrow to that pair.
+  const row = args.task
+    ? ({
+        bodyKey: 'agentQuestionAskedBody',
+        params: {
+          ...shared,
+          title: args.task.title,
+          projectId: args.task.projectId,
+        },
+        resourceType: 'task',
+        resourceId: args.task.id,
+        taskId: args.task.id,
+      } as const)
+    : ({
+        bodyKey: 'agentQuestionAskedNoTaskBody',
+        params: projectId !== null ? { ...shared, projectId } : { ...shared },
+        resourceType: 'dashboard',
+        resourceId: projectId ?? args.organizationId,
+      } as const);
   let notified = 0;
   for (const userId of [...new Set(recipients)].slice(0, MAX_ASK_RECIPIENTS)) {
     if (
@@ -1013,17 +1079,11 @@ export async function notifyAgentQuestionAsked(
       continue;
     }
     await writeCoalescedNotification(db, {
+      ...row,
       userId,
       organizationId: args.organizationId,
       type: 'agent_escalation',
       titleKey: 'agentQuestionAsked',
-      bodyKey: args.task
-        ? 'agentQuestionAskedBody'
-        : 'agentQuestionAskedNoTaskBody',
-      params,
-      resourceType: args.task ? 'task' : 'dashboard',
-      resourceId: args.task ? args.task.id : (projectId ?? args.organizationId),
-      ...(args.task ? { taskId: args.task.id } : {}),
       actorType: 'agent',
       actorId: args.automationLabel,
     });

--- a/services/platform/backend/domains/erasure/service.ts
+++ b/services/platform/backend/domains/erasure/service.ts
@@ -158,7 +158,7 @@ async function parkForDualApproval(
       requestId: args.requestId,
     },
     subjectUserId: args.targetUserId,
-    link: { kind: 'dsar' },
+    link: { kind: 'dsar', requestId: args.requestId },
   });
 }
 
@@ -1667,7 +1667,7 @@ export async function confirmAndScheduleErasure(
       requestId: row.id,
     },
     subjectUserId: row.targetUserId,
-    link: { kind: 'dsar' },
+    link: { kind: 'dsar', requestId: row.id },
   });
 }
 

--- a/services/platform/backend/domains/knowledge/index-health.ts
+++ b/services/platform/backend/domains/knowledge/index-health.ts
@@ -615,7 +615,7 @@ function notificationArgs(
   const shared = {
     organizationIds: [organizationId],
     category: 'security' as const,
-    link: { kind: 'audit-logs' },
+    link: { kind: 'audit-logs' } as const,
     dedupeKey: `knowledge-index:${event.kind}:${index}:${stamp}`,
   };
   switch (event.kind) {

--- a/services/platform/backend/domains/notifications/service.ts
+++ b/services/platform/backend/domains/notifications/service.ts
@@ -2,6 +2,7 @@ import type { Sql, TransactionSql } from 'postgres';
 
 import { NOTIFICATION_HINT_ENTITY } from '../../../lib/shared/hint-entities.ts';
 import { isAdminRole } from '../../auth/membership.ts';
+import type { OrgNotificationLink } from '../../core/notifications/org_notification_link.ts';
 import { toJson } from '../../db/sql.ts';
 import { emitHintInTx } from '../../realtime/outbox.ts';
 
@@ -39,7 +40,7 @@ export interface WriteNotificationArgs {
   bodyKey: string;
   params?: Record<string, unknown>;
   subjectUserId?: string;
-  link?: Record<string, unknown>;
+  link?: OrgNotificationLink;
   /**
    * Durable idempotency key, unique per org — derive from the triggering
    * entity, never mint per attempt; a duplicate delivery becomes a no-op.

--- a/services/platform/backend/domains/organizations/routes.ts
+++ b/services/platform/backend/domains/organizations/routes.ts
@@ -83,6 +83,8 @@ export function createOrganizationRoutes(deps: {
           name: session.user.name || session.user.email || 'A member',
         },
         subjectUserId: userId,
+        // The page where an admin grants the credits this asks for.
+        link: { kind: 'budgets' },
       }),
     );
     return c.json({ ok: true });

--- a/services/platform/backend/domains/tasks/date-notifications.test.ts
+++ b/services/platform/backend/domains/tasks/date-notifications.test.ts
@@ -205,3 +205,67 @@ describe('enforceTaskDatesForOrg — each row is claimed and announced in its ow
     expect(rolledBack).toEqual(['TASK_COMMENT_INVALID']);
   });
 });
+
+/**
+ * The defect this pins: every rung wrote `params: { title }` and dropped the
+ * project it already had in hand, so the bell row fell back to the org home
+ * and the email shipped with no CTA at all. Both link builders need `taskId`
+ * and `params.projectId` together to open the task.
+ */
+describe('enforceTaskDatesForOrg — every rung stamps the project', () => {
+  it('the start-date rung sends the project alongside the task', async () => {
+    const { sql } = fakeSql((text, values) => {
+      if (
+        text.startsWith('SELECT t2.id FROM app.tasks t2') &&
+        text.includes('start_date_ms')
+      ) {
+        return [{ id: 't-a' }];
+      }
+      if (text.startsWith('UPDATE app.tasks SET start_notified_at_ms')) {
+        return [sweepRow(String(values[1]))];
+      }
+      return [];
+    });
+
+    await enforceTaskDatesForOrg(sql, 'org-1');
+
+    expect(notifyUser).toHaveBeenCalledTimes(1);
+    const [, args] = vi.mocked(notifyUser).mock.calls[0] ?? [];
+    expect(args?.taskId).toBe('t-a');
+    expect(args?.params).toEqual({ title: 'Task t-a', projectId: 'p-1' });
+  });
+
+  it('the escalation rung sends it to every recipient', async () => {
+    const { sql } = fakeSql((text, values) => {
+      if (
+        text.startsWith('SELECT t2.id FROM app.tasks t2') &&
+        text.includes('> coalesce(t2.sla_level, 0)')
+      ) {
+        return [{ id: 't-late' }];
+      }
+      if (
+        text.startsWith('UPDATE app.tasks SET sla_level = ?, sla_level_at_ms')
+      ) {
+        return values.includes('t-late')
+          ? [sweepRow('t-late', { newLevel: 4 })]
+          : [];
+      }
+      if (text.startsWith('SELECT "userId" FROM "member"')) {
+        return [{ userId: 'u-admin' }];
+      }
+      return [];
+    });
+
+    await enforceTaskDatesForOrg(sql, 'org-1');
+
+    // The task's creator plus the org admin.
+    expect(notifyUser).toHaveBeenCalledTimes(2);
+    for (const [, args] of vi.mocked(notifyUser).mock.calls) {
+      expect(args.titleKey).toBe('taskSlaEscalated');
+      expect(args.params).toEqual({
+        title: 'Task t-late',
+        projectId: 'p-1',
+      });
+    }
+  });
+});

--- a/services/platform/backend/domains/tasks/date-notifications.ts
+++ b/services/platform/backend/domains/tasks/date-notifications.ts
@@ -105,7 +105,7 @@ async function notifyDateAlert(
     type: 'task_deadline',
     titleKey: args.titleKey,
     bodyKey: args.bodyKey,
-    params: { title: args.row.title },
+    params: { title: args.row.title, projectId: args.row.projectId },
     resourceType: 'task',
     resourceId: args.row.taskId,
     taskId: args.row.taskId,
@@ -363,6 +363,9 @@ export async function enforceTaskDatesForOrg(
         for (const adminId of await orgAdminUserIds(tx, organizationId)) {
           escalationTargets.add(adminId);
         }
+        // Built once: every recipient gets the same row, and the project is
+        // what makes it deep-link to the task.
+        const params = { title: row.title, projectId: row.projectId };
         for (const userId of escalationTargets) {
           await notifyUser(tx, {
             userId,
@@ -370,7 +373,7 @@ export async function enforceTaskDatesForOrg(
             type: 'task_deadline',
             titleKey: 'taskSlaEscalated',
             bodyKey: 'taskSlaEscalatedBody',
-            params: { title: row.title },
+            params,
             resourceType: 'task',
             resourceId: row.taskId,
             taskId: row.taskId,

--- a/services/platform/backend/domains/websites/service.ts
+++ b/services/platform/backend/domains/websites/service.ts
@@ -401,6 +401,9 @@ export async function recordScanFailure(
         titleKey: 'websiteScanPaused',
         bodyKey: 'websiteScanPausedDetails',
         params: { domain: args.domain, failures },
+        // The row's status is set to `error` in this same transaction, so
+        // the filtered list contains the site the alert is about.
+        link: { kind: 'websites' },
       });
     }
   });

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -34608,7 +34608,12 @@ async function checkBellHintWire(
       type: 'task_status_changed',
       titleKey: 'taskStatusChanged',
       bodyKey: 'taskStatusChangedBody',
-      params: { title: 'Bell wire', from: 'todo', to: 'in_progress' },
+      params: {
+        title: 'Bell wire',
+        from: 'todo',
+        to: 'in_progress',
+        projectId: 'p-bell-wire',
+      },
       resourceType: 'task',
       resourceId: 'itest-bell-wire',
       taskId: 'itest-bell-wire',

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -21660,6 +21660,72 @@ async function checkNotificationEmailSink(
         .sort()
         .join('|')}`,
     );
+
+    // E) The overdue-email defect, end to end: a task-bound bell whose
+    // params carry NO project. The writer resolves it from `app.tasks`,
+    // org-scoped, inside the caller's transaction — so the mail that lands
+    // opens the task instead of shipping with no CTA at all.
+    const deadlineProject = await sql<{ id: string }[]>`
+      INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                                updated_at_ms)
+      VALUES (${orgId}, 'Deadline project', ${userId}, ${Date.now()},
+              ${Date.now()})
+      RETURNING id
+    `;
+    const deadlineProjectId = deadlineProject[0]?.id ?? '';
+    const deadlineTask = await sql<{ id: string }[]>`
+      INSERT INTO app.tasks (
+        org_id, project_id, title, status, rank, number, created_by,
+        created_by_type, created_at_ms, updated_at_ms, status_changed_at_ms
+      ) VALUES (
+        ${orgId}, ${deadlineProjectId}, 'Redesign side-navigation', 'todo',
+        'a0', 1, ${userId}, 'user', ${Date.now()}, ${Date.now()},
+        ${Date.now()}
+      )
+      RETURNING id
+    `;
+    const deadlineTaskId = deadlineTask[0]?.id ?? '';
+
+    await writeCoalescedNotification(sql, {
+      userId,
+      organizationId: orgId,
+      type: 'task_deadline',
+      titleKey: 'taskSlaEscalated',
+      bodyKey: 'taskSlaEscalatedBody',
+      // The shape the union now refuses from a typed caller — the point of
+      // the case is that the writer still repairs it at runtime.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- deliberately a row that arrived without its project
+      params: { title: 'Redesign side-navigation' } as unknown as {
+        projectId: string;
+      } & Record<string, unknown>,
+      resourceType: 'task',
+      resourceId: deadlineTaskId,
+      taskId: deadlineTaskId,
+      actorType: 'system',
+    });
+    const deadlineDrained = await drainNotificationEmails(sql);
+    const deadlineMail = smtpSends[1];
+    const deadlineLink =
+      `/dashboard/${orgId}/projects/${deadlineProjectId}` +
+      `/tasks?task=${deadlineTaskId}`;
+    const storedParams = await sql<{ projectId: string | null }[]>`
+      SELECT params ->> 'projectId' AS "projectId"
+      FROM app.user_notifications
+      WHERE org_id = ${orgId} AND task_id = ${deadlineTaskId}
+      LIMIT 1
+    `;
+
+    record(
+      'overdue notification email opens its task',
+      deadlineDrained &&
+        smtpSends.length === 2 &&
+        storedParams[0]?.projectId === deadlineProjectId &&
+        deadlineMail?.subject === 'Overdue task escalated' &&
+        (deadlineMail?.html ?? '').includes(`<a href="`) &&
+        (deadlineMail?.html ?? '').includes(deadlineLink) &&
+        (deadlineMail?.text ?? '').includes(`Open in Tale: `),
+      `drained=${deadlineDrained} emails=${smtpSends.length} (want 2) storedProject=${storedParams[0]?.projectId}==${deadlineProjectId} subject=${deadlineMail?.subject} link=${(deadlineMail?.html ?? '').includes(deadlineLink)} want=${deadlineLink} cta=${(deadlineMail?.text ?? '').includes('Open in Tale: ')}`,
+    );
   } finally {
     setMailTransportForTesting(DEFAULT_MAIL_FAKE);
   }

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -21732,6 +21732,108 @@ async function checkNotificationEmailSink(
 }
 
 /**
+ * The 0087 backfill: stored task rows written before the project was
+ * stamped still have to deep-link, and the statement that repairs them must
+ * be idempotent and must not cross a tenant boundary. Runs the migration's
+ * own UPDATE against rows seeded here — boot already applied it, so a fresh
+ * row needs the statement re-executed to be judged.
+ */
+async function checkNotificationProjectBackfill(
+  sql: Sql,
+  ctx: { orgId: string; userId: string },
+): Promise<void> {
+  const { orgId, userId } = ctx;
+  const now = Date.now();
+  const applied = await sql<{ name: string }[]>`
+    SELECT name FROM app_migrations
+    WHERE name = '0087_notification_params_project_backfill.sql'
+  `;
+
+  const project = await sql<{ id: string }[]>`
+    INSERT INTO app.projects (org_id, name, created_by, created_at_ms,
+                              updated_at_ms)
+    VALUES (${orgId}, 'Backfill project', ${userId}, ${now}, ${now})
+    RETURNING id
+  `;
+  const projectId = project[0]?.id ?? '';
+  const task = await sql<{ id: string }[]>`
+    INSERT INTO app.tasks (
+      org_id, project_id, title, status, rank, number, created_by,
+      created_by_type, created_at_ms, updated_at_ms, status_changed_at_ms
+    ) VALUES (
+      ${orgId}, ${projectId}, 'Backfill task', 'todo', 'a0', 1, ${userId},
+      'user', ${now}, ${now}, ${now}
+    )
+    RETURNING id
+  `;
+  const taskId = task[0]?.id ?? '';
+
+  // A stored row of the shape the emitters used to write.
+  const stale = await sql<{ id: string }[]>`
+    INSERT INTO app.user_notifications (
+      user_id, org_id, type, title_key, body_key, params, resource_type,
+      resource_id, task_id, actor_type, read, created_at_ms
+    ) VALUES (
+      ${userId}, ${orgId}, 'task_deadline', 'taskSlaEscalated',
+      'taskSlaEscalatedBody', ${sql.json({ title: 'Backfill task' })}, 'task',
+      ${taskId}, ${taskId}, 'system', false, ${now}
+    )
+    RETURNING id
+  `;
+  const staleId = stale[0]?.id ?? '';
+
+  // The same task id under a DIFFERENT organization: the join carries
+  // `org_id` on both sides, so this row must be left alone.
+  const foreignOrgId = `itest-foreign-${now}`;
+  const foreign = await sql<{ id: string }[]>`
+    INSERT INTO app.user_notifications (
+      user_id, org_id, type, title_key, body_key, params, resource_type,
+      resource_id, task_id, actor_type, read, created_at_ms
+    ) VALUES (
+      ${userId}, ${foreignOrgId}, 'task_deadline', 'taskSlaEscalated',
+      'taskSlaEscalatedBody', ${sql.json({ title: 'Not yours' })}, 'task',
+      ${taskId}, ${taskId}, 'system', false, ${now}
+    )
+    RETURNING id
+  `;
+  const foreignId = foreign[0]?.id ?? '';
+
+  const backfill = async (): Promise<number> => {
+    const rows = await sql`
+      UPDATE app.user_notifications n
+      SET params = coalesce(n.params, '{}'::jsonb)
+                   || jsonb_build_object('projectId', t.project_id)
+      FROM app.tasks t
+      WHERE n.task_id = t.id
+        AND n.org_id = t.org_id
+        AND n.params ->> 'projectId' IS NULL
+      RETURNING n.id
+    `;
+    return rows.length;
+  };
+
+  const firstPass = await backfill();
+  const secondPass = await backfill();
+
+  const after = await sql<{ id: string; projectId: string | null }[]>`
+    SELECT id, params ->> 'projectId' AS "projectId"
+    FROM app.user_notifications WHERE id IN (${staleId}, ${foreignId})
+  `;
+  const repaired = after.find((row) => row.id === staleId)?.projectId;
+  const untouched = after.find((row) => row.id === foreignId)?.projectId;
+
+  record(
+    'notification project backfill (idempotent, org-scoped)',
+    applied.length === 1 &&
+      firstPass >= 1 &&
+      secondPass === 0 &&
+      repaired === projectId &&
+      untouched === null,
+    `applied=${applied.length} first=${firstPass} second=${secondPass} (want 0) repaired=${repaired}==${projectId} foreignUntouched=${untouched === null}`,
+  );
+}
+
+/**
  * The chat assistant's conversations search leg (rag_search entity leg,
  * previously an honest empty): subject/contact/body matching over the rows
  * the mailbox and send checks seeded, with the assignment-privacy predicate
@@ -45151,6 +45253,10 @@ async function main(): Promise<void> {
       [
         'checkSandboxBlobDoor',
         () => checkSandboxBlobDoor(sql, baseUrl, authCtx),
+      ],
+      [
+        'checkNotificationProjectBackfill',
+        () => checkNotificationProjectBackfill(sql, authCtx),
       ],
       ['checkTurnReattach', () => checkTurnReattach(sql, authCtx)],
       ['checkQueuedRunRecovery', () => checkQueuedRunRecovery(sql, authCtx)],

--- a/services/platform/tests/manual/suites/notifications.md
+++ b/services/platform/tests/manual/suites/notifications.md
@@ -126,9 +126,10 @@ their own action, so a single account cannot generate those rows.
   (`inbox.taskReviewReminder`), **Review overdue**
   (`inbox.taskReviewEscalated`), **Workflow waiting on input**
   (`inbox.humanInputEscalated`), **Agent escalation**
-  (`inbox.agentEscalation`, body `inbox.agentEscalationBody`) → Assert only
-  that any observed row renders its **translated title** (one of the strings
-  above) — never a raw key like `inbox.taskDueSoon`
+  (`inbox.agentEscalation`, body `inbox.agentEscalationBody`) → Assert the
+  row renders its **translated title** (one of the strings above) — never a
+  raw key like `inbox.taskDueSoon` — and that clicking a **deadline** row
+  (start / due soon / overdue) opens the task sheet, NOT the org dashboard
 - [ ] `NOTIF-F13` · **Agent asked a question** — Park an automation run on
   `ask_human` with a task subject ([approvals.md](approvals.md)
   APV-F5/APV-F7); as any member who can **see the task's project**, open the
@@ -142,6 +143,15 @@ their own action, so a single account cannot generate those rows.
   stacking); once anyone answers — or the ask expires/cancels — the unread
   rows flip to read **without** manual mark-read and a still-pending email is
   cancelled.
+- [ ] `NOTIF-F14` · **Org alerts open their subject** — Env-gated
+  documentation row (these are admin/system-driven). As an owner/admin, on
+  any org row observed in the bell: a **Usage credits requested**
+  (`notifications.creditRequestTitle`) row opens **Settings → Governance →
+  Policies & limits**; a **Website scan paused**
+  (`notifications.websiteScanPaused`) row opens **Websites** filtered to
+  `status=error`; a DSAR row (`notifications.dsarApprovalNeeded` /
+  `dsarScheduled`) opens **that request**, not the requests list → No org row
+  lands on a bare Governance or Automations landing page
 > The **Upgraded to v{version}** changelog release toast is **not** a bell
 > notification — it belongs to the app shell and is covered in
 > [navigation.md](navigation.md) (its NAV-F12), which owns the changelog.


### PR DESCRIPTION
An overdue-task email went out naming a task and giving no way to open it.
Every notification now links to what it names, in the bell and in email, and a
new notification type cannot ship without one.

## Why

All three date rungs wrote `params: { title }` and dropped the project id the
sweep already had (`date-notifications.ts:108`, `:373`). Both link builders
need `taskId` and `params.projectId` together, so the bell row fell back to the
org home and `renderActionableEmailContent` dropped the CTA paragraph.

The link is derived from an optional `params` bag. The row already carries a
typed entity reference that neither builder reads. Omitting a key failed
quietly: no type error, no red test. A unit test pinned the fallback as
correct.

## What changed

- `CollabNotificationInput` is a two-arm union, so `taskId` cannot be passed
  without `params.projectId`. This caught the three emitter sites.
- `writeCoalescedNotification` resolves a missing project from the task,
  org-scoped, only on the miss path, on the caller's transaction handle.
- An actionable email always renders a CTA. `buildPersonalNotificationUrl`
  returns the org dashboard where it used to return null.
- Notification links read `SITE_URL` at call time and carry `BASE_PATH`. The
  module-load constant ignored `BASE_PATH`, so subpath deployments 404'd.
- Five rows now open their subject rather than a list: the DSAR request, the
  usage-credits alert, the website-scan alert, and an org-scoped agent
  escalation. The `agent` link kind is deleted; nothing stamped it.
- `orgNotificationTarget`'s `default` arm returned the link object, giving
  `<Link>` no `to`. It returns the category landing.
- Migration `0087` backfills rows already in people's bells.

## Risk

The union rejects a `taskId` without a project at every call site, including
ones a future emitter adds. A caller building args dynamically must satisfy the
pair or accept the runtime lookup.

## Tests

| Assertion | Mutation that turned it red |
| --- | --- |
| Deadline rungs stamp the project | Drop `projectId` from either rung |
| The writer repairs a projectless row | Invert the `taskId` guard |
| The lookup is org-scoped | Drop `AND org_id` from its `WHERE` |
| Every type reaches its declared path | Remove the run branch from the bell |
| Both builders agree | Remove that branch from the email only |
| Org links reach their page | Point the websites link at Automations |
| `SITE_URL` is read per call | Restore the module-load constant |
| `BASE_PATH` is carried | Return the bare origin |

`personal_notification_url.ts` had no unit test; it has 14. The parity suite
drives both builders from one table, 52 assertions.
`checkNotificationEmailSink` gained the reported defect end to end against a
seeded task, and the backfill has its own idempotency and tenant probe.

## Scope

Does not close the comment anchor. `mention` and `task_commented` store the
comment id in `resource_id`, but no route addresses a comment, so the reader
still lands on the task and scrolls. That needs a route.

Body copy is unchanged. Four conversation strings still say "open your Inbox to
reply" though the row links there.

Gate: `bun run check` green; `backend:integration` green on throwaway Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
