### PR TITLE
chore(deps): remove unused AI SDK provider dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,6 @@
       "name": "@tale/platform",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
         "@better-auth/api-key": "1.6.30",
         "@better-auth/oauth-provider": "1.6.30",
         "@better-auth/passkey": "1.6.30",
@@ -489,8 +488,6 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
-
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -3315,8 +3312,6 @@
     "json-pointer": ["json-pointer@0.6.2", "", { "dependencies": { "foreach": "^2.0.4" } }, "sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw=="],
 
     "json-promise": ["json-promise@1.1.8", "", { "dependencies": { "bluebird": "*" } }, "sha512-rz31P/7VfYnjQFrF60zpPTT0egMPlc8ZvIQHWs4ZtNZNnAXRmXo6oS+6eyWr5sEMG03OVhklNrTXxiIRYzoUgQ=="],
-
-    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-compare": ["json-schema-compare@0.2.2", "", { "dependencies": { "lodash": "^4.17.4" } }, "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -149,7 +149,6 @@ export default {
         // subsystems ignored above. Same debt ledger, same exit: delete a
         // line when its consumer wires up, or drop the dependency with it.
         // ------------------------------------------------------------
-        '@ai-sdk/provider',
         '@measured/puck',
         '@modelcontextprotocol/sdk',
         '@tanstack/react-virtual',

--- a/services/platform/package.json
+++ b/services/platform/package.json
@@ -30,7 +30,6 @@
     "pwa:icons": "bunx pwa-assets-generator --preset minimal-2023 public/assets/logo-black.svg"
   },
   "dependencies": {
-    "@ai-sdk/provider": "3.0.8",
     "@better-auth/api-key": "1.6.30",
     "@better-auth/oauth-provider": "1.6.30",
     "@better-auth/passkey": "1.6.30",


### PR DESCRIPTION
## Summary

Platform still declares `@ai-sdk/provider` even though no source imports it. Remove the dependency and its Knip exemption, and regenerate the Bun lockfile to prune it and its orphan `json-schema` dependency. OpenCode's sandbox provider configuration remains independent of platform's dependencies.

## Checklist

- [x] `bun run check` passes (43/43 tasks).
- [x] `bun run lint:sast` passes (0 findings; scanner reports existing partial-analysis warnings).
- [x] Translations: N/A — dependency cleanup with no user-visible strings.
- [x] Docs: N/A — no behavior, configuration, or API changes.
- [x] READMEs: N/A — no setup or usage changes.

## Test plan

- `bun run knip:check` passed after removing the exemption.
- In a fresh detached worktree with this patch, `bun install --frozen-lockfile --ignore-scripts` passed and module resolution confirmed `@ai-sdk/provider` is absent.
- In that clean installation, platform typecheck and production build passed.
- `bun run --filter @tale/platform test lib/chat backend/core/chat lib/harnesses` passed in the clean installation: 33 files, 531 tests.
