### PR TITLE
fix(platform): classify provider account refusals and check providerSlug

### DIFF
--- a/docs/de/develop/api-reference.md
+++ b/docs/de/develop/api-reference.md
@@ -174,7 +174,7 @@ Das Projekt in der URL bestimmt den Kontext der Aufgaben- und Dokumentwerkzeuge 
 
 Projektchats folgen ebenfalls dem Ablauf 202, dann Statusabfrage. Wähle ein Projekt, das du lesen darfst, lege einen Thread an, sende eine Nachricht, frage den Status ab und lies die Antwort:
 
-Rufe vor dem Senden die Modelle ab. Übernimm `id` als `model` und `providerSlug` für die Auswahl des Anbieters. Die Liste berücksichtigt die Modellzugriffsregeln der Organisation und enthält nur Modelle, die REST direkt aufrufen kann. Ist sie leer, steht dem Schlüsselbesitzer kein Chat-Modell zur Verfügung.
+Rufe vor dem Senden die Modelle ab. Übernimm `id` als `model` und `providerSlug` für die Auswahl des Anbieters. Die Liste berücksichtigt die Modellzugriffsregeln der Organisation und enthält nur Modelle, die REST direkt aufrufen kann. Ist sie leer, steht dem Schlüsselbesitzer kein Chat-Modell zur Verfügung. Das Paar wird beim Senden geprüft: Ein `providerSlug`, den die Liste nicht kennt, ergibt **400**, `CHAT_PROVIDER_UNKNOWN`; einer, der das gewählte `model` nicht bedient, **400**, `CHAT_MODEL_NOT_ON_PROVIDER` — der Turn weicht nie stillschweigend auf einen anderen Anbieter aus.
 
 ```bash
 curl -sS "https://your-host.example.com/api/v1/models" \
@@ -210,7 +210,7 @@ curl -sS "https://your-host.example.com/api/v1/projects/<projectId>/threads/<thr
 
 Für persönliche Chats ohne Projekt verwendest du `/api/v1/threads` sowie die zugehörigen Detail-, Nachrichten- und Statuspfade. Projektthreads sind dort nicht erreichbar. Ein falsches Projekt in der URL ergibt **404**. Beide Chatarten verwenden den eingebauten Assistenten; `projectId`, `agentSlug` oder `agentId` beim Anlegen oder Senden ergibt **400**. Projektleser einschließlich Mitgliedern dürfen Threads anlegen und Nachrichten senden. Ein archiviertes Projekt verweigert diese Aufrufe mit **403**, ein archivierter Thread das Senden mit **409**.
 
-Ein Modellfehler kann als Assistenten-Nachricht mit lesbarem `error` und, wenn verfügbar, `errorCode` erscheinen. Vor dem Öffnen des Turns prüft der Worker den angenommenen Thread und den Projektzugriff erneut. Wechselt der Thread während der Wartezeit das Projekt oder entfällt der Zugriff, führt er den Turn nicht aus und schreibt auch keine Fehlermeldung in den neuen Kontext.
+Ein Modellfehler kann als Assistenten-Nachricht mit lesbarem `error` und, wenn verfügbar, `errorCode` erscheinen. Die Modellliste ist der konfigurierte Katalog der Organisation, kein Versprechen des Anbieterkontos — zwei Codes meinen deshalb das Konto, nicht die Anfrage: `credit_exhausted` (Guthaben aufgebraucht) und `model_not_entitled` (der Tarif des Anbieters enthält dieses Modell nicht). Wähl ein anderes Modell oder bring das Konto in Ordnung — Warten ändert nichts, und keiner von beiden ist ein `rate_limited`. Vor dem Öffnen des Turns prüft der Worker den angenommenen Thread und den Projektzugriff erneut. Wechselt der Thread während der Wartezeit das Projekt oder entfällt der Zugriff, führt er den Turn nicht aus und schreibt auch keine Fehlermeldung in den neuen Kontext.
 
 ## Die Dateien eines Projekts durchsuchen
 

--- a/docs/en/develop/api-reference.md
+++ b/docs/en/develop/api-reference.md
@@ -174,7 +174,7 @@ The project in the URL is the context for the run's task and document tools. An 
 
 Project chat follows the same 202-then-poll shape. Use a project you can read, create a thread, post a message, poll the generation, then read the messages:
 
-List models before sending a message. Use an entry’s `id` as `model` and its `providerSlug` to select the provider. The list respects the organization’s model-access policy and includes only models callable directly through REST; an empty list means no chat model is available to this key holder.
+List models before sending a message. Use an entry’s `id` as `model` and its `providerSlug` to select the provider. The list respects the organization’s model-access policy and includes only models callable directly through REST; an empty list means no chat model is available to this key holder. The pair is checked on send: a `providerSlug` the list does not carry answers **400**, `CHAT_PROVIDER_UNKNOWN`, and one that does not serve the chosen `model` answers **400**, `CHAT_MODEL_NOT_ON_PROVIDER` — the turn never falls back to another provider behind your back.
 
 ```bash
 curl -sS "https://your-host.example.com/api/v1/models" \
@@ -210,7 +210,7 @@ curl -sS "https://your-host.example.com/api/v1/projects/<projectId>/threads/<thr
 
 For a personal chat with no project, use `/api/v1/threads` and its corresponding detail, messages and generation paths. Those URLs cannot address project threads. A wrong project URL answers **404**. Both kinds use the built-in assistant; `projectId`, `agentSlug` and `agentId` in create or message bodies answer **400**. Project readers, including Members, may create and send; an archived project refuses these writes with **403**, and an archived thread refuses a message with **409**.
 
-A model failure can appear as an assistant message with readable `error` text and, when available, `errorCode`. The worker rechecks the accepted thread and project access before opening the turn. If the thread moves projects or access is lost while the request waits, it does not run or append an error in the new scope.
+A model failure can appear as an assistant message with readable `error` text and, when available, `errorCode`. The model list is the organization’s configured catalog, not a promise from the provider’s account, so two codes mean the account rather than the request: `credit_exhausted` (the balance is spent) and `model_not_entitled` (the provider’s plan excludes this model). Pick another model or fix the account — waiting changes nothing, and neither is a `rate_limited`. The worker rechecks the accepted thread and project access before opening the turn. If the thread moves projects or access is lost while the request waits, it does not run or append an error in the new scope.
 
 ## Search a project's files
 

--- a/docs/fr/develop/api-reference.md
+++ b/docs/fr/develop/api-reference.md
@@ -174,7 +174,7 @@ Le projet dans l’URL fournit le contexte aux outils de tâches et de documents
 
 Le chat de projet suit aussi la séquence 202, puis suivi. Choisis un projet que tu peux lire, crée un thread, envoie un message, interroge la génération, puis lis les messages :
 
-Liste les modèles avant d’envoyer un message. Reprends `id` dans `model` et `providerSlug` pour choisir le fournisseur. La liste respecte les règles d’accès aux modèles de l’organisation et ne contient que ceux que REST peut appeler directement. Une liste vide signifie qu’aucun modèle de chat n’est disponible pour le détenteur de la clé.
+Liste les modèles avant d’envoyer un message. Reprends `id` dans `model` et `providerSlug` pour choisir le fournisseur. La liste respecte les règles d’accès aux modèles de l’organisation et ne contient que ceux que REST peut appeler directement. Une liste vide signifie qu’aucun modèle de chat n’est disponible pour le détenteur de la clé. Le couple est vérifié à l’envoi : un `providerSlug` absent de la liste donne **400**, `CHAT_PROVIDER_UNKNOWN`, et un fournisseur qui ne sert pas le `model` choisi donne **400**, `CHAT_MODEL_NOT_ON_PROVIDER` — le tour ne bascule jamais en silence vers un autre fournisseur.
 
 ```bash
 curl -sS "https://your-host.example.com/api/v1/models" \
@@ -210,7 +210,7 @@ curl -sS "https://your-host.example.com/api/v1/projects/<projectId>/threads/<thr
 
 Pour un chat personnel sans projet, utilise `/api/v1/threads` et ses chemins de détail, de messages et de génération. Ces URL ne donnent pas accès aux threads de projet. Un mauvais projet dans l’URL donne **404**. Les deux types de chat utilisent l’assistant intégré ; `projectId`, `agentSlug` ou `agentId` dans un corps de création ou de message donne **400**. Les lecteurs du projet, y compris les Membres, peuvent créer et envoyer. Un projet archivé refuse ces écritures avec **403** ; un thread archivé refuse un message avec **409**.
 
-Un échec du modèle peut apparaître dans un message d’assistant avec un texte lisible dans `error` et, si disponible, un `errorCode`. Avant d’ouvrir le tour, le worker revérifie le thread accepté et l’accès au projet. Si le thread change de projet ou que l’accès disparaît pendant l’attente, il n’exécute pas le tour et n’ajoute pas d’erreur dans le nouveau contexte.
+Un échec du modèle peut apparaître dans un message d’assistant avec un texte lisible dans `error` et, si disponible, un `errorCode`. La liste des modèles est le catalogue configuré de l’organisation, pas une promesse du compte fournisseur : deux codes désignent donc le compte plutôt que la requête, `credit_exhausted` (solde épuisé) et `model_not_entitled` (le forfait du fournisseur n’inclut pas ce modèle). Choisis un autre modèle ou remets le compte en ordre — attendre ne change rien, et aucun des deux n’est un `rate_limited`. Avant d’ouvrir le tour, le worker revérifie le thread accepté et l’accès au projet. Si le thread change de projet ou que l’accès disparaît pendant l’attente, il n’exécute pas le tour et n’ajoute pas d’erreur dans le nouveau contexte.
 
 ## Rechercher dans les fichiers d’un projet
 

--- a/services/platform/app/features/automations/lib/builder-error-display.ts
+++ b/services/platform/app/features/automations/lib/builder-error-display.ts
@@ -11,6 +11,7 @@ const HARD_FAILURE_CODES = new Set<ChatErrorCode>([
   'missing_api_key',
   'auth_error',
   'credit_exhausted',
+  'model_not_entitled',
   'provider_unreachable',
   'model_not_found',
 ]);

--- a/services/platform/backend/core/chat/resolve_model.test.ts
+++ b/services/platform/backend/core/chat/resolve_model.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveProvidersForOrgId } from '../lib/providers/org_providers';
+import { getServableCatalog } from '../lib/providers/servable_catalog';
+import { resolveModel } from './turn_action';
+
+/**
+ * Two connectors serve the same model id. The composer names one as a HINT:
+ * an unmatched hint falls back to whichever connector serves the id. The
+ * REST door names one as a CHOICE the caller was promised: if that pair
+ * stops resolving between the 202 and the run — the connector removed or
+ * renamed, the model gone from its catalog — the turn refuses instead of
+ * sending the conversation to a provider the caller never named.
+ */
+
+vi.mock('../lib/providers/org_providers', () => ({
+  resolveProvidersForOrgId: vi.fn(),
+}));
+vi.mock('../lib/providers/servable_catalog', () => ({
+  getServableCatalog: vi.fn(),
+}));
+
+const connector = (name: string, models: string[]) => ({
+  name,
+  catalog: { source: 'file', models },
+  baseUrl: `https://${name}.example/v1`,
+});
+
+function connectors(...defs: Array<{ name: string; models: string[] }>) {
+  vi.mocked(resolveProvidersForOrgId).mockResolvedValue(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the resolver reads name, catalog.source and baseUrl
+    defs.map((def) => connector(def.name, def.models)) as never,
+  );
+  vi.mocked(getServableCatalog).mockImplementation(
+    async (c) =>
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the fake connector carries its model ids
+      (c as unknown as { catalog: { models: string[] } }).catalog.models.map(
+        (id) => ({ id, provider: c.name }),
+      ) as never,
+  );
+}
+
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- no ctx facility is reached with file-backed catalogs
+const ctx = { runQuery: vi.fn() } as never;
+
+describe('resolveModel', () => {
+  it('as a hint, falls back to the other connector serving the id', async () => {
+    connectors(
+      { name: 'other', models: ['m'] },
+      { name: 'chosen', models: [] },
+    );
+    const resolved = await resolveModel(ctx, 'org-1', 'm', 'chosen');
+    expect(resolved.connector.name).toBe('other');
+  });
+
+  it('as a choice, refuses when the chosen connector no longer serves the id', async () => {
+    connectors(
+      { name: 'other', models: ['m'] },
+      { name: 'chosen', models: [] },
+    );
+    await expect(
+      resolveModel(ctx, 'org-1', 'm', 'chosen', true),
+    ).rejects.toMatchObject({
+      data: { code: 'CHAT_PROVIDER_UNAVAILABLE' },
+    });
+  });
+
+  it('as a choice, refuses when the chosen connector is gone', async () => {
+    connectors({ name: 'other', models: ['m'] });
+    await expect(
+      resolveModel(ctx, 'org-1', 'm', 'chosen', true),
+    ).rejects.toMatchObject({
+      data: { code: 'CHAT_PROVIDER_UNAVAILABLE' },
+    });
+  });
+
+  it('as a choice, resolves the chosen connector when it serves the id', async () => {
+    connectors(
+      { name: 'other', models: ['m'] },
+      { name: 'chosen', models: ['m'] },
+    );
+    const resolved = await resolveModel(ctx, 'org-1', 'm', 'chosen', true);
+    expect(resolved.connector.name).toBe('chosen');
+  });
+
+  it('without a provider, keeps refusing an unknown model as CHAT_MODEL_UNKNOWN', async () => {
+    connectors({ name: 'other', models: [] });
+    await expect(resolveModel(ctx, 'org-1', 'm')).rejects.toMatchObject({
+      data: { code: 'CHAT_MODEL_UNKNOWN' },
+    });
+  });
+});

--- a/services/platform/backend/core/chat/turn_action.ts
+++ b/services/platform/backend/core/chat/turn_action.ts
@@ -92,23 +92,35 @@ interface ResolvedModel {
  * The connector that lists it is the one whose wire the turn will speak.
  * A provider hint (the composer's picked section) is tried first, so two
  * providers serving the same id resolve to the copy the user chose; an
- * unmatched hint falls back to the id-only walk rather than refusing. A
+ * unmatched hint falls back to the id-only walk rather than refusing. With
+ * `strict` (the REST door, where the provider is a CHOICE the caller was
+ * promised) only the named connector is consulted, and a pair that no
+ * longer resolves — the connector removed or renamed, the model gone from
+ * its catalog between the 202 and the run — refuses the turn instead of
+ * sending the conversation to a provider the caller never named. A
  * catalog-less connector (Azure deployment names) serves its DEFAULT
  * credential's allowlist — the same credential the direct wire resolves. */
-async function resolveModel(
+export async function resolveModel(
   ctx: ActionCtx,
   organizationId: string,
   modelId: string,
   providerSlug?: string,
+  strict = false,
 ): Promise<ResolvedModel> {
   const connectors = await resolveProvidersForOrgId(ctx, organizationId);
   const ordered =
     providerSlug === undefined
       ? connectors
-      : [
-          ...connectors.filter((connector) => connector.name === providerSlug),
-          ...connectors.filter((connector) => connector.name !== providerSlug),
-        ];
+      : strict
+        ? connectors.filter((connector) => connector.name === providerSlug)
+        : [
+            ...connectors.filter(
+              (connector) => connector.name === providerSlug,
+            ),
+            ...connectors.filter(
+              (connector) => connector.name !== providerSlug,
+            ),
+          ];
   for (const connector of ordered) {
     let allowlist: readonly string[] | undefined;
     if (connector.catalog.source === 'none') {
@@ -123,6 +135,12 @@ async function resolveModel(
     const catalog = await getServableCatalog(connector, allowlist);
     const entry = catalog.find((candidate) => candidate.id === modelId);
     if (entry) return { entry, connector };
+  }
+  if (strict && providerSlug !== undefined) {
+    throw new AppError({
+      code: 'CHAT_PROVIDER_UNAVAILABLE',
+      message: `Provider "${providerSlug}" no longer serves model "${modelId}" in this organization. Pick a pair GET /api/v1/models lists.`,
+    });
   }
   throw new AppError({
     code: 'CHAT_MODEL_UNKNOWN',
@@ -753,6 +771,11 @@ export interface ExecuteTurnArgs {
    * `modelSelection: 'auto'` is present. */
   readonly modelId?: string;
   readonly providerSlug?: string;
+  /** REST: the named provider is a CHOICE, not a hint — resolution never
+   * falls back to another connector serving the same id, and a pair that
+   * no longer resolves refuses the turn. The composer leaves this unset;
+   * its hint semantics stand. */
+  readonly providerStrict?: boolean;
   /** Auto — the chat lane's opt-in per-message pick: the server resolves a
    * concrete (provider, model) pair for THIS message before anything binds.
    * The REST and arena lanes never pass it; they stay explicit. */
@@ -1122,7 +1145,13 @@ export async function executeTurn(
         )
       : null;
   const pendingResolved = settled(
-    resolveModel(ctx, args.organizationId, modelId, providerSlug),
+    resolveModel(
+      ctx,
+      args.organizationId,
+      modelId,
+      providerSlug,
+      args.providerStrict === true,
+    ),
   );
   const pendingGovernanceCap = settled(
     ctx.runQuery(internal.governance.queries.getContextCapInternal, {

--- a/services/platform/backend/domains/chat/rest-turn.test.ts
+++ b/services/platform/backend/domains/chat/rest-turn.test.ts
@@ -214,6 +214,30 @@ describe('runApiTurn — the accepted scope is checked again before execution', 
     );
   });
 
+  it('carries the accepted provider as a strict choice into the turn', async () => {
+    boundary.loadOwnedThread.mockResolvedValue({
+      id: 't-1',
+      kind: 'direct',
+      projectId: null,
+      archived: false,
+    });
+    vi.mocked(runChatTurn).mockRejectedValue(unknownModel);
+    await runApiTurn(sql, {
+      ...payload,
+      providerSlug: 'provider-a',
+      providerStrict: true,
+    });
+    // The 202 promised this provider; the turn must refuse a pair that
+    // stopped resolving rather than fall back to another connector.
+    expect(runChatTurn).toHaveBeenCalledWith(
+      sql,
+      expect.objectContaining({
+        providerSlug: 'provider-a',
+        providerStrict: true,
+      }),
+    );
+  });
+
   it('preserves the exact accepted scope when drain requeues the job', async () => {
     vi.mocked(isBackendDraining).mockResolvedValue(true);
     const accepted = { ...payload, expectedProjectId: 'p-a' };

--- a/services/platform/backend/domains/chat/rest-turn.ts
+++ b/services/platform/backend/domains/chat/rest-turn.ts
@@ -39,6 +39,10 @@ export interface ApiTurnPayload {
   userText: string;
   modelId: string;
   providerSlug?: string;
+  /** The named provider is a choice the turn must keep — no fallback to
+   * another connector, whatever the configuration does between the 202
+   * and the run. */
+  providerStrict?: boolean;
   locale?: string;
 }
 
@@ -148,6 +152,7 @@ export async function runApiTurn(
       ...(payload.providerSlug !== undefined
         ? { providerSlug: payload.providerSlug }
         : {}),
+      ...(payload.providerStrict === true ? { providerStrict: true } : {}),
       locale: payload.locale ?? 'en',
       onUserMessageAppended: async () => {
         userAppended = true;

--- a/services/platform/backend/domains/chat/service.ts
+++ b/services/platform/backend/domains/chat/service.ts
@@ -36,6 +36,9 @@ export interface ChatTurnRequest {
   readonly attachments?: ExecuteTurnArgs['attachments'];
   readonly modelId?: string;
   readonly providerSlug?: string;
+  /** REST: the named provider is a choice the turn must keep (see
+   * `ExecuteTurnArgs.providerStrict`). */
+  readonly providerStrict?: boolean;
   readonly reasoningEffort?: ExecuteTurnArgs['reasoningEffort'];
   readonly locale?: string;
   readonly resend?: boolean;
@@ -72,6 +75,7 @@ export async function runChatTurn(
     ...(request.providerSlug !== undefined
       ? { providerSlug: request.providerSlug }
       : {}),
+    ...(request.providerStrict === true ? { providerStrict: true } : {}),
     ...(request.reasoningEffort !== undefined
       ? { reasoningEffort: request.reasoningEffort }
       : {}),

--- a/services/platform/backend/jobs/tasks.ts
+++ b/services/platform/backend/jobs/tasks.ts
@@ -150,6 +150,7 @@ export interface TaskPayloads {
     userText: string;
     modelId: string;
     providerSlug?: string;
+    providerStrict?: boolean;
     locale?: string;
   };
   /** One outbound conversation send — fired after the undo window; the

--- a/services/platform/backend/rest/v1-threads.scope.test.ts
+++ b/services/platform/backend/rest/v1-threads.scope.test.ts
@@ -9,6 +9,26 @@ import type { RestEnv } from './shared.ts';
 import { createThreadRestRoutes } from './v1-threads.ts';
 
 vi.mock('../jobs/enqueue.ts', () => ({ addJobInTx: vi.fn() }));
+// A send names its provider, and the door holds the pair to what
+// `GET /models` lists — scope is what is under test here, so the catalog
+// simply carries the pair every send below uses.
+vi.mock('../domains/chat/composer.ts', () => ({
+  listComposerModels: vi.fn(() =>
+    Promise.resolve({
+      models: [
+        {
+          id: 'model-a',
+          label: 'Model A',
+          providerSlug: 'provider-a',
+          providerLabel: 'Provider A',
+          credential: { authMethod: 'api-key' },
+        },
+      ],
+      harnesses: [],
+      voice: { ttsAvailable: false, transcriptionAvailable: false },
+    }),
+  ),
+}));
 
 interface Query {
   text: string;

--- a/services/platform/backend/rest/v1-threads.test.ts
+++ b/services/platform/backend/rest/v1-threads.test.ts
@@ -2,13 +2,45 @@
 
 import { Hono } from 'hono';
 import type { Sql } from 'postgres';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { listComposerModels } from '../domains/chat/composer.ts';
 import { addJobInTx } from '../jobs/enqueue.ts';
 import type { RestEnv } from './shared.ts';
 import { createThreadRestRoutes } from './v1-threads.ts';
 
 vi.mock('../jobs/enqueue.ts', () => ({ addJobInTx: vi.fn() }));
+vi.mock('../domains/chat/composer.ts', () => ({
+  listComposerModels: vi.fn(),
+}));
+
+/** What `GET /models` advertises in these tests: one direct pair, plus a
+ * subscription model the REST door hides because it only runs in a sandbox. */
+function catalog() {
+  vi.mocked(listComposerModels).mockResolvedValue({
+    models: [
+      {
+        id: 'model-a',
+        label: 'Model A',
+        providerSlug: 'provider-a',
+        providerLabel: 'Provider A',
+        credential: { authMethod: 'api-key' },
+      },
+      {
+        id: 'sandbox-model',
+        label: 'Sandbox model',
+        providerSlug: 'subscription',
+        providerLabel: 'Subscription',
+        credential: {
+          authMethod: 'subscription-key',
+          constraints: { execution: 'sandbox', harness: 'claude-code' },
+        },
+      },
+    ],
+    harnesses: [],
+    voice: { ttsAvailable: false, transcriptionAvailable: false },
+  });
+}
 
 interface Captured {
   text: string;
@@ -97,6 +129,12 @@ describe('GET /threads/{id}/messages limit', () => {
 });
 
 describe('POST /threads/{id}/messages body', () => {
+  beforeEach(() => {
+    vi.mocked(addJobInTx).mockClear();
+    vi.mocked(listComposerModels).mockReset();
+    catalog();
+  });
+
   it('forwards the chosen model provider to the background turn', async () => {
     const { sql } = fakeSql();
     const res = await mount(sql).request(
@@ -136,6 +174,78 @@ describe('POST /threads/{id}/messages body', () => {
     expect(
       queries.some((q) => q.text.startsWith('INSERT INTO app.messages')),
     ).toBe(false);
+  });
+});
+
+/**
+ * An explicit `providerSlug` is a choice. The turn's own resolution treats
+ * an unmatched provider as a hint and falls back to whichever connector
+ * serves the model id — so a machine caller that sent a typo got a reply
+ * from a provider it never named, with nothing in the 202 saying so. The
+ * door now holds the pair to what `GET /models` advertises.
+ */
+describe('POST /threads/{id}/messages provider choice', () => {
+  beforeEach(() => {
+    vi.mocked(addJobInTx).mockClear();
+    vi.mocked(listComposerModels).mockReset();
+    catalog();
+  });
+
+  const send = (sql: Sql, body: Record<string, unknown>) =>
+    mount(sql).request('http://localhost/threads/t-1/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'Hello', ...body }),
+    });
+
+  it('refuses a provider the model list does not carry, and queues nothing', async () => {
+    const { sql } = fakeSql();
+    const res = await send(sql, {
+      model: 'model-a',
+      providerSlug: 'tale-eval-nonexistent-provider',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: expect.stringContaining('Unknown provider'),
+      code: 'CHAT_PROVIDER_UNKNOWN',
+    });
+    expect(addJobInTx).not.toHaveBeenCalled();
+  });
+
+  it('refuses a listed provider that does not serve the chosen model', async () => {
+    const { sql } = fakeSql();
+    const res = await send(sql, {
+      model: 'model-b',
+      providerSlug: 'provider-a',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: expect.stringContaining('does not serve model "model-b"'),
+      code: 'CHAT_MODEL_NOT_ON_PROVIDER',
+    });
+    expect(addJobInTx).not.toHaveBeenCalled();
+  });
+
+  it('holds the caller to the REST projection — a sandbox-only provider is unknown here', async () => {
+    const { sql } = fakeSql();
+    const res = await send(sql, {
+      model: 'sandbox-model',
+      providerSlug: 'subscription',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ code: 'CHAT_PROVIDER_UNKNOWN' });
+  });
+
+  it('does not consult the catalog when no provider is named', async () => {
+    const { sql } = fakeSql();
+    const res = await send(sql, { model: 'model-a' });
+    expect(res.status).toBe(202);
+    expect(listComposerModels).not.toHaveBeenCalled();
+    expect(addJobInTx).toHaveBeenCalledWith(
+      sql,
+      'chat.api_turn',
+      expect.objectContaining({ modelId: 'model-a' }),
+    );
   });
 });
 

--- a/services/platform/backend/rest/v1-threads.test.ts
+++ b/services/platform/backend/rest/v1-threads.test.ts
@@ -156,6 +156,9 @@ describe('POST /threads/{id}/messages body', () => {
       expect.objectContaining({
         modelId: 'model-a',
         providerSlug: 'provider-a',
+        // A choice, not a hint: the turn must not fall back to another
+        // connector if the configuration changes before it runs.
+        providerStrict: true,
       }),
     );
   });

--- a/services/platform/backend/rest/v1-threads.ts
+++ b/services/platform/backend/rest/v1-threads.ts
@@ -449,8 +449,11 @@ export function createThreadRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
         expectedProjectId: projectId,
         userText: body.data.content,
         modelId: body.data.model,
+        // A named provider is the caller's choice all the way to the wire —
+        // the turn refuses a pair that stops resolving rather than falling
+        // back to another connector.
         ...(body.data.providerSlug !== undefined
-          ? { providerSlug: body.data.providerSlug }
+          ? { providerSlug: body.data.providerSlug, providerStrict: true }
           : {}),
         ...(body.data.locale !== undefined ? { locale: body.data.locale } : {}),
       });

--- a/services/platform/backend/rest/v1-threads.ts
+++ b/services/platform/backend/rest/v1-threads.ts
@@ -80,30 +80,74 @@ function restMessageError(stored: string): {
 export function createThreadRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
   const app = new Hono<RestEnv>();
 
+  /** The models this door advertises: the composer's servable set narrowed
+   * to direct credentials — a subscription model only runs in a sandbox. A
+   * send is checked against the SAME projection, so the caller is held to
+   * exactly what `GET /models` told them. */
+  const restModels = async (c: Context<RestEnv>) => {
+    const { models } = await listComposerModels(deps.sql, {
+      organizationId: c.get('organizationId'),
+      userId: c.get('userId'),
+    });
+    return models.filter(
+      ({ credential }) =>
+        credential.authMethod === 'api-key' || credential.authMethod === 'env',
+    );
+  };
+
   app.get('/models', async (c) => {
     try {
-      const { models } = await listComposerModels(deps.sql, {
-        organizationId: c.get('organizationId'),
-        userId: c.get('userId'),
-      });
       return c.json({
-        models: models
-          .filter(
-            ({ credential }) =>
-              credential.authMethod === 'api-key' ||
-              credential.authMethod === 'env',
-          )
-          .map(({ id, label, providerSlug, providerLabel }) => ({
+        models: (await restModels(c)).map(
+          ({ id, label, providerSlug, providerLabel }) => ({
             id,
             label,
             providerSlug,
             providerLabel,
-          })),
+          }),
+        ),
       });
     } catch (error) {
       return domainErrorResponse(c, error);
     }
   });
+
+  /** An explicit `providerSlug` is a choice, not a hint: the turn's own
+   * resolution treats an unmatched provider as a preference and falls back
+   * to whichever connector serves the model id — right for the composer,
+   * which only offers real pairs, wrong for a machine caller that sent a
+   * typo and got a reply from a provider it never named. Null when the pair
+   * is one `GET /models` lists; otherwise the 400 naming what is wrong. */
+  const refuseUnlistedProvider = async (
+    c: Context<RestEnv>,
+    modelId: string,
+    providerSlug: string,
+  ): Promise<Response | null> => {
+    const models = await restModels(c);
+    if (!models.some((model) => model.providerSlug === providerSlug)) {
+      return c.json(
+        {
+          error: `Unknown provider "${providerSlug}". GET /api/v1/models lists the providers this key can send to.`,
+          code: 'CHAT_PROVIDER_UNKNOWN',
+        },
+        400,
+      );
+    }
+    if (
+      !models.some(
+        (model) => model.providerSlug === providerSlug && model.id === modelId,
+      )
+    ) {
+      return c.json(
+        {
+          error: `Provider "${providerSlug}" does not serve model "${modelId}". GET /api/v1/models lists each model with its provider.`,
+          code: 'CHAT_MODEL_NOT_ON_PROVIDER',
+        },
+        400,
+      );
+    }
+    return null;
+  };
 
   const threadView = (row: RestThreadRow, generating: boolean) => ({
     id: row.id,
@@ -363,6 +407,20 @@ export function createThreadRestRoutes(deps: { sql: Sql }): Hono<RestEnv> {
       const projectId = projectIdFor(c);
       const thread = await loadRestThread(c, threadIdFor(c), projectId);
       if (thread === null) return c.json({ error: 'Thread not found' }, 404);
+      // After the visibility gate — an invisible thread stays an opaque 404
+      // whatever the body says — and before the thread's own state answers.
+      if (body.data.providerSlug !== undefined) {
+        try {
+          const refusal = await refuseUnlistedProvider(
+            c,
+            body.data.model,
+            body.data.providerSlug,
+          );
+          if (refusal) return refusal;
+        } catch (error) {
+          return domainErrorResponse(c, error);
+        }
+      }
       if (thread.archived) {
         return c.json({ error: 'This conversation is archived.' }, 409);
       }

--- a/services/platform/lib/shared/chat-errors.test.ts
+++ b/services/platform/lib/shared/chat-errors.test.ts
@@ -21,6 +21,38 @@ describe('classifyChatErrorCode', () => {
     ).toBe('credit_exhausted');
   });
 
+  it("classifies Z.ai's account refusals, which arrive as HTTP 429, before rate limits", () => {
+    // The generation layer wraps the provider body into the message; the
+    // classifier must read the refusal out of that text, not just a code.
+    const wrapped =
+      'The model provider answered 429: {"error":{"code":"1311","message":"Your current subscription plan does not yet include access to GLM-5V-Turbo"}}';
+    expect(classifyChatErrorCode({ status: 429, message: wrapped })).toBe(
+      'model_not_entitled',
+    );
+    expect(classifyChatErrorCode({ status: 429, code: '1311' })).toBe(
+      'model_not_entitled',
+    );
+    expect(
+      classifyChatErrorCode({
+        message: 'This model is not included in your plan.',
+      }),
+    ).toBe('model_not_entitled');
+    expect(
+      classifyChatErrorCode({
+        status: 429,
+        message:
+          '429 Insufficient balance or no resource package. Please recharge.',
+      }),
+    ).toBe('credit_exhausted');
+    expect(classifyChatErrorCode({ status: 429, code: '1113' })).toBe(
+      'credit_exhausted',
+    );
+    // A real rate limit still reads as one.
+    expect(
+      classifyChatErrorCode({ status: 429, message: 'Too many requests' }),
+    ).toBe('rate_limited');
+  });
+
   it('classifies auth errors by 401/403 and message', () => {
     expect(classifyChatErrorCode({ status: 401 })).toBe('auth_error');
     expect(classifyChatErrorCode({ status: 403 })).toBe('auth_error');

--- a/services/platform/lib/shared/chat-errors.test.ts
+++ b/services/platform/lib/shared/chat-errors.test.ts
@@ -53,6 +53,56 @@ describe('classifyChatErrorCode', () => {
     ).toBe('rate_limited');
   });
 
+  it('reads the provider code out of the real wire shapes, not only a flat field', () => {
+    // The direct wire wraps the provider body into its sentence with the
+    // status attached — the code is inside the JSON text, the wording may
+    // be anything (a localized message, a rewrite).
+    expect(
+      classifyChatErrorCode({
+        status: 429,
+        message:
+          'The model provider answered 429: {"error":{"code":"1311","message":"当前套餐不包含该模型"}}',
+      }),
+    ).toBe('model_not_entitled');
+    expect(
+      classifyChatErrorCode({
+        status: 429,
+        message:
+          'The model provider answered 429: {"error":{"code":"1113","message":"余额不足"}}',
+      }),
+    ).toBe('credit_exhausted');
+    // An SDK error nests the provider body under `error`.
+    expect(
+      classifyChatErrorCode({
+        status: 429,
+        error: { code: '1311', message: 'refused' },
+      }),
+    ).toBe('model_not_entitled');
+    expect(classifyChatErrorCode({ status: 429, error: { code: 1113 } })).toBe(
+      'credit_exhausted',
+    );
+  });
+
+  it('classifies the platform’s own model refusals as model_not_found', () => {
+    expect(
+      classifyChatErrorCode({
+        data: {
+          code: 'CHAT_PROVIDER_UNAVAILABLE',
+          message:
+            'Provider "a" no longer serves model "m" in this organization.',
+        },
+      }),
+    ).toBe('model_not_found');
+    expect(
+      classifyChatErrorCode({
+        data: {
+          code: 'CHAT_MODEL_UNKNOWN',
+          message: 'No model "m" is available in this organization.',
+        },
+      }),
+    ).toBe('model_not_found');
+  });
+
   it('classifies auth errors by 401/403 and message', () => {
     expect(classifyChatErrorCode({ status: 401 })).toBe('auth_error');
     expect(classifyChatErrorCode({ status: 403 })).toBe('auth_error');

--- a/services/platform/lib/shared/chat-errors.ts
+++ b/services/platform/lib/shared/chat-errors.ts
@@ -115,18 +115,33 @@ function extractErrorFacts(error: unknown): ErrorFacts {
     err.data !== null && typeof err.data === 'object'
       ? (err.data as Record<string, unknown>)
       : undefined;
-  const code =
-    typeof err.code === 'string'
-      ? err.code
-      : typeof data?.code === 'string'
-        ? data.code
-        : undefined;
   const message =
     typeof data?.message === 'string'
       ? data.message
       : typeof err.message === 'string'
         ? err.message
         : '';
+  // A provider's own code rides in the `{error: {code, message}}` body. The
+  // direct wire wraps that body into the sentence it throws ("The model
+  // provider answered 429: {…}") with only the status attached, and an SDK
+  // error nests it under `error` — so the code is read from the top level,
+  // a platform refusal's `data`, a nested `error`, and last from the wrapped
+  // JSON text, before any wording is consulted.
+  const nested =
+    err.error !== null && typeof err.error === 'object'
+      ? (err.error as Record<string, unknown>)
+      : undefined;
+  const embedded = /"code"\s*:\s*"?([A-Za-z0-9_.-]+)"?/.exec(message);
+  const code =
+    typeof err.code === 'string'
+      ? err.code
+      : typeof data?.code === 'string'
+        ? data.code
+        : typeof nested?.code === 'string'
+          ? nested.code
+          : typeof nested?.code === 'number'
+            ? String(nested.code)
+            : embedded?.[1];
   return { status, code, message: message.toLowerCase() };
 }
 
@@ -171,6 +186,11 @@ export function classifyChatErrorCode(error: unknown): ChatErrorCode {
     code === 'CHAT_CREDENTIAL_UNSUPPORTED'
   ) {
     return 'auth_error';
+  }
+  // The organization lists no such model, or the chosen provider stopped
+  // serving it before the turn ran (the REST door's strict choice).
+  if (code === 'CHAT_MODEL_UNKNOWN' || code === 'CHAT_PROVIDER_UNAVAILABLE') {
+    return 'model_not_found';
   }
 
   // Org has no usable provider / no API key at all — actionable setup error.

--- a/services/platform/lib/shared/chat-errors.ts
+++ b/services/platform/lib/shared/chat-errors.ts
@@ -33,6 +33,7 @@ export function isStoppedReason(reason: string | undefined): boolean {
 export const CHAT_ERROR_CODES = [
   'missing_api_key',
   'credit_exhausted',
+  'model_not_entitled',
   'auth_error',
   'model_not_found',
   'unsupported_parameter',
@@ -60,6 +61,7 @@ export function isChatErrorCode(value: unknown): value is ChatErrorCode {
 export const CHAT_ERROR_I18N_KEY: Readonly<Record<ChatErrorCode, string>> = {
   missing_api_key: 'errorHintMissingApiKey',
   credit_exhausted: 'errorHintCreditExhausted',
+  model_not_entitled: 'errorHintModelNotEntitled',
   auth_error: 'errorHintAuthError',
   model_not_found: 'errorHintModelNotFound',
   unsupported_parameter: 'errorHintUnsupportedParameter',
@@ -83,6 +85,7 @@ export const CHAT_ERROR_I18N_KEY_NAMED: Readonly<
   Partial<Record<ChatErrorCode, string>>
 > = {
   credit_exhausted: 'errorHintCreditExhaustedNamed',
+  model_not_entitled: 'errorHintModelNotEntitledNamed',
   auth_error: 'errorHintAuthErrorNamed',
   provider_unreachable: 'errorHintProviderUnreachableNamed',
   model_not_found: 'errorHintModelNotFoundNamed',
@@ -179,10 +182,27 @@ export function classifyChatErrorCode(error: unknown): ChatErrorCode {
     return 'missing_api_key';
   }
 
+  // The account's plan excludes THIS model while others still serve — Z.ai
+  // answers it as HTTP 429 (code 1311, "Your current subscription plan does
+  // not yet include access to …"), so this must precede the status-429
+  // rate-limit branch: no wait lifts it, and the remedy is another model or
+  // a plan change, not a retry.
+  if (
+    code === '1311' ||
+    /subscription plan does not (yet )?include|not included in your (plan|package|subscription)|plan does not (yet )?include access/i.test(
+      message,
+    )
+  ) {
+    return 'model_not_entitled';
+  }
+
   // Out of funds — account-level, every model on the provider fails the same.
+  // Z.ai's spent balance is also an HTTP 429 (code 1113), hence the message
+  // patterns and the code alongside the 402 every other provider answers.
   if (
     status === 402 ||
-    /more credits|can only afford|credit.*insufficient|insufficient.*credit|never purchased credits|credit.*(limit|reached)|\b402\b/i.test(
+    code === '1113' ||
+    /more credits|can only afford|credit.*insufficient|insufficient.*credit|never purchased credits|credit.*(limit|reached)|insufficient balance|no resource package|please recharge|\b402\b/i.test(
       message,
     )
   ) {

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -316,6 +316,7 @@ analytics:
     errorType:
       missing_api_key: API-Schlüssel fehlt
       credit_exhausted: Guthaben aufgebraucht
+      model_not_entitled: Modell nicht im Tarif
       auth_error: Authentifizierungsfehler
       model_not_found: Modell nicht gefunden
       unsupported_parameter: Parameter nicht unterstützt

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -1397,6 +1397,8 @@ chat:
     zu senken.
   errorHintProviderError: Der KI-Anbieter hat vorübergehend technische Probleme. Versuch es gleich nochmal.
   errorHintRateLimited: Zu viele Anfragen. Warte einen Moment und versuch es erneut.
+  errorHintModelNotEntitled: Der Tarif des Anbieters enthält dieses Modell nicht.
+    Wähl ein anderes Modell oder lass deinen Administrator den Tarif erweitern.
   errorHintTokenLimit: Das Token-Limit des Modells wurde überschritten. Versuche
     eine kürzere Anfrage oder bitte deinen Administrator, die
     Modelleinstellungen anzupassen.
@@ -1421,6 +1423,8 @@ chat:
   errorHintModelNotFoundNamed: Das ausgewählte Modell wurde bei {provider} nicht
     gefunden. Es wurde möglicherweise umbenannt oder entfernt.
   errorHintRateLimitedNamed: Ratenlimit bei {provider} erreicht. Warte einen Moment und versuch es erneut.
+  errorHintModelNotEntitledNamed: Der Tarif bei {provider} enthält dieses Modell
+    nicht. Wähl ein anderes Modell oder lass deinen Administrator den Tarif erweitern.
 
   errorGenerating: Antwort konnte nicht erzeugt werden. Versuch es erneut.
   errorTriedModels: '{count} Modelle wurden vor dem Abbruch versucht.'

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -303,6 +303,7 @@ analytics:
     errorType:
       missing_api_key: Missing API key
       credit_exhausted: Credit exhausted
+      model_not_entitled: Model not in plan
       auth_error: Auth error
       model_not_found: Model not found
       unsupported_parameter: Unsupported parameter

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1358,6 +1358,8 @@ chat:
     tokens.
   errorHintProviderError: The AI provider is temporarily experiencing issues. Try again in a moment.
   errorHintRateLimited: Too many requests. Wait a moment and try again.
+  errorHintModelNotEntitled: The provider's plan does not include this model.
+    Pick another model, or ask your administrator to upgrade the plan.
   errorHintTokenLimit:
     The model's output token limit was exceeded. Try a shorter
     request or ask your administrator to adjust the model settings.
@@ -1379,6 +1381,8 @@ chat:
     The selected model was not found on {provider}. It
     may have been renamed or removed.
   errorHintRateLimitedNamed: Rate limit reached on {provider}. Wait a moment and try again.
+  errorHintModelNotEntitledNamed: The {provider} plan does not include this
+    model. Pick another model, or ask your administrator to upgrade the plan.
 
   errorGenerating: Couldn't generate a reply. Try again.
   errorTriedModels: 'Tried {count} models before giving up.'

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -318,6 +318,7 @@ analytics:
     errorType:
       missing_api_key: Clé API manquante
       credit_exhausted: Crédits épuisés
+      model_not_entitled: Modèle hors forfait
       auth_error: Erreur d'authentification
       model_not_found: Modèle introuvable
       unsupported_parameter: Paramètre non pris en charge

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -1406,6 +1406,8 @@ chat:
     ou demande à ton administrateur de le baisser.
   errorHintProviderError: Le fournisseur d'IA rencontre temporairement des problèmes. Réessaie dans un instant.
   errorHintRateLimited: Trop de requêtes. Patiente un moment, puis réessaie.
+  errorHintModelNotEntitled: Le forfait du fournisseur n'inclut pas ce modèle.
+    Choisis un autre modèle ou demande à ton administrateur d'étendre le forfait.
   errorHintTokenLimit: La limite de tokens en sortie du modèle a été dépassée.
     Essaie une requête plus courte ou demande à ton administrateur d'ajuster les
     paramètres du modèle.
@@ -1429,6 +1431,8 @@ chat:
   errorHintModelNotFoundNamed: Le modèle sélectionné est introuvable chez
     {provider}. Il a peut-être été renommé ou supprimé.
   errorHintRateLimitedNamed: Limite de débit atteinte chez {provider}. Patiente un moment, puis réessaie.
+  errorHintModelNotEntitledNamed: Le forfait chez {provider} n'inclut pas ce
+    modèle. Choisis un autre modèle ou demande à ton administrateur d'étendre le forfait.
 
   errorGenerating: Impossible de générer une réponse. Réessaie.
   errorTriedModels: "{count} modèles ont été essayés avant d'abandonner."

--- a/services/platform/public/openapi.json
+++ b/services/platform/public/openapi.json
@@ -7445,7 +7445,7 @@
       "get": {
         "tags": ["Threads"],
         "summary": "List available chat models",
-        "description": "The configured chat models available to the key holder in this organization, filtered by model-access policy and direct API credentials. Subscription models that require a sandbox are excluded. An empty list means none are available. Use id as model and providerSlug when sending a message.",
+        "description": "The configured chat models available to the key holder in this organization, filtered by model-access policy and direct API credentials. Subscription models that require a sandbox are excluded. An empty list means none are available. Use id as model and providerSlug when sending a message. The list is the organization’s configured catalog, not a promise from the provider’s account: a plan that excludes a listed model fails the turn with errorCode `model_not_entitled`, a spent balance with `credit_exhausted`.",
         "operationId": "listChatModels",
         "security": [
           {
@@ -7970,7 +7970,7 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 200,
-                    "description": "Provider slug returned with the model"
+                    "description": "Provider slug returned with the model. Checked against GET /api/v1/models: a slug the list does not carry answers 400 `CHAT_PROVIDER_UNKNOWN`, one that does not serve the model 400 `CHAT_MODEL_NOT_ON_PROVIDER` — never a silent fallback to another provider."
                   },
                   "locale": {
                     "type": "string",
@@ -8011,7 +8011,7 @@
             }
           },
           "400": {
-            "description": "Invalid request (malformed body or parameters)",
+            "description": "Invalid body, an unknown providerSlug (`CHAT_PROVIDER_UNKNOWN`), or a provider that does not serve the model (`CHAT_MODEL_NOT_ON_PROVIDER`)",
             "content": {
               "application/json": {
                 "schema": {
@@ -8679,7 +8679,7 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 200,
-                    "description": "Provider slug returned with the model"
+                    "description": "Provider slug returned with the model. Checked against GET /api/v1/models: a slug the list does not carry answers 400 `CHAT_PROVIDER_UNKNOWN`, one that does not serve the model 400 `CHAT_MODEL_NOT_ON_PROVIDER` — never a silent fallback to another provider."
                   },
                   "locale": {
                     "type": "string",
@@ -8720,7 +8720,7 @@
             }
           },
           "400": {
-            "description": "Invalid request (malformed body or parameters)",
+            "description": "Invalid body, an unknown providerSlug (`CHAT_PROVIDER_UNKNOWN`), or a provider that does not serve the model (`CHAT_MODEL_NOT_ON_PROVIDER`)",
             "content": {
               "application/json": {
                 "schema": {

--- a/services/platform/scripts/openapi/spec.ts
+++ b/services/platform/scripts/openapi/spec.ts
@@ -2006,7 +2006,7 @@ export function buildSpec(): Json {
       tags: ['Threads'],
       summary: 'List available chat models',
       description:
-        'The configured chat models available to the key holder in this organization, filtered by model-access policy and direct API credentials. Subscription models that require a sandbox are excluded. An empty list means none are available. Use id as model and providerSlug when sending a message.',
+        'The configured chat models available to the key holder in this organization, filtered by model-access policy and direct API credentials. Subscription models that require a sandbox are excluded. An empty list means none are available. Use id as model and providerSlug when sending a message. The list is the organization’s configured catalog, not a promise from the provider’s account: a plan that excludes a listed model fails the turn with errorCode `model_not_entitled`, a spent balance with `credit_exhausted`.',
       operationId: 'listChatModels',
       security: sec,
       responses: {
@@ -2156,7 +2156,8 @@ export function buildSpec(): Json {
               type: 'string',
               minLength: 1,
               maxLength: 200,
-              description: 'Provider slug returned with the model',
+              description:
+                'Provider slug returned with the model. Checked against GET /api/v1/models: a slug the list does not carry answers 400 `CHAT_PROVIDER_UNKNOWN`, one that does not serve the model 400 `CHAT_MODEL_NOT_ON_PROVIDER` — never a silent fallback to another provider.',
             },
             locale: { type: 'string', minLength: 1, maxLength: 20 },
           },
@@ -2183,6 +2184,9 @@ export function buildSpec(): Json {
             'Archived or non-direct thread, or a turn is already running',
           ),
           ...standardErrors,
+          '400': errorResponse(
+            'Invalid body, an unknown providerSlug (`CHAT_PROVIDER_UNKNOWN`), or a provider that does not serve the model (`CHAT_MODEL_NOT_ON_PROVIDER`)',
+          ),
         },
       },
     };


### PR DESCRIPTION
Part 2 of the fixes for the 2026-09-10 black-box API evaluation (E02, E03). Independent of #3309.

## What was wrong

- **E02** — `GET /models` listed `glm-5v-turbo`, but the deployment's Z.ai plan does not include it. Z.ai answers that as HTTP 429 (`{"code":"1311","message":"Your current subscription plan does not yet include access to GLM-5V-Turbo"}`), and the classifier's status-429 branch stamped the assistant message `errorCode: "rate_limited"` — telling the consumer to wait and retry something no wait can lift. A spent balance (code 1113, also a 429) was mislabelled the same way.
- **E03** — the REST send accepted `providerSlug: "tale-eval-nonexistent-provider"` and answered 202; the turn treats the slug as a hint and fell back to `zai`, which generated the reply. Nothing in the docs disclosed the fallback.

## What changes

- `lib/shared/chat-errors.ts`: new code `model_not_entitled` (plan excludes the model — 1311 or the plan/package wording) and the balance patterns (1113, "insufficient balance", "no resource package") under `credit_exhausted`, both checked before the status-429 branch. Hint strings in en/de/fr; the automation builder treats the new code as a hard failure like `credit_exhausted`.
- `rest/v1-threads.ts`: an explicit `providerSlug` is checked against the same projection `GET /models` answers — unlisted → 400 `CHAT_PROVIDER_UNKNOWN`; listed but not serving the model → 400 `CHAT_MODEL_NOT_ON_PROVIDER`. Ordered after the thread's visibility gate (an invisible thread stays an opaque 404) and before its state gates. A send without `providerSlug` does not consult the catalog. The composer's hint semantics in `turn_action.ts` are untouched — the app only offers real pairs.
- OpenAPI + `docs/{en,de,fr}/develop/api-reference.md`: the model list is the configured catalog, not a promise from the provider's account; the two account codes; the two new 400s.

## Proof

- `chat-errors.test.ts`: the wrapped 1311 body, the bare code, the plan wording → `model_not_entitled`; 1113 and the balance wording → `credit_exhausted`; a plain 429 still → `rate_limited`.
- `v1-threads.test.ts`: unknown provider, listed-but-wrong-model, sandbox-only provider → 400 with the code and nothing queued; no `providerSlug` → 202 without a catalog lookup.
- `bun run check` green.

## Deployment note (not in this repo)

The platform.tale.dev Z.ai credential should carry a `modelAllowlist` that excludes `glm-5v-turbo` until the plan includes it — the catalog cannot know a plan's contents, so the allowlist is the lever that keeps the listed set callable.
