### PR TITLE
fix(cli): normalize source checkout SSH key line endings

### DIFF
--- a/services/docs/tests/manual/reference/automation.md
+++ b/services/docs/tests/manual/reference/automation.md
@@ -58,6 +58,10 @@ reviewed bundle identity, private stdin, confirmation placement, local native
 HTTP replay and scrubbed failure cleanup. Runtime, snapshot and native adapter
 fault tests live under `tools/cli/src/lib/deployment/`. These fixtures do not
 replace a destination rollout and independent native readback.
+`tools/cli/src/lib/deployment/sources.test.ts` additionally parses synthetic
+private keys with real OpenSSH after temporary-file materialization: LF, CRLF
+and missing final newlines retain the same key identity, with private file
+permissions, cleanup and public-runtime credential isolation checked.
 
 - **The Playwright suite drives the same origin a round does.** Never run
   `bun run test:e2e` beside a round: it signs in, creates and deletes data, and

--- a/tools/cli/src/lib/deployment/inputs.test.ts
+++ b/tools/cli/src/lib/deployment/inputs.test.ts
@@ -340,7 +340,7 @@ test('failed private source checkout scrubs errors and removes its ephemeral key
             expect(ssh).toContain('IdentitiesOnly=yes');
             expect(options?.env).not.toHaveProperty('TALE_SOURCE_SSH_KEY');
             keySeen =
-              readFileSync(keyFile, 'utf8') === 'private-source-key-marker';
+              readFileSync(keyFile, 'utf8') === 'private-source-key-marker\n';
             return {
               stdout: '',
               stderr: 'private-source-key-marker',

--- a/tools/cli/src/lib/deployment/sources.test.ts
+++ b/tools/cli/src/lib/deployment/sources.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, expect, test } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { TALE_REPOSITORY, withDeploymentSources } from './sources';
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+
+const revision = 'b'.repeat(40);
+const client = { repository: 'https://github.com/north-labs/desk', revision };
+const runtime = { repository: TALE_REPOSITORY, revision };
+const success = (stdout = '') => ({
+  stdout,
+  stderr: '',
+  exitCode: 0,
+  success: true,
+});
+
+function syntheticKey() {
+  const root = mkdtempSync(join(tmpdir(), 'tale-source-ssh-test-'));
+  roots.push(root);
+  const file = join(root, 'synthetic-key');
+  execFileSync(
+    'ssh-keygen',
+    [
+      '-q',
+      '-t',
+      'ed25519',
+      '-N',
+      '',
+      '-C',
+      'synthetic-source-test',
+      '-f',
+      file,
+    ],
+    { stdio: 'pipe', timeout: 5000 },
+  );
+  return { file, contents: readFileSync(file, 'utf8') };
+}
+
+const publicKey = (file: string) =>
+  execFileSync('ssh-keygen', ['-y', '-P', '', '-f', file], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: 5000,
+  });
+
+// Managed source preparation requires a POSIX host. Check the actual OpenSSH
+// parser and its private-file permissions on both supported CI host families.
+const testPosix = test.skipIf(process.platform === 'win32');
+for (const variant of ['LF', 'missing LF', 'CRLF', 'CRLF missing LF']) {
+  testPosix(
+    `private source acquisition preserves the OpenSSH key identity with ${variant}`,
+    async () => {
+      const original = syntheticKey();
+      const expectedPublicKey = publicKey(original.file);
+      const lineEndings = variant.startsWith('CRLF')
+        ? original.contents.replaceAll('\n', '\r\n')
+        : original.contents;
+      const sourceKey = variant.includes('missing')
+        ? lineEndings.replace(/[\r\n]+$/, '')
+        : lineEndings;
+      let keyFile = '';
+      let privateFetches = 0;
+      let publicFetches = 0;
+      await withDeploymentSources(
+        [client, runtime],
+        {
+          sourceKey,
+          fetchImpl: async () =>
+            Response.json({
+              ssh_keys: [
+                expectedPublicKey.trim().split(' ').slice(0, 2).join(' '),
+              ],
+            }),
+          run: async (command, args, options) => {
+            expect(command).toBe('git');
+            expect(options?.silent).toBe(true);
+            expect(options?.env).not.toHaveProperty('TALE_SOURCE_SSH_KEY');
+            expect(JSON.stringify(options?.env)).not.toContain(sourceKey);
+            if (args.includes('fetch')) {
+              const ssh = options?.env?.GIT_SSH_COMMAND;
+              if (ssh) {
+                privateFetches++;
+                keyFile = /'-i' '([^']+)'/.exec(ssh)?.[1] ?? '';
+                expect(ssh).toContain('StrictHostKeyChecking=yes');
+                expect(ssh).toContain('IdentitiesOnly=yes');
+                expect(ssh).toContain('BatchMode=yes');
+                expect(statSync(keyFile).mode & 0o777).toBe(0o600);
+                expect(statSync(dirname(keyFile)).mode & 0o777).toBe(0o700);
+                // Parsing the actual temporary file catches missing terminal LF;
+                // comparing public keys proves the key itself was not changed.
+                expect(publicKey(keyFile)).toBe(expectedPublicKey);
+                expect(readFileSync(keyFile, 'utf8')).toBe(original.contents);
+              } else {
+                publicFetches++;
+                expect(options?.env).not.toHaveProperty('GIT_SSH_COMMAND');
+              }
+            }
+            return success(args.includes('rev-parse') ? revision : '');
+          },
+        },
+        async (source) => {
+          expect(existsSync(source(client))).toBe(true);
+          expect(existsSync(source(runtime))).toBe(true);
+          expect(existsSync(keyFile)).toBe(true);
+        },
+      );
+      expect(privateFetches).toBe(1);
+      expect(publicFetches).toBe(1);
+      expect(existsSync(keyFile)).toBe(false);
+      expect(existsSync(dirname(keyFile))).toBe(false);
+      expect(readFileSync(original.file, 'utf8')).toBe(original.contents);
+    },
+    30_000,
+  );
+}
+
+test('public runtime source acquisition does not stage or use a client key', async () => {
+  const sourceKey = 'unused-private-source-marker';
+  let root = '';
+  await withDeploymentSources(
+    [runtime],
+    {
+      sourceKey,
+      fetchImpl: () => {
+        throw new Error('public source must not request SSH metadata');
+      },
+      run: async (_command, args, options) => {
+        expect(options?.env).not.toHaveProperty('GIT_SSH_COMMAND');
+        expect(options?.env).not.toHaveProperty('TALE_SOURCE_SSH_KEY');
+        expect(JSON.stringify(options?.env)).not.toContain(sourceKey);
+        return success(args.includes('rev-parse') ? revision : '');
+      },
+    },
+    async (source) => {
+      root = dirname(source(runtime));
+      expect(existsSync(join(root, 'source-key'))).toBe(false);
+      expect(existsSync(join(root, 'known-hosts'))).toBe(false);
+    },
+  );
+  expect(existsSync(root)).toBe(false);
+});

--- a/tools/cli/src/lib/deployment/sources.ts
+++ b/tools/cli/src/lib/deployment/sources.ts
@@ -184,10 +184,17 @@ export async function withDeploymentSources<T>(
         // declared client repository and is never passed to Docker or Tale.
         if (options.sourceKey && request.repository !== TALE_REPOSITORY) {
           if (!ssh) {
-            await writeFile(sshKey, options.sourceKey, {
-              mode: 0o600,
-              flag: 'wx',
-            });
+            // Secret transports may remove the final newline; OpenSSH needs it.
+            // Normalize text line endings without trimming the key payload.
+            const privateKey = options.sourceKey.replaceAll('\r\n', '\n');
+            await writeFile(
+              sshKey,
+              privateKey.endsWith('\n') ? privateKey : `${privateKey}\n`,
+              {
+                mode: 0o600,
+                flag: 'wx',
+              },
+            );
             await writeFile(
               knownHosts,
               await githubKnownHosts(options.fetchImpl ?? fetch),


### PR DESCRIPTION
## Summary

Private source preparation failed when a secret transport removed the final newline from an otherwise valid OpenSSH key. Normalize CRLF and restore a missing terminal LF only when writing the owned temporary key; canonical key bytes, public-key identity, host verification and public runtime credential isolation remain intact.

## Checklist

- **N/A locally for the complete `bun run check` gate:** this Mac run stopped at the unchanged sandbox-runtime-daemon suite (93 passed, 54 failed); `/bin/sh -n services/sandbox-runtime/entrypoint.sh` reports the existing line 421 syntax incompatibility. Required Linux CI remains the full repository gate. The affected CLI lane passes 712 tests with 19 expected skips, plus independent typecheck and configured lint; repository formatting and Knip pass.
- [x] `bun run lint:sast` passes: 467 rules, 3456 files, zero findings; the new test file also passes the full rule set explicitly.
- **N/A — translations:** no product message or error wording changes.
- **N/A — end-user docs:** no flag, environment variable name, source policy or documented command behavior changes; this fixes internal key-file materialization. The automation register now names the real OpenSSH regression.
- **N/A — root READMEs:** no installation or command changes.

## Test plan

- Generated fresh synthetic ED25519 keys. Before the fix, actual OpenSSH parsing failed for missing LF, CRLF and CRLF without final LF (three red cases); canonical LF and public runtime key isolation passed. After the fix, all five new cases pass and all variants derive the same public key. Tests verify 0600 key / 0700 directory permissions, cleanup, unchanged input files, strict host checking and no client credential in the public runtime Git environment.
- Targeted source/input tests: 12 passed, 0 failed, 300 assertions. Full CLI: 712 passed, 19 expected skips, 0 failed, 7154 assertions. Manual register gate: 773 boxes validated. Existing failed-checkout redaction/cleanup regression remains green.
- No real credentials, Git/SSH network connection, host deployment or runtime/configuration pin changes were used by the regression tests.
