### PR TITLE
fix(sandbox): route DeepSeek Claude Code natively, bump the gateway

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -78,7 +78,7 @@ x-dev-secrets: &dev-secrets
   # admin credential (dev-secrets.test.ts pins the lockstep). The gateway
   # stores the password's hash in its volume, so the value must stay stable.
   SANDBOX_TOKEN: ${SANDBOX_TOKEN:-local-dev-insecure-sandbox-token-do-not-use-in-prod-0123456789abcdef}
-  SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: ${SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD:-local-dev-insecure-gateway-admin-password}
+  SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: ${SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD:-Local-dev-insecure-gateway-admin-password-1}
 
 services:
   db:

--- a/configs/platform/system/providers/deepseek/provider.yml
+++ b/configs/platform/system/providers/deepseek/provider.yml
@@ -7,6 +7,16 @@ name: deepseek
 displayName: DeepSeek
 apiFormat: openai
 baseUrl: https://api.deepseek.com
+# Sandbox coding harnesses that speak the Anthropic wire to the gateway
+# (Claude Code) ride DeepSeek's native Anthropic-compatible endpoint, so the
+# gateway passes Anthropic through instead of down-converting Anthropic→OpenAI.
+# The OpenAI base above (used by the direct API lane and OpenAI-wire harnesses)
+# mishandles multi-turn thinking: it drops the assistant's `reasoning_content`
+# on tool-loop turns and DeepSeek 400s ("`reasoning_content` ... must be passed
+# back to the API"). The Anthropic endpoint round-trips thinking blocks natively.
+harnessEndpoint:
+  baseUrl: https://api.deepseek.com/anthropic
+  apiFormat: anthropic
 catalog:
   source: static
 embedding: unknown

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -73,6 +73,23 @@ function parseDotEnv(filePath: string): Record<string, string> {
 // Same generators (and value shapes) the CLI uses in
 // tools/cli/src/lib/config/ensure-env.ts, so a host `bun dev` secret is
 // indistinguishable in strength from a `tale init` one.
+
+/** Mint a sandbox-LLM-gateway admin password that satisfies Bifrost's policy
+ * (>= v1.6.9: at least 12 chars with an uppercase, a lowercase, a digit and a
+ * non-alphanumeric special char, enforced on first-time auth setup). A random
+ * base64url string never guarantees each class — a special char is absent
+ * ~half the time — so guarantee each on top of a strong random base. `-` is
+ * base64url-safe: no .env quoting, safe in a Basic-auth header. Kept in step
+ * with the CLI's generateGatewayAdminPassword (ensure-env.ts). */
+function generateGatewayAdminPassword(): string {
+  let pw = randomBytes(18).toString('base64url');
+  if (!/[A-Z]/.test(pw)) pw += 'A';
+  if (!/[a-z]/.test(pw)) pw += 'a';
+  if (!/[0-9]/.test(pw)) pw += '3';
+  if (!/[^A-Za-z0-9]/.test(pw)) pw += '-';
+  return pw;
+}
+
 const SECRET_GENERATORS: Record<string, () => string> = {
   INSTANCE_SECRET: () => randomBytes(32).toString('hex'),
   BETTER_AUTH_SECRET: () => randomBytes(32).toString('base64'),
@@ -83,12 +100,13 @@ const SECRET_GENERATORS: Record<string, () => string> = {
   SANDBOX_TOKEN: () => randomBytes(32).toString('hex'),
   // Admin credential for the sandbox LLM gateway's management API. The backend
   // refuses every management call without it (the gateway shares one port on
-  // the sandbox network). Mirrors the CLI's generatePassword (16 random bytes,
-  // base64url). Must stay STABLE once minted: the gateway stores its hash in
-  // its own volume, so a changed value locks the platform out until that
-  // volume is wiped — which is why it is persisted to .env like the others.
-  SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: () =>
-    randomBytes(16).toString('base64url'),
+  // the sandbox network). Mirrors the CLI's generateGatewayAdminPassword — the
+  // gateway (Bifrost >= v1.6.9) enforces a password policy on first-time auth
+  // setup, so this is not a plain base64url secret. Must stay STABLE once
+  // minted: the gateway stores its hash in its own volume, so a changed value
+  // locks the platform out until that volume is wiped — which is why it is
+  // persisted to .env like the others.
+  SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: generateGatewayAdminPassword,
   // Postgres/ParadeDB superuser password (db + knowledge-db). Postgres reads it
   // only on the container's first init (initdb), and the platform orchestrator
   // derives KNOWLEDGE_DATABASE_URL from it — so an unset value silently breaks

--- a/services/platform/backend/core/lib/providers/agent_serving.test.ts
+++ b/services/platform/backend/core/lib/providers/agent_serving.test.ts
@@ -49,7 +49,12 @@ function harness(
     slug,
     displayName: slug,
     credentialPolicy: policy,
-    credentialEnvKeys: ['TALE_GATEWAY_TOKEN'],
+    // An anthropic-wire harness (Claude Code) points ANTHROPIC_BASE_URL at the
+    // gateway's `/anthropic` path; the serving reads this to decide the native
+    // Anthropic harness lane. Mirror that for the subscription-delivery fixture.
+    credentialEnvKeys: withSubscriptionDelivery
+      ? ['ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN', 'TALE_GATEWAY_TOKEN']
+      : ['TALE_GATEWAY_TOKEN'],
     modelIdDialect: 'vendor-native',
     promptTransport: 'stdin-ndjson',
     capabilities: { planMode: false, steering: false, mcp: false },
@@ -113,6 +118,21 @@ const OPENROUTER: ProviderDefinition = providerDefinitionSchema.parse({
   baseUrl: 'https://openrouter.ai/api/v1',
   catalog: { source: 'openrouter-api' },
   auth: [{ method: 'api-key' }, { method: 'env' }],
+});
+
+/** An OpenAI-format connector that also exposes a native Anthropic endpoint
+ * for anthropic-wire harnesses (mirrors the shipped `deepseek`). */
+const DEEPSEEK: ProviderDefinition = providerDefinitionSchema.parse({
+  name: 'deepseek',
+  displayName: 'DeepSeek',
+  apiFormat: 'openai',
+  baseUrl: 'https://api.deepseek.com',
+  harnessEndpoint: {
+    baseUrl: 'https://api.deepseek.com/anthropic',
+    apiFormat: 'anthropic',
+  },
+  catalog: { source: 'static' },
+  auth: [{ method: 'api-key' }],
 });
 
 /** Default-credential rows by provider slug; the fake ctx serves them. */
@@ -656,5 +676,50 @@ describe('catalog-less providers serve their credential allowlist', () => {
         harness: 'claude-code',
       }),
     ).rejects.toThrow(/provider "azure" cannot serve model "gpt-5-eu-prod"/);
+  });
+});
+
+describe('resolveWorkflowAgentServing — native Anthropic harness lane', () => {
+  it("routes a Claude Code session onto the connector's native Anthropic endpoint", async () => {
+    // deepseek is OpenAI-format for the direct/API lane but exposes a native
+    // Anthropic endpoint; an anthropic-wire harness (Claude Code) rides it so
+    // the gateway forwards Anthropic through instead of down-converting.
+    resolveConnectors.mockResolvedValue([DEEPSEEK]);
+    credentials = { deepseek: DIRECT };
+    getProviderCatalog.mockResolvedValue([{ id: 'deepseek-v4-flash' }]);
+
+    const serving = await resolveWorkflowAgentServing(ctx, {
+      organizationId: ORG,
+      model: 'deepseek-v4-flash',
+      modelProvider: 'deepseek',
+      harness: 'claude-code',
+    });
+
+    expect(serving).toEqual({
+      lane: 'gateway',
+      providerSlug: 'deepseek',
+      modelId: 'deepseek-v4-flash',
+      anthropicHarnessLane: true,
+    });
+  });
+
+  it('keeps an OpenAI-wire harness (codex) on the OpenAI base for the same connector', async () => {
+    resolveConnectors.mockResolvedValue([DEEPSEEK]);
+    credentials = { deepseek: DIRECT };
+    getProviderCatalog.mockResolvedValue([{ id: 'deepseek-v4-flash' }]);
+
+    const serving = await resolveWorkflowAgentServing(ctx, {
+      organizationId: ORG,
+      model: 'deepseek-v4-flash',
+      modelProvider: 'deepseek',
+      harness: 'codex',
+    });
+
+    // No `anthropicHarnessLane` flag → the OpenAI record serves it.
+    expect(serving).toEqual({
+      lane: 'gateway',
+      providerSlug: 'deepseek',
+      modelId: 'deepseek-v4-flash',
+    });
   });
 });

--- a/services/platform/backend/core/lib/providers/agent_serving.ts
+++ b/services/platform/backend/core/lib/providers/agent_serving.ts
@@ -57,7 +57,16 @@ import {
  * connector's own catalog spelling (what the wire — or the vendor CLI —
  * accepts). */
 export type AgentTurnServing =
-  | { lane: 'gateway'; providerSlug: string; modelId: string }
+  | {
+      lane: 'gateway';
+      providerSlug: string;
+      modelId: string;
+      /** The requesting harness speaks the Anthropic wire to the gateway AND
+       * this connector declares a native Anthropic harness endpoint, so the
+       * session rides that endpoint (a distinct `…__anthropic` record) instead
+       * of the OpenAI base. Absent/false ⇒ the OpenAI record. */
+      anthropicHarnessLane?: boolean;
+    }
   | {
       lane: 'subscription';
       providerSlug: string;
@@ -293,6 +302,31 @@ export async function walkDirectServing(
  * actionable reason — a pin NEVER falls back to another provider (the
  * silent-swap billing surprise is the defect the pin exists to close).
  */
+/** Whether a harness talks the Anthropic wire to the sandbox gateway — it
+ * points ANTHROPIC_BASE_URL at the gateway's `/anthropic` path, declared by
+ * ANTHROPIC_BASE_URL in its credentialEnvKeys. Today only Claude Code does. */
+function harnessSpeaksAnthropicWire(harness: string): boolean {
+  return (
+    loadHarnesses()
+      .find((def) => def.slug === harness)
+      ?.credentialEnvKeys.includes('ANTHROPIC_BASE_URL') ?? false
+  );
+}
+
+/** The gateway serving should ride the connector's native Anthropic harness
+ * endpoint (a distinct `…__anthropic` gateway record): the harness speaks the
+ * Anthropic wire and the connector declares such an endpoint. Otherwise the
+ * OpenAI base serves — an OpenAI-wire harness never crosses onto it. */
+function usesAnthropicHarnessEndpoint(
+  harness: string,
+  connector: { harnessEndpoint?: { apiFormat: string } },
+): boolean {
+  return (
+    connector.harnessEndpoint?.apiFormat === 'anthropic' &&
+    harnessSpeaksAnthropicWire(harness)
+  );
+}
+
 export async function resolvePinnedAgentServing(
   ctx: ActionCtx,
   args: {
@@ -331,7 +365,13 @@ export async function resolvePinnedAgentServing(
       connector,
     ]);
     if (walk.target !== null) {
-      return { lane: 'gateway', ...walk.target };
+      return {
+        lane: 'gateway',
+        ...walk.target,
+        ...(usesAnthropicHarnessEndpoint(args.harness, connector)
+          ? { anthropicHarnessLane: true }
+          : {}),
+      };
     }
     const detail =
       walk.unreachable.length > 0
@@ -434,7 +474,17 @@ export async function resolveWorkflowAgentServing(
     connectors,
   );
   if (direct.target !== null) {
-    return { lane: 'gateway', ...direct.target };
+    const chosen = connectors.find(
+      (entry) => entry.name === direct.target?.providerSlug,
+    );
+    return {
+      lane: 'gateway',
+      ...direct.target,
+      ...(chosen !== undefined &&
+      usesAnthropicHarnessEndpoint(args.harness, chosen)
+        ? { anthropicHarnessLane: true }
+        : {}),
+    };
   }
 
   const unreachable = [...direct.unreachable];

--- a/services/platform/backend/core/node_only/sandbox/gateway_provisioning.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/gateway_provisioning.test.ts
@@ -266,6 +266,50 @@ describe('provisionSessionGatewayKey', () => {
     });
   });
 
+  it("routes the Claude Code lane to the connector's native Anthropic endpoint under a distinct record", async () => {
+    // deepseek declares a harnessEndpoint (api.deepseek.com/anthropic). An
+    // anthropic-wire harness (Claude Code) rides it: a distinct `__anthropic`
+    // record whose upstream is that endpoint, kept apart from the OpenAI record
+    // other harnesses use for the same model — the gateway then forwards
+    // Anthropic through instead of down-converting to OpenAI.
+    mockedResolve.mockResolvedValue(apiKeyResolution('sk-ds'));
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    mockedCatalog.mockResolvedValue([
+      {
+        id: 'deepseek-v4-flash',
+        pricing: { inputCentsPerMillion: 14, outputCentsPerMillion: 28 },
+      },
+    ] as unknown as Awaited<ReturnType<typeof getProviderCatalog>>);
+    await provisionSessionGatewayKey(fakeCtx(), {
+      organizationId: 'org_1',
+      sessionId: 'sess-cc',
+      allowedModels: [
+        {
+          providerSlug: 'deepseek',
+          modelId: 'deepseek-v4-flash',
+          anthropicHarnessLane: true,
+        },
+      ],
+      budgetCents: 500,
+    });
+    expect(provisionProviders).toHaveBeenCalledWith('org_1', [
+      expect.objectContaining({
+        name: 'org_1__deepseek__deepseek-v4-flash__anthropic',
+        baseUrl: 'https://api.deepseek.com/anthropic',
+        apiFormat: 'anthropic',
+        models: ['deepseek-v4-flash'],
+        apiKey: 'sk-ds',
+      }),
+    ]);
+    // Pricing scoped to that SAME distinct record, else its turns bill 0.
+    expect(ensureModelPricingOverride).toHaveBeenCalledWith({
+      gatewayProvider: 'org_1__deepseek__deepseek-v4-flash__anthropic',
+      modelId: 'deepseek-v4-flash',
+      inputCentsPerMillion: 14,
+      outputCentsPerMillion: 28,
+    });
+  });
+
   it('keeps two orgs sharing a custom connector name on separate gateway records', async () => {
     // A custom connector is an org-defined file; two orgs may both ship an
     // `internal.yml`-style connector under one name (here the shipped

--- a/services/platform/backend/core/node_only/sandbox/gateway_provisioning.ts
+++ b/services/platform/backend/core/node_only/sandbox/gateway_provisioning.ts
@@ -124,6 +124,11 @@ export async function buildProviderProvision(
     apiFormat: connector.apiFormat,
     apiKey: resolved.secret,
     models,
+    // Carried as metadata so the per-model expansion can route an anthropic-
+    // wire harness (Claude Code) to the connector's native Anthropic endpoint.
+    ...(connector.harnessEndpoint
+      ? { harnessEndpoint: connector.harnessEndpoint }
+      : {}),
   };
 }
 
@@ -161,10 +166,15 @@ async function pushModelPricing(
       )?.pricing;
       if (pricing === undefined) continue;
       await ensureModelPricingOverride({
+        // Key the override to the SAME record the session routes to — the
+        // anthropic-harness variant (`…__anthropic`) is its own record, so
+        // without this its turns bill at the gateway's price (0 for a custom
+        // upstream) and the key's cap never trips.
         gatewayProvider: resolveGatewayRouting(
           args.organizationId,
           ref.providerSlug,
           ref.modelId,
+          { anthropicHarnessLane: ref.anthropicHarnessLane },
         ).gatewayProvider,
         modelId: ref.modelId,
         inputCentsPerMillion: pricing.inputCentsPerMillion,
@@ -276,6 +286,14 @@ export async function provisionSessionGatewayKey(
   for (const ref of args.allowedModels) {
     const base = baseBySlug.get(ref.providerSlug);
     if (!base) continue;
+    // Claude Code lane: an anthropic-wire harness on a connector that declares
+    // a native Anthropic endpoint rides a DISTINCT per-model record whose
+    // upstream is that endpoint, so the gateway forwards Anthropic through
+    // instead of down-converting Anthropic→OpenAI (which DeepSeek mishandles
+    // for multi-turn reasoning replay). Kept apart from the OpenAI record other
+    // harnesses use for the same model, so the two never overwrite each other.
+    const anthropicLane =
+      ref.anthropicHarnessLane === true && base.harnessEndpoint !== undefined;
     const provision = isStandardGatewayProvider(ref.providerSlug)
       ? base
       : {
@@ -284,8 +302,15 @@ export async function provisionSessionGatewayKey(
             args.organizationId,
             ref.providerSlug,
             ref.modelId,
+            { anthropicHarnessLane: anthropicLane },
           ).gatewayProvider,
           models: [ref.modelId],
+          ...(anthropicLane && base.harnessEndpoint
+            ? {
+                baseUrl: base.harnessEndpoint.baseUrl,
+                apiFormat: base.harnessEndpoint.apiFormat,
+              }
+            : {}),
         };
     if (slugByRecord.has(provision.name)) continue;
     slugByRecord.set(provision.name, ref.providerSlug);

--- a/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.test.ts
+++ b/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.test.ts
@@ -32,6 +32,9 @@ function stubGateway(
     configStatus?: number;
     configBody?: string;
     clientConfig?: Record<string, unknown>;
+    /** GET /api/config reports auth already enabled (a password is stored), so
+     * applyGatewayConfig must PRESERVE it rather than re-send a plaintext one. */
+    authEnabled?: boolean;
     /** The gateway stored the minted key WITHOUT its budget. */
     mintWithoutBudget?: boolean;
     /** Overrides `GET /api/governance/pricing-overrides` lists. */
@@ -70,7 +73,18 @@ function stubGateway(
       if (method === 'GET' && u.endsWith('/api/config')) {
         return Promise.resolve(
           new Response(
-            JSON.stringify({ client_config: opts.clientConfig ?? {} }),
+            JSON.stringify({
+              client_config: opts.clientConfig ?? {},
+              ...(opts.authEnabled
+                ? {
+                    auth_config: {
+                      is_enabled: true,
+                      admin_username: { value: 'admin', type: 'plain_text' },
+                      admin_password: { value: '<redacted>' },
+                    },
+                  }
+                : {}),
+            }),
             { status: 200 },
           ),
         );
@@ -783,7 +797,10 @@ describe('applyGatewayConfig', () => {
         enforce_auth_on_inference: true,
         enforce_governance_header: true,
       },
-      // Always pushed — the management plane is never left anonymous.
+      // First-time bootstrap (GET reports auth not yet enabled): the plaintext
+      // password is sent to establish it — the gateway hashes it on store. A
+      // freshly minted secret is policy-compliant by construction, so the
+      // gateway's >= v1.6.9 strength check passes.
       auth_config: {
         is_enabled: true,
         admin_username: 'admin',
@@ -793,21 +810,29 @@ describe('applyGatewayConfig', () => {
     });
   });
 
-  it('pushes admin Basic auth (plaintext password — the gateway hashes it) on every apply', async () => {
+  it('preserves the stored password once auth is enabled, so the gateway strength policy never trips', async () => {
     vi.stubEnv('SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD', 'pw-2');
-    const calls = stubGateway({ clientConfig: { log_retention_days: 14 } });
+    const calls = stubGateway({
+      clientConfig: { log_retention_days: 14 },
+      authEnabled: true,
+    });
     const mod = await loadModule();
     await mod.applyGatewayConfig();
     const put = calls.find(
       (c) => c.method === 'PUT' && c.url.endsWith('/api/config'),
     );
+    // Empty value → the gateway keeps its stored hash (SecretVar.
+    // ShouldPreserveStored) and skips the >= v1.6.9 password policy, which a
+    // secret minted before the policy (e.g. a base64url one with no special
+    // char) would otherwise 400 on ("must include one special character").
     expect(put?.body?.auth_config).toEqual({
       is_enabled: true,
       admin_username: 'admin',
-      admin_password: 'pw-2',
+      admin_password: '',
       disable_auth_on_inference: true,
     });
-    // And the apply itself authenticated with the same credential.
+    // Basic auth still uses the real credential — the password is unchanged,
+    // it is simply not re-asserted in the body.
     for (const call of calls) {
       expect(call.headers.authorization).toBe(basicFor('pw-2'));
     }
@@ -848,6 +873,40 @@ describe('resolveGatewayRouting', () => {
       gatewayModel:
         'org_1__vercel-ai-gateway__alibaba_qwen-3-14b/alibaba/qwen-3-14b',
     });
+  });
+
+  it('routes a custom connector to a distinct `__anthropic` record for the Claude Code lane', async () => {
+    const mod = await loadModule();
+    const openai = mod.resolveGatewayRouting(
+      ORG,
+      'deepseek',
+      'deepseek-v4-flash',
+    );
+    const anthropic = mod.resolveGatewayRouting(
+      ORG,
+      'deepseek',
+      'deepseek-v4-flash',
+      { anthropicHarnessLane: true },
+    );
+    expect(openai.gatewayProvider).toBe('org_1__deepseek__deepseek-v4-flash');
+    expect(anthropic.gatewayProvider).toBe(
+      'org_1__deepseek__deepseek-v4-flash__anthropic',
+    );
+    // Distinct records → the two upstreams (openai base vs native anthropic)
+    // never overwrite each other for the same (org, model).
+    expect(anthropic.gatewayProvider).not.toBe(openai.gatewayProvider);
+    expect(anthropic.gatewayModel).toBe(
+      'org_1__deepseek__deepseek-v4-flash__anthropic/deepseek-v4-flash',
+    );
+  });
+
+  it('ignores the anthropic-harness lane for a standard connector (it owns its wire)', async () => {
+    const mod = await loadModule();
+    expect(
+      mod.resolveGatewayRouting(ORG, 'anthropic', 'claude-fable-5', {
+        anthropicHarnessLane: true,
+      }),
+    ).toEqual(mod.resolveGatewayRouting(ORG, 'anthropic', 'claude-fable-5'));
   });
 
   it('gives two orgs sharing a custom connector name two distinct records', async () => {

--- a/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.ts
+++ b/services/platform/backend/core/node_only/sandbox/llm_gateway_admin.ts
@@ -174,8 +174,18 @@ function customGatewayProviderName(
   organizationId: string,
   slug: string,
   modelId: string,
+  anthropicHarnessLane = false,
 ): string {
-  return `${organizationId}__${slug}__${modelId}`.replace(/\//g, '_');
+  // An anthropic-wire harness (Claude Code) on a connector that declares a
+  // native Anthropic harness endpoint rides a DISTINCT record so its upstream
+  // (base_provider_type: anthropic) never overwrites the OpenAI record other
+  // harnesses use for the same (org, model). `__anthropic` is a safe suffix:
+  // `/` is still stripped below, and the segment stays one gateway record name.
+  const base = `${organizationId}__${slug}__${modelId}`;
+  return (anthropicHarnessLane ? `${base}__anthropic` : base).replace(
+    /\//g,
+    '_',
+  );
 }
 
 export interface GatewayRouting {
@@ -186,18 +196,31 @@ export interface GatewayRouting {
   gatewayModel: string;
 }
 
+/** Extra routing inputs beyond the (org, connector, model) triple. */
+export interface GatewayRoutingOpts {
+  /** The requesting harness speaks the Anthropic wire to the gateway AND the
+   * connector declares a native Anthropic harness endpoint, so this session
+   * rides a distinct per-model record (`…__anthropic`) whose upstream is that
+   * endpoint. Ignored for standard connectors (they own their record + wire
+   * format and declare no harness endpoint). */
+  anthropicHarnessLane?: boolean;
+}
+
 /**
  * Map an (org, connector, catalog model id) triple onto gateway routing. A
  * standard connector name routes to the shared native provider record
  * (`<name>/<modelId>`); any other connector routes to the org's own
- * per-model upstream record (`<orgId>__<name>__<modelId>/<modelId>`). Single
+ * per-model upstream record (`<orgId>__<name>__<modelId>/<modelId>`), or its
+ * anthropic-harness sibling (`…__anthropic/<modelId>`) when opts say so. Single
  * source of truth shared by the harness glue (model env), the mint (VK
- * binding), and the provisioner (record names) so they can never drift.
+ * binding), and the provisioner (record names) so they can never drift — pass
+ * the SAME opts at every call site for one session's model.
  */
 export function resolveGatewayRouting(
   organizationId: string,
   providerSlug: string,
   modelId: string,
+  opts: GatewayRoutingOpts = {},
 ): GatewayRouting {
   if (isStandardGatewayProvider(providerSlug)) {
     return {
@@ -205,7 +228,12 @@ export function resolveGatewayRouting(
       gatewayModel: `${providerSlug}/${modelId}`,
     };
   }
-  const name = customGatewayProviderName(organizationId, providerSlug, modelId);
+  const name = customGatewayProviderName(
+    organizationId,
+    providerSlug,
+    modelId,
+    opts.anthropicHarnessLane,
+  );
   return { gatewayProvider: name, gatewayModel: `${name}/${modelId}` };
 }
 
@@ -214,6 +242,9 @@ export function resolveGatewayRouting(
 export interface AllowedModelRef {
   providerSlug: string;
   modelId: string;
+  /** Route this model through the connector's native Anthropic harness
+   * endpoint (Claude Code lane). See {@link GatewayRoutingOpts}. */
+  anthropicHarnessLane?: boolean;
 }
 
 export interface MintVirtualKeyArgs {
@@ -256,6 +287,7 @@ export async function mintVirtualKey(
       args.organizationId,
       ref.providerSlug,
       ref.modelId,
+      { anthropicHarnessLane: ref.anthropicHarnessLane },
     );
     const models = byProvider.get(gatewayProvider) ?? [];
     models.push(ref.modelId, gatewayModel);
@@ -619,6 +651,11 @@ export interface ProviderProvision {
   apiKey: string;
   /** Catalog model ids (the connector's own dialect) this key may serve. */
   models: string[];
+  /** Platform-side metadata only (never pushed to the gateway): the
+   * connector's native Anthropic harness endpoint, applied to the per-model
+   * record when an anthropic-wire harness rides this provider. See
+   * {@link GatewayRoutingOpts.anthropicHarnessLane}. */
+  harnessEndpoint?: { baseUrl: string; apiFormat: 'openai' | 'anthropic' };
 }
 
 /**
@@ -989,6 +1026,7 @@ export async function applyGatewayConfig(): Promise<void> {
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
   const cfg = (await getRes.json()) as {
     client_config?: Record<string, unknown>;
+    auth_config?: { is_enabled?: boolean };
   };
   const current = cfg.client_config ?? {};
   // `PUT /api/config` re-validates the whole client_config, but GET returns
@@ -1006,15 +1044,27 @@ export async function applyGatewayConfig(): Promise<void> {
     enforce_auth_on_inference: true,
     enforce_governance_header: true,
   };
+  // The gateway (Bifrost >= v1.6.9) enforces an admin-password strength policy
+  // (>=12 chars, an upper, a lower, a digit and a non-alphanumeric special
+  // char) — but ONLY when the password is being CHANGED. It treats a plaintext
+  // `admin_password` as a change, so re-asserting one on every apply 400s
+  // ("auth password must include one special character") for any secret minted
+  // before the policy (a base64url secret has no special char ~half the time).
+  // Once auth is established we therefore send the password in "preserve
+  // stored" form (an empty value → SecretVar.ShouldPreserveStored on the
+  // gateway): it keeps the existing hash and skips the policy, and Basic auth
+  // keeps matching the unchanged secret. Only the FIRST-time bootstrap sends
+  // the plaintext to establish auth — and that minted secret is policy-
+  // compliant by construction (the ensure-env / dev-secret generators). The
+  // gateway hashes the stored password itself (bcrypt); managementHeaders()
+  // sends the plaintext as Basic.
+  const authAlreadyEnabled = cfg.auth_config?.is_enabled === true;
   const body: Record<string, unknown> = {
     client_config: clientConfig,
-    // Send the PLAINTEXT password — the gateway hashes it itself on store
-    // and compares with bcrypt at request time. Pre-hashing would
-    // double-hash and every Basic-auth call would 401.
     auth_config: {
       is_enabled: true,
       admin_username: adminUsername(),
-      admin_password: requireGatewayAdminPassword(),
+      admin_password: authAlreadyEnabled ? '' : requireGatewayAdminPassword(),
       // Inference is gated by enforce_auth_on_inference (VK), not admin
       // login.
       disable_auth_on_inference: true,

--- a/services/platform/backend/core/tasks/agent_run_host.ts
+++ b/services/platform/backend/core/tasks/agent_run_host.ts
@@ -471,14 +471,20 @@ async function mintTurnServing(
   resolved: TaskServing,
 ): Promise<PreparedServing> {
   if (resolved.lane === 'gateway') {
+    // Claude Code + a connector with a native Anthropic harness endpoint
+    // (DeepSeek) rides that endpoint's distinct record; the flag must reach the
+    // execModel routing, the provision, and the mint identically or they drift.
+    const anthropicHarnessLane = resolved.anthropicHarnessLane === true;
     const target = {
       providerSlug: resolved.providerSlug,
       modelId: resolved.modelId,
+      anthropicHarnessLane,
     };
     const routing = resolveGatewayRouting(
       args.organizationId,
       target.providerSlug,
       target.modelId,
+      { anthropicHarnessLane },
     );
     // A text-only serving model still meets image inputs (task attachments,
     // scanned PDFs) — arm the vision polyfill so those route through the

--- a/services/platform/lib/shared/schemas/providers.ts
+++ b/services/platform/lib/shared/schemas/providers.ts
@@ -284,6 +284,21 @@ export const providerDefinitionSchema = z
      * credential row stores its own `endpointUrl`).
      */
     endpointMode: z.enum(['fixed', 'per-credential']).optional(),
+    /**
+     * An alternate endpoint for the SANDBOX HARNESS (gateway) lane only — never
+     * the direct API lane. A provider whose direct/API lane is OpenAI-format
+     * may expose a native Anthropic-compatible endpoint that a Claude Code
+     * session (which speaks the Anthropic wire to the gateway) should ride, so
+     * the gateway forwards Anthropic natively instead of down-converting
+     * Anthropic→OpenAI — a conversion some upstreams (DeepSeek) mishandle for
+     * multi-turn `reasoning_content` replay. Consulted only when the requesting
+     * harness's gateway wire matches this `apiFormat`; other harnesses keep the
+     * provider's `baseUrl`/`apiFormat`. Realistically `apiFormat: anthropic`.
+     */
+    harnessEndpoint: z
+      .object({ baseUrl: providerBaseUrlSchema, apiFormat: apiFormatSchema })
+      .strict()
+      .optional(),
     catalog: catalogSourceSchema,
     /** See {@link providerEmbeddingSupportSchema}. Absent = `unknown`. */
     embedding: providerEmbeddingSupportSchema.optional(),

--- a/services/platform/scripts/dev-secrets.test.ts
+++ b/services/platform/scripts/dev-secrets.test.ts
@@ -44,6 +44,19 @@ describe('dev sandbox control-plane secrets — lockstep with compose.dev.yml', 
       DEV_SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD,
     );
   });
+
+  // A fresh dockerized dev gateway sets THIS value as its admin password on
+  // first-time auth setup, and Bifrost (>= v1.6.9) rejects one that misses any
+  // class (>=12 chars, upper, lower, digit, special) — then every sandbox call
+  // is a 401. Guard the literal from regressing below the policy.
+  it('gateway admin dev default satisfies the gateway password policy', () => {
+    const pw = DEV_SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD;
+    expect(pw.length).toBeGreaterThanOrEqual(12);
+    expect(pw).toMatch(/[A-Z]/);
+    expect(pw).toMatch(/[a-z]/);
+    expect(pw).toMatch(/[0-9]/);
+    expect(pw).toMatch(/[^A-Za-z0-9]/);
+  });
 });
 
 describe('ensureSandboxToken', () => {

--- a/services/platform/scripts/dev-secrets.ts
+++ b/services/platform/scripts/dev-secrets.ts
@@ -114,8 +114,14 @@ export function ensureSandboxLlmGatewayUrl(env: NodeJS.ProcessEnv): void {
  */
 export const DEV_SANDBOX_TOKEN =
   'local-dev-insecure-sandbox-token-do-not-use-in-prod-0123456789abcdef';
+// Must satisfy the gateway's own password policy (Bifrost >= v1.6.9: >=12
+// chars with an uppercase, a lowercase, a digit and a special char), since a
+// fresh dockerized dev gateway sets THIS value as its admin password on
+// first-time auth setup — a non-compliant one 400s and every sandbox call is
+// then a 401. Kept byte-identical with compose.dev.yml (dev-secrets.test.ts
+// pins the lockstep).
 export const DEV_SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD =
-  'local-dev-insecure-gateway-admin-password';
+  'Local-dev-insecure-gateway-admin-password-1';
 
 /** Shared HMAC key for backend → sandbox spawner request signing. */
 export function ensureSandboxToken(env: NodeJS.ProcessEnv): void {

--- a/services/sandbox-llm-gateway/Dockerfile
+++ b/services/sandbox-llm-gateway/Dockerfile
@@ -13,8 +13,15 @@
 ARG VERSION=dev
 
 # Upstream gateway core (vendor image — NOT renamed; this is the literal
-# upstream artifact). Pinned because the project has had VK auth regressions.
-FROM maximhq/bifrost:v1.5.13
+# upstream artifact). Pinned (the project has had VK auth regressions) — verify
+# virtual-key auth after any bump. Held at v1.6.11: v1.5.13 provisioned DeepSeek
+# as a generic custom-OpenAI upstream and dropped its `reasoning_content` on
+# tool-loop turns, so DeepSeek 400'd ("The `reasoning_content` in the thinking
+# mode must be passed back to the API") on every thinking claude-code run.
+# v1.6.9 made DeepSeek thinking survive multi-turn on the OpenAI-compatible
+# surface; v1.6.10/.11 hardened reasoning replay. Deliberately below the v2.0.0
+# major (datasheet-backed request reshaping — larger regression surface).
+FROM maximhq/bifrost:v1.6.11
 
 # Re-declare VERSION arg (ARGs don't persist after FROM)
 ARG VERSION=dev

--- a/tools/cli/src/lib/config/ensure-env.ts
+++ b/tools/cli/src/lib/config/ensure-env.ts
@@ -21,6 +21,24 @@ function generatePassword(): string {
 }
 
 /**
+ * Mint a sandbox-LLM-gateway admin password that satisfies Bifrost's policy
+ * (>= v1.6.9: at least 12 chars with an uppercase, a lowercase, a digit and a
+ * non-alphanumeric special char, enforced when auth is first established). A
+ * random base64url string never guarantees each class — a special char is
+ * absent ~half the time — so guarantee each on top of a strong random base.
+ * `-` is base64url-safe: no .env quoting, safe in a Basic-auth header. Kept in
+ * step with the host dev generator (scripts/dev.ts).
+ */
+function generateGatewayAdminPassword(): string {
+  let pw = randomBytes(18).toString('base64url');
+  if (!/[A-Z]/.test(pw)) pw += 'A';
+  if (!/[a-z]/.test(pw)) pw += 'a';
+  if (!/[0-9]/.test(pw)) pw += '3';
+  if (!/[^A-Za-z0-9]/.test(pw)) pw += '-';
+  return pw;
+}
+
+/**
  * Internal TLS-derivation discriminator. `trial` = the local default written
  * by `tale init`; `production` = a real domain chosen at `tale deploy`.
  */
@@ -393,7 +411,7 @@ async function runHeadlessAutoSecretFill(
     SANDBOX_TOKEN: generateHexSecret,
     TALE_AUDIT_SIGNING_KEY: generateHexSecret,
     TALE_AUDIT_PEPPER: generateHexSecret,
-    SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: generatePassword,
+    SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: generateGatewayAdminPassword,
     OBJECT_STORE_SECRET_KEY: generatePassword,
   };
 
@@ -520,7 +538,7 @@ async function runPartialEnvSetup(
     SANDBOX_TOKEN: generateHexSecret,
     TALE_AUDIT_SIGNING_KEY: generateHexSecret,
     TALE_AUDIT_PEPPER: generateHexSecret,
-    SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: generatePassword,
+    SANDBOX_LLM_GATEWAY_ADMIN_PASSWORD: generateGatewayAdminPassword,
     OBJECT_STORE_SECRET_KEY: generatePassword,
   };
 
@@ -592,7 +610,7 @@ async function runEnvSetup(envPath: string): Promise<EnvSetupResult> {
     sandboxToken: generateHexSecret(),
     auditSigningKey: generateHexSecret(),
     auditPepper: generateHexSecret(),
-    llmGatewayAdminPassword: generatePassword(),
+    llmGatewayAdminPassword: generateGatewayAdminPassword(),
     objectStoreSecretKey: generatePassword(),
   });
 


### PR DESCRIPTION
## What & why

Task agents on DeepSeek + the Claude Code harness failed every run with `API Error: 400 The reasoning_content in the thinking mode must be passed back to the API`. The sandbox LLM gateway (Bifrost v1.5.13) provisioned DeepSeek as a generic custom-OpenAI upstream and dropped the assistant's `reasoning_content` on tool-loop turns; DeepSeek requires it replayed once a request carries tools. The same session ran GLM-5.3-flash for 90 minutes with thinking + tools with no error (Z.ai does not enforce the replay), isolating it to the DeepSeek OpenAI-conversion path.

## Changes

**Bump the gateway to Bifrost v1.6.11.** v1.6.9 fixes DeepSeek multi-turn thinking on the OpenAI-compatible surface; v1.6.10/.11 harden reasoning replay. Held below v2.0.0's datasheet-backed request rewrite.

**Preserve the stored admin password on config apply.** The bump surfaces Bifrost's admin-password policy (>= v1.6.9: 12+ chars with an upper, lower, digit and special char), enforced only when the password is being changed. The platform re-sent the plaintext admin password on every `applyGatewayConfig`, so a secret minted before the policy was rejected with 400 and no sandbox session of any harness could start. `applyGatewayConfig` now preserves the stored password once auth is enabled (empty value, `SecretVar.ShouldPreserveStored`) and sends a plaintext one only on first-time bootstrap. The dev/CLI generators and the fixed dev default are now policy-compliant. No rotation, no volume wipe.

**Route the Claude Code lane to DeepSeek's native Anthropic endpoint.** A new optional provider field `harnessEndpoint` (DeepSeek: `api.deepseek.com/anthropic`, anthropic format) lets an anthropic-wire harness (Claude Code) ride a distinct `<org>__<slug>__<model>__anthropic` gateway record whose upstream is that endpoint, so the gateway forwards Anthropic through instead of down-converting Anthropic to OpenAI. It is kept apart from the OpenAI record other harnesses use for the same model. The lane decision is made once where the serving resolves and carried through routing, provisioning, the virtual-key mint and pricing. The automations lane keeps the now-fixed OpenAI path; the two records coexist without collision.

## Verification

- Against the running v1.6.11 gateway: the preserve-stored config PUT returns 200; the old plaintext PUT returns 400.
- `bun run check` green (format, lint, typecheck, test, test:ui); `knip:check` green.
- New tests cover the password-preserve vs first-bootstrap paths, the `__anthropic` routing variant, native-endpoint provisioning and pricing, and the Claude-Code-vs-Codex serving split.
