### PR TITLE
fix(platform): show archived work in search, labelled as archived

### DIFF
--- a/packages/ui/src/components/search/search-command.test.tsx
+++ b/packages/ui/src/components/search/search-command.test.tsx
@@ -332,4 +332,30 @@ describe('SearchCommand', () => {
       expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
     });
   });
+
+  // A result's status label. The palette shows archived work (#2999), so the
+  // row has to be able to say a hit is archived.
+  it('renders a result badge beside the title', async () => {
+    respond = () => ({
+      kind: 'ready',
+      results: [result({ id: '1', badge: 'Archived' })],
+    });
+    const { user } = renderCommand();
+    await user.type(screen.getByPlaceholderText(L.placeholder), 'config');
+    await waitFor(() =>
+      expect(screen.getByText('Archived')).toBeInTheDocument(),
+    );
+  });
+
+  it('renders no badge when a result carries none', async () => {
+    respond = () => ({ kind: 'ready', results: [result({ id: '1' })] });
+    const { user } = renderCommand();
+    await user.type(screen.getByPlaceholderText(L.placeholder), 'config');
+    await waitFor(() =>
+      expect(
+        screen.getByRole('option', { name: /Configuration/ }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('Archived')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/search/search-result-row.tsx
+++ b/packages/ui/src/components/search/search-result-row.tsx
@@ -108,6 +108,11 @@ export function SearchResultRow({
             <span className="truncate">
               <Highlight text={result.title} terms={highlightTerms} />
             </span>
+            {result.badge ? (
+              <span className="border-border-base/70 text-fg-subtle shrink-0 rounded border px-1.5 py-px text-[10px] font-medium">
+                {result.badge}
+              </span>
+            ) : null}
           </span>
           {secondary ? (
             <span className="text-fg-muted mt-0.5 line-clamp-2 text-xs leading-relaxed">

--- a/packages/ui/src/components/search/types.ts
+++ b/packages/ui/src/components/search/types.ts
@@ -18,6 +18,9 @@ export interface SearchResult<TData = object> {
   /** Secondary line under the title (a chat preview, an entity subtitle).
    *  Ignored when `body` is present — `body` drives a highlighted snippet. */
   subtitle?: string;
+  /** Short status label rendered beside the title (e.g. "Archived"). The
+   *  source supplies it already localized. */
+  badge?: string;
   /** Group key — section for docs, date-bucket for threads, entity type for
    *  mixed lists. Falls back to a single "Results" group when omitted. */
   group?: string;

--- a/services/platform/app/features/documents/data/documents-search-source.ts
+++ b/services/platform/app/features/documents/data/documents-search-source.ts
@@ -4,6 +4,7 @@ import type { SearchResult, SearchSource } from '@tale/ui/search';
 import { useMemo } from 'react';
 
 import { useBackendQuery } from '@/app/hooks/use-backend-query';
+import { useT } from '@/lib/i18n/client';
 
 const NO_RESULTS: SearchResult<DocumentSearchHitData>[] = [];
 
@@ -19,6 +20,7 @@ export function createDocumentsSearchSource(options: {
 }): SearchSource<DocumentSearchHitData> {
   const { organizationId, enabled = true } = options;
   return (query, { active }) => {
+    const { t } = useT('dialogs');
     const trimmed = query.trim();
     const hits = useBackendQuery(
       'documents/search:searchDocuments',
@@ -34,6 +36,11 @@ export function createDocumentsSearchSource(options: {
         id: hit.documentId,
         title: hit.title,
         subtitle: hit.snippet,
+        // A document has no archive state of its own; its project's is the
+        // only label it can carry (#3007).
+        ...(hit.projectArchived
+          ? { badge: t('search.badgeProjectArchived') }
+          : {}),
         group: 'documents',
         data: {
           kind: 'document' as const,
@@ -41,7 +48,7 @@ export function createDocumentsSearchSource(options: {
           projectId: hit.projectId,
         },
       }));
-    }, [hits.data]);
+    }, [hits.data, t]);
 
     if (!enabled || !active || trimmed.length === 0) {
       return { results: NO_RESULTS, status: 'ready' };

--- a/services/platform/app/features/projects/components/project-archived-badge.tsx
+++ b/services/platform/app/features/projects/components/project-archived-badge.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Badge } from '@tale/ui/badge';
+import { Archive } from 'lucide-react';
+
+import { useT } from '@/lib/i18n/client';
+
+/**
+ * Inline badge when a project is archived — the project page's breadcrumb
+ * leaf, so a retired project says so on every one of its tabs rather than
+ * only in the Projects list.
+ */
+export function ProjectArchivedBadge({ className }: { className?: string }) {
+  const { t } = useT('projects');
+  return (
+    <Badge variant="yellow" icon={Archive} className={className}>
+      {t('archived.badge')}
+    </Badge>
+  );
+}

--- a/services/platform/app/features/projects/data/projects-search-source.ts
+++ b/services/platform/app/features/projects/data/projects-search-source.ts
@@ -4,6 +4,7 @@ import type { SearchResult, SearchSource } from '@tale/ui/search';
 import { useMemo } from 'react';
 
 import { useBackendQuery } from '@/app/hooks/use-backend-query';
+import { useT } from '@/lib/i18n/client';
 
 const NO_RESULTS: SearchResult<ProjectSearchHitData>[] = [];
 
@@ -17,6 +18,7 @@ export function createProjectsSearchSource(options: {
 }): SearchSource<ProjectSearchHitData> {
   const { organizationId, enabled = true } = options;
   return (query, { active }) => {
+    const { t } = useT('dialogs');
     const trimmed = query.trim();
     const hits = useBackendQuery(
       'projects/search:searchProjects',
@@ -32,10 +34,11 @@ export function createProjectsSearchSource(options: {
         id: hit.projectId,
         title: hit.key ? `${hit.key} · ${hit.name}` : hit.name,
         subtitle: hit.snippet,
+        ...(hit.archived ? { badge: t('search.badgeArchived') } : {}),
         group: 'projects',
         data: { kind: 'project' as const },
       }));
-    }, [hits.data]);
+    }, [hits.data, t]);
 
     if (!enabled || !active || trimmed.length === 0) {
       return { results: NO_RESULTS, status: 'ready' };

--- a/services/platform/app/features/tasks/components/kanban-board.test.tsx
+++ b/services/platform/app/features/tasks/components/kanban-board.test.tsx
@@ -59,6 +59,7 @@ function makeTask(
   title: string,
   status: TaskRow['status'],
   rank: string,
+  overrides: Partial<TaskRow> = {},
 ): TaskRow {
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal fixture; the board renders title/status/rank only
   return {
@@ -74,6 +75,7 @@ function makeTask(
     createdByType: 'user',
     createdAt: 0,
     updatedAt: 0,
+    ...overrides,
   } as unknown as TaskRow;
 }
 
@@ -100,5 +102,34 @@ describe('KanbanBoard backlog lane', () => {
     }
     expect(screen.getByText('Triaged task')).toBeInTheDocument();
     expect(screen.getByText('Proposed task')).toBeInTheDocument();
+  });
+});
+
+// An archived card used to be signalled by `opacity-70` alone, which makes
+// colour the sole carrier of the meaning (WCAG 2.1 AA 1.4.1).
+describe('KanbanBoard archived cards', () => {
+  // Both fixtures carry a `projectKey`. Without one `formatTaskIdentifier`
+  // returns null, the identifier row is skipped entirely, and the negative
+  // case would pass even with the badge hard-coded to always render.
+  it('gives an archived card the Archived badge', () => {
+    render(
+      <KanbanBoard
+        projectKey="TAL"
+        tasks={[makeTask('Retired task', 'todo', 'a0', { archivedAt: 123 })]}
+      />,
+    );
+    expect(screen.getByText('TAL-1')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+  });
+
+  it('leaves a live card without one', () => {
+    render(
+      <KanbanBoard
+        projectKey="TAL"
+        tasks={[makeTask('Live task', 'todo', 'a0')]}
+      />,
+    );
+    expect(screen.getByText('TAL-1')).toBeInTheDocument();
+    expect(screen.queryByText('Archived')).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/tasks/components/task-archived-badge.tsx
+++ b/services/platform/app/features/tasks/components/task-archived-badge.tsx
@@ -5,11 +5,15 @@ import { Archive } from 'lucide-react';
 
 import { useT } from '@/lib/i18n/client';
 
-/** Inline badge when a task is archived — shown in the task detail header. */
-export function TaskArchivedBadge() {
+/**
+ * Inline badge when a task is archived — the task detail header, and the
+ * board card and list row, where `opacity-70` alone carried the meaning and
+ * colour is not an accessible sole cue (WCAG 2.1 AA 1.4.1).
+ */
+export function TaskArchivedBadge({ className }: { className?: string }) {
   const { t } = useT('tasks');
   return (
-    <Badge variant="yellow" icon={Archive}>
+    <Badge variant="yellow" icon={Archive} className={className}>
       {t('archived.badge')}
     </Badge>
   );

--- a/services/platform/app/features/tasks/components/task-card.tsx
+++ b/services/platform/app/features/tasks/components/task-card.tsx
@@ -16,6 +16,7 @@ import type { TaskDoc } from '../lib/display';
 import { subtaskProgress } from '../lib/subtasks';
 import { AssigneePicker } from './assignee-picker';
 import { PriorityPicker } from './priority-picker';
+import { TaskArchivedBadge } from './task-archived-badge';
 import { TaskAutomationBadge } from './task-automation-badge';
 import { useTaskBoardContext } from './task-board-context';
 import {
@@ -146,15 +147,22 @@ export function TaskCard({
           sortable.listeners?.onKeyDown?.(e);
         }}
       >
-        {identifier && (
-          <Text
-            as="span"
-            variant="caption"
-            className="font-mono text-[10px] tracking-wide"
-          >
-            {identifier}
-          </Text>
-        )}
+        {identifier || task.archivedAt != null ? (
+          <Row gap={1} align="center">
+            {identifier && (
+              <Text
+                as="span"
+                variant="caption"
+                className="font-mono text-[10px] tracking-wide"
+              >
+                {identifier}
+              </Text>
+            )}
+            {task.archivedAt != null && (
+              <TaskArchivedBadge className="px-1.5 py-px text-[10px]" />
+            )}
+          </Row>
+        ) : null}
         <Text as="p" variant="label" className="line-clamp-2 leading-snug">
           {task.title}
         </Text>

--- a/services/platform/app/features/tasks/components/tasks-list.test.tsx
+++ b/services/platform/app/features/tasks/components/tasks-list.test.tsx
@@ -37,9 +37,6 @@ vi.mock('../hooks/use-actor-directory', () => ({
   }),
 }));
 
-// The contract/choreography hooks reach Convex (provider-backed); the board
-// render tests care about lanes and rows, so stub them at the module seam —
-// the pure helpers stay real via importOriginal.
 vi.mock('../hooks/use-task-status-choreography', async (importOriginal) => ({
   ...(await importOriginal<
     typeof import('../hooks/use-task-status-choreography')
@@ -55,50 +52,38 @@ vi.mock('../hooks/use-task-subject-contract', async (importOriginal) => ({
   useTaskContractAutomations: () => [],
 }));
 
-function makeTask(
-  title: string,
-  status: TaskRow['status'],
-  rank: string,
-): TaskRow {
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal fixture; the list renders title/status/rank only
+function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- minimal fixture; the row renders title/status/archivedAt only
   return {
-    _id: `task_${title}`,
+    _id: 'task_1',
     _creationTime: 0,
     organizationId: 'org_test',
     projectId: 'project_1',
-    title,
-    status,
-    rank,
+    title: 'Chase the invoice',
+    status: 'todo',
+    rank: 'a0',
     number: 1,
+    projectKey: 'TAL',
     createdBy: 'user_1',
     createdByType: 'user',
     createdAt: 0,
     updatedAt: 0,
+    ...overrides,
   } as unknown as TaskRow;
 }
 
-describe('TasksList backlog section', () => {
-  it('renders every status section including backlog and its rows', () => {
-    render(
-      <TasksList
-        tasks={[
-          makeTask('Triaged task', 'todo', 'a0'),
-          makeTask('Proposed task', 'backlog', 'a1'),
-        ]}
-      />,
-    );
+// An archived row was signalled by `opacity-70` alone, which makes colour the
+// sole carrier of the meaning (WCAG 2.1 AA 1.4.1).
+describe('TasksList archived rows', () => {
+  it('gives an archived row the Archived badge', () => {
+    render(<TasksList tasks={[makeTask({ archivedAt: 123 })]} />);
+    expect(screen.getByText('Chase the invoice')).toBeInTheDocument();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+  });
 
-    for (const section of [
-      'Backlog',
-      'To do',
-      'In progress',
-      'In review',
-      'Done',
-      'Cancelled',
-    ]) {
-      expect(screen.getByText(section)).toBeInTheDocument();
-    }
-    expect(screen.getByText('Triaged task')).toBeInTheDocument();
-    expect(screen.getByText('Proposed task')).toBeInTheDocument();
+  it('leaves a live row without one', () => {
+    render(<TasksList tasks={[makeTask()]} />);
+    expect(screen.getByText('Chase the invoice')).toBeInTheDocument();
+    expect(screen.queryByText('Archived')).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/features/tasks/components/tasks-list.tsx
+++ b/services/platform/app/features/tasks/components/tasks-list.tsx
@@ -22,6 +22,7 @@ import { partitionSubtasks, subtaskProgress } from '../lib/subtasks';
 import { AssigneePicker } from './assignee-picker';
 import { PriorityPicker } from './priority-picker';
 import { useRunCancelConfirm } from './run-cancel-confirm';
+import { TaskArchivedBadge } from './task-archived-badge';
 import { useTaskBoardContext } from './task-board-context';
 import type { TaskRow } from './task-card';
 import {
@@ -382,6 +383,9 @@ function TaskListRow({
       >
         {task.title}
       </Text>
+      {task.archivedAt != null && (
+        <TaskArchivedBadge className="shrink-0 px-1.5 py-px text-[10px]" />
+      )}
       {task.labels && task.labels.length > 0 && (
         <span className="hidden shrink-0 items-center gap-1 md:flex">
           {task.labels.slice(0, 3).map((label) => (

--- a/services/platform/app/features/tasks/data/tasks-search-source.ts
+++ b/services/platform/app/features/tasks/data/tasks-search-source.ts
@@ -17,6 +17,7 @@ import type { SearchResult, SearchSource } from '@tale/ui/search';
 import { useMemo } from 'react';
 
 import { useBackendQuery } from '@/app/hooks/use-backend-query';
+import { useT } from '@/lib/i18n/client';
 
 const NO_RESULTS: SearchResult<TaskSearchHitData>[] = [];
 
@@ -32,6 +33,7 @@ export function createTasksSearchSource(options: {
 }): SearchSource<TaskSearchHitData> {
   const { organizationId, projectId } = options;
   return (query, { active }) => {
+    const { t } = useT('dialogs');
     const trimmed = query.trim();
     const hits = useBackendQuery(
       'tasks/search:searchTasks',
@@ -49,15 +51,23 @@ export function createTasksSearchSource(options: {
       if (!hits.data) return NO_RESULTS;
       return hits.data.map((hit) => {
         const identifier = formatTaskIdentifier(hit.projectKey, hit.number);
+        // The task's own state wins: an archived task in an archived project
+        // reads "Archived", not "Archived project" (#2999).
+        const badge = hit.archived
+          ? t('search.badgeArchived')
+          : hit.projectArchived
+            ? t('search.badgeProjectArchived')
+            : undefined;
         return {
           id: hit.taskId,
           title: identifier ? `${identifier} · ${hit.title}` : hit.title,
           subtitle: hit.snippet,
+          ...(badge !== undefined ? { badge } : {}),
           group: 'tasks',
           data: { kind: 'task' as const, projectId: hit.projectId },
         };
       });
-    }, [hits.data]);
+    }, [hits.data, t]);
 
     if (!active || trimmed.length === 0) {
       return { results: NO_RESULTS, status: 'ready' };

--- a/services/platform/app/lib/backend/contract/documents.ts
+++ b/services/platform/app/lib/backend/contract/documents.ts
@@ -420,6 +420,7 @@ export interface DocumentsContract {
       folderId?: string;
       projectId?: string;
       updatedAt: number;
+      projectArchived?: true;
     }>;
   };
 }

--- a/services/platform/app/lib/backend/contract/projects.ts
+++ b/services/platform/app/lib/backend/contract/projects.ts
@@ -399,6 +399,7 @@ export interface ProjectsContract {
       key?: string;
       snippet: string;
       updatedAt: number;
+      archived?: true;
     }>;
   };
   'projects/secrets/actions:deleteProjectSecret': {

--- a/services/platform/app/lib/backend/contract/tasks.ts
+++ b/services/platform/app/lib/backend/contract/tasks.ts
@@ -865,6 +865,8 @@ export interface TasksContract {
       updatedAt: number;
       number?: number;
       projectKey?: string;
+      archived?: true;
+      projectArchived?: true;
     }>;
   };
   'tasks/serving_preview:previewUnpinnedTaskServing': {

--- a/services/platform/app/lib/backend/projects.ts
+++ b/services/platform/app/lib/backend/projects.ts
@@ -205,6 +205,7 @@ function paletteHitView(row: ProjectWire): PaletteSearchItem {
     ...(row.key !== null ? { key: row.key } : {}),
     snippet,
     updatedAt: row.updatedAt,
+    ...(row.archivedAt !== null ? { archived: true } : {}),
   };
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the one fetch-boundary projection to the 0.4 shape
   return view as PaletteSearchItem;

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.test.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.test.tsx
@@ -127,12 +127,16 @@ const ProjectDetailLayout = (
   Route as unknown as { component: () => React.ReactElement }
 ).component;
 
-function setup(automations: unknown[] | undefined) {
+function setup(
+  automations: unknown[] | undefined,
+  projectOverrides: Record<string, unknown> = {},
+) {
   mockUseProject.mockReturnValue({
     project: {
       _id: 'proj-1',
       name: 'Apollo',
       canAdminister: false,
+      ...projectOverrides,
     },
     isLoading: false,
   });
@@ -215,5 +219,25 @@ describe('project shell — All projects Tasks mode', () => {
       ).not.toBeInTheDocument();
       expect(screen.getByText(label)).toHaveAttribute('aria-disabled', 'true');
     }
+  });
+});
+
+// An archived project said so only in the Projects list. Every one of its tabs
+// now carries the badge, beside the breadcrumb leaf.
+describe('project shell — archived badge', () => {
+  it('badges the breadcrumb when the project is archived', () => {
+    setup([], { archivedAt: 1789000000000 });
+
+    expect(screen.getByText('Apollo')).toBeInTheDocument();
+    expect(screen.getByText('projects.archived.badge')).toBeInTheDocument();
+  });
+
+  it('leaves a live project unbadged', () => {
+    setup([]);
+
+    expect(screen.getByText('Apollo')).toBeInTheDocument();
+    expect(
+      screen.queryByText('projects.archived.badge'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
+++ b/services/platform/app/routes/dashboard/$id/projects/$projectId.tsx
@@ -28,6 +28,7 @@ import {
   type TabNavigationItem,
 } from '@/app/components/ui/navigation/tab-navigation';
 import { useAutomations } from '@/app/features/automations/hooks/queries';
+import { ProjectArchivedBadge } from '@/app/features/projects/components/project-archived-badge';
 import {
   isProjectTasksPath,
   ProjectBreadcrumbSwitcher,
@@ -281,11 +282,16 @@ function ProjectDetailLayout() {
                     className="contents"
                   >
                     {project ? (
-                      <ProjectBreadcrumbSwitcher
-                        organizationId={organizationId}
-                        projectId={asProjectId(projectId)}
-                        projectName={project.name}
-                      />
+                      <span className="inline-flex items-center gap-2">
+                        <ProjectBreadcrumbSwitcher
+                          organizationId={organizationId}
+                          projectId={asProjectId(projectId)}
+                          projectName={project.name}
+                        />
+                        {project.archivedAt !== undefined && (
+                          <ProjectArchivedBadge className="px-1.5 py-px text-[10px]" />
+                        )}
+                      </span>
                     ) : (
                       <SkeletonBox>
                         <span className="inline-block h-4 w-32 align-middle" />

--- a/services/platform/backend/domains/documents/service.ts
+++ b/services/platform/backend/domains/documents/service.ts
@@ -1298,6 +1298,9 @@ export interface DocumentSearchHit {
   folderId?: string;
   projectId?: string;
   updatedAt: number;
+  /** The document's project is archived. A document has no archive state of
+   *  its own, so this is the only label it can carry (the #3007 shape). */
+  projectArchived?: true;
 }
 
 /** Palette search over hub + readable-project documents (title match; the
@@ -1309,8 +1312,15 @@ export async function searchDocumentsView(
 ): Promise<DocumentSearchHit[]> {
   const term = query.trim();
   if (term === '') return [];
-  const projects = await listProjects(sql, auth);
+  // #2999: an archived project's files stay searchable and say so. Trash is
+  // unaffected — `lifecycle_status` remains a hard fence.
+  const projects = await listProjects(sql, auth, { includeArchived: true });
   const projectIds = projects.map((project) => project.id);
+  const archivedProjectIds = new Set(
+    projects
+      .filter((project) => project.archivedAt !== null)
+      .map((project) => project.id),
+  );
   const rows = await sql<(DocumentRow & { folderPath: string | null })[]>`
     SELECT ${sql.unsafe(DOCUMENT_COLUMNS)}, folder_path AS "folderPath"
     FROM app.documents
@@ -1319,7 +1329,9 @@ export async function searchDocumentsView(
       AND title ILIKE ${`%${term}%`}
       AND (${hubAccessClause(sql, auth)}
         OR (project_id IS NOT NULL AND project_id = ANY(${projectIds})))
-    ORDER BY coalesce(source_modified_at_ms, created_at_ms) DESC
+    ORDER BY
+      (project_id IS NOT NULL AND project_id = ANY(${[...archivedProjectIds]})),
+      coalesce(source_modified_at_ms, created_at_ms) DESC
     LIMIT ${HUB_SEARCH_MAX}
   `;
   return rows.map((row) => {
@@ -1337,6 +1349,9 @@ export async function searchDocumentsView(
     };
     if (row.folderId !== null) hit.folderId = row.folderId;
     if (row.projectId !== null) hit.projectId = row.projectId;
+    if (row.projectId !== null && archivedProjectIds.has(row.projectId)) {
+      hit.projectArchived = true;
+    }
     return hit;
   });
 }

--- a/services/platform/backend/domains/projects/service.ts
+++ b/services/platform/backend/domains/projects/service.ts
@@ -1878,13 +1878,15 @@ export async function searchProjects(
   if (query.trim().length === 0) {
     return [];
   }
+  // #2999: an archived project stays searchable. `PROJECT_COLUMNS` already
+  // carries `archived_at_ms`, so the caller labels the row from what it gets.
+  // Archived rows sort last so they cannot fill the capped page.
   return sql<ProjectRow[]>`
     SELECT ${sql.unsafe(PROJECT_COLUMNS)} FROM app.projects
     WHERE org_id = ${auth.organizationId}
-      AND archived_at_ms IS NULL
       AND name ILIKE ${term}
       AND ${visibilityClause(sql, auth)}
-    ORDER BY updated_at_ms DESC
+    ORDER BY (archived_at_ms IS NOT NULL), updated_at_ms DESC
     LIMIT ${Math.min(limit, 50)}
   `;
 }

--- a/services/platform/backend/domains/tasks/service.ts
+++ b/services/platform/backend/domains/tasks/service.ts
@@ -2709,6 +2709,10 @@ export interface TaskSearchHit {
   updatedAt: number;
   number?: number;
   projectKey?: string;
+  /** The task itself is archived. Omitted when false (the #3007 shape). */
+  archived?: true;
+  /** The task's project is archived; the task may still be live work. */
+  projectArchived?: true;
 }
 
 /**
@@ -2733,16 +2737,23 @@ export async function searchTasks(
 
   let projectIds: string[];
   const projectKeys = new Map<string, string | null>();
+  // #2999: archived work stays searchable and says it is archived. An archived
+  // project is read here so its live tasks are findable at all, and its id is
+  // kept so every hit from it can carry `projectArchived`.
+  const archivedProjectIds = new Set<string>();
   if (args.projectId !== undefined) {
     const project = await loadProjectOrThrow(sql, args.projectId);
-    if (project.archivedAt !== null) return [];
     assertTaskReadable(project, auth);
     projectIds = [project.id];
     projectKeys.set(project.id, project.key);
+    if (project.archivedAt !== null) archivedProjectIds.add(project.id);
   } else {
-    const projects = await listProjects(sql, auth);
+    const projects = await listProjects(sql, auth, { includeArchived: true });
     projectIds = projects.map((project) => project.id);
-    for (const project of projects) projectKeys.set(project.id, project.key);
+    for (const project of projects) {
+      projectKeys.set(project.id, project.key);
+      if (project.archivedAt !== null) archivedProjectIds.add(project.id);
+    }
   }
   if (projectIds.length === 0) return [];
 
@@ -2753,21 +2764,22 @@ export async function searchTasks(
     description: string | null;
     updatedAt: number;
     number: number | null;
+    archivedAt: number | null;
   }
   const fieldHits = await sql<FieldHit[]>`
     SELECT t.id AS "taskId", t.project_id AS "projectId", t.title,
-           t.description, t.updated_at_ms::float8 AS "updatedAt", t.number
+           t.description, t.updated_at_ms::float8 AS "updatedAt", t.number,
+           t.archived_at_ms::float8 AS "archivedAt"
     FROM app.tasks t
     JOIN app.projects p ON p.id = t.project_id
     WHERE t.org_id = ${auth.organizationId}
       AND t.project_id = ANY(${projectIds})
-      AND t.archived_at_ms IS NULL
       AND lower(
         t.title || ' ' || coalesce(t.description, '') || ' ' ||
         coalesce(t.external_id, '') || ' ' ||
         coalesce(p.key || '-' || t.number::text, '')
       ) LIKE ALL(${patterns})
-    ORDER BY t.updated_at_ms DESC
+    ORDER BY (t.archived_at_ms IS NOT NULL), t.updated_at_ms DESC
     LIMIT ${SEARCH_MAX_RESULTS}
   `;
   const seen = new Set(fieldHits.map((hit) => hit.taskId));
@@ -2783,6 +2795,8 @@ export async function searchTasks(
     };
     if (hit.number !== null) row.number = hit.number;
     if (key !== null) row.projectKey = key;
+    if (hit.archivedAt !== null) row.archived = true;
+    if (archivedProjectIds.has(hit.projectId)) row.projectArchived = true;
     return row;
   };
   const results: TaskSearchHit[] = fieldHits.map((hit) =>
@@ -2791,18 +2805,19 @@ export async function searchTasks(
 
   if (results.length < SEARCH_MAX_RESULTS) {
     const commentHits = await sql<(FieldHit & { body: string })[]>`
-      SELECT DISTINCT ON (t.updated_at_ms, t.id)
+      SELECT DISTINCT ON ((t.archived_at_ms IS NOT NULL), t.updated_at_ms, t.id)
              t.id AS "taskId", t.project_id AS "projectId", t.title,
              t.description, t.updated_at_ms::float8 AS "updatedAt", t.number,
+             t.archived_at_ms::float8 AS "archivedAt",
              m.text AS body
       FROM app.task_discussion_message_meta meta
       JOIN app.messages m ON m.id = meta.message_id
       JOIN app.tasks t ON t.id = meta.task_id
       WHERE meta.org_id = ${auth.organizationId}
         AND t.project_id = ANY(${projectIds})
-        AND t.archived_at_ms IS NULL
         AND lower(coalesce(m.text, '')) LIKE ALL(${patterns})
-      ORDER BY t.updated_at_ms DESC, t.id, m.created_at_ms DESC
+      ORDER BY (t.archived_at_ms IS NOT NULL), t.updated_at_ms DESC, t.id,
+               m.created_at_ms DESC
       LIMIT ${SEARCH_MAX_RESULTS}
     `;
     for (const hit of commentHits) {
@@ -2811,7 +2826,11 @@ export async function searchTasks(
       seen.add(hit.taskId);
       results.push(toHit(hit, hit.body));
     }
-    results.sort((a, b) => b.updatedAt - a.updatedAt);
+    results.sort(
+      (a, b) =>
+        Number(a.archived ?? false) - Number(b.archived ?? false) ||
+        b.updatedAt - a.updatedAt,
+    );
   }
   return results;
 }

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -2511,7 +2511,7 @@ async function checkTasks(
   // tasks and a search that excludes them cancel out: the row vanishes the
   // moment you type. Both reads are asserted here over one archived task.
   const boardSchema = z.object({
-    tasks: z.array(z.object({ _id: z.string() }).loose()),
+    tasks: z.array(z.object({ id: z.string() }).loose()),
   });
   const boardWith = boardSchema.safeParse(
     await get(
@@ -2523,15 +2523,19 @@ async function checkTasks(
   );
   const onBoardWith =
     boardWith.success &&
-    boardWith.data.tasks.some((t) => t._id === archivedTaskId);
+    boardWith.data.tasks.some((t) => t.id === archivedTaskId);
   const onBoardWithout =
     boardWithout.success &&
-    boardWithout.data.tasks.some((t) => t._id === archivedTaskId);
+    boardWithout.data.tasks.some((t) => t.id === archivedTaskId);
   const inSearch = afterTaskArchive.some((h) => h.taskId === archivedTaskId);
   record(
     'Show archived + a search query still shows the archived task (#3325)',
-    onBoardWith && !onBoardWithout && inSearch,
-    `board(includeArchived)=${onBoardWith} (want true), board(default)=${onBoardWithout} (want false), search=${inSearch} (want true) — the page renders the intersection`,
+    boardWith.success &&
+      boardWithout.success &&
+      onBoardWith &&
+      !onBoardWithout &&
+      inSearch,
+    `parsed=${boardWith.success}/${boardWithout.success} (both want true), board(includeArchived)=${onBoardWith} (want true), board(default)=${onBoardWithout} (want false), search=${inSearch} (want true) — the page renders the intersection`,
   );
 
   await send(

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -2507,6 +2507,33 @@ async function checkTasks(
     afterTaskArchive.findIndex((h) => h.taskId === liveTaskId) <
     afterTaskArchive.findIndex((h) => h.taskId === archivedTaskId);
 
+  // The tasks page renders `board ∩ search`, so a board that includes archived
+  // tasks and a search that excludes them cancel out: the row vanishes the
+  // moment you type. Both reads are asserted here over one archived task.
+  const boardSchema = z.object({
+    tasks: z.array(z.object({ _id: z.string() }).loose()),
+  });
+  const boardWith = boardSchema.safeParse(
+    await get(
+      `/api/app/tasks?orgId=${orgId}&projectId=${archProjectId}&includeArchived=true`,
+    ),
+  );
+  const boardWithout = boardSchema.safeParse(
+    await get(`/api/app/tasks?orgId=${orgId}&projectId=${archProjectId}`),
+  );
+  const onBoardWith =
+    boardWith.success &&
+    boardWith.data.tasks.some((t) => t._id === archivedTaskId);
+  const onBoardWithout =
+    boardWithout.success &&
+    boardWithout.data.tasks.some((t) => t._id === archivedTaskId);
+  const inSearch = afterTaskArchive.some((h) => h.taskId === archivedTaskId);
+  record(
+    'Show archived + a search query still shows the archived task (#3325)',
+    onBoardWith && !onBoardWithout && inSearch,
+    `board(includeArchived)=${onBoardWith} (want true), board(default)=${onBoardWithout} (want false), search=${inSearch} (want true) — the page renders the intersection`,
+  );
+
   await send(
     'POST',
     `/api/app/projects/${archProjectId}/archive?orgId=${orgId}`,

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -2529,6 +2529,33 @@ async function checkTasks(
       afterProjectArchive.some((h) => h.taskId === archivedTaskId),
     `archivedHit=${JSON.stringify(archivedHit)}, liveHit=${JSON.stringify(liveHit)}, liveFirst=${liveSortsFirst}, afterProjectArchive=${JSON.stringify(afterProjectArchive.map((h) => [h.taskId === liveTaskId ? 'live' : 'archived', h.archived, h.projectArchived]))}`,
   );
+
+  // The SQL ORDER BY, on its own. The page is capped at SEARCH_MAX_RESULTS
+  // (25); fill it with live rows so an archived row can only appear by
+  // displacing one. Archiving bumps `updated_at_ms`, so a recency-only sort
+  // puts the archived row first. At exactly 25 field hits the comment leg —
+  // and with it the merge sort — never runs, leaving the SQL key alone.
+  const CAP = 25;
+  const crowdIds: string[] = [];
+  for (let i = 0; i < CAP; i += 1) {
+    crowdIds.push(await mkTask(`Crowdable live ${i}`));
+  }
+  const crowdArchivedId = await mkTask('Crowdable archived');
+  await send(
+    'POST',
+    `/api/app/tasks/${crowdArchivedId}/archive?orgId=${orgId}`,
+  );
+  const crowded = hitSchema.safeParse(
+    await get(`/api/app/tasks/search?q=Crowdable&orgId=${orgId}`),
+  );
+  const crowdedRows = crowded.success ? crowded.data.results : [];
+  record(
+    'a capped page keeps live tasks and drops the archived one (#2999)',
+    crowdedRows.length === CAP &&
+      !crowdedRows.some((h) => h.taskId === crowdArchivedId) &&
+      crowdIds.every((id) => crowdedRows.some((h) => h.taskId === id)),
+    `rows=${crowdedRows.length} (want ${CAP}), archivedPresent=${crowdedRows.some((h) => h.taskId === crowdArchivedId)} (want false), liveMissing=${crowdIds.filter((id) => !crowdedRows.some((h) => h.taskId === id)).length} (want 0)`,
+  );
 }
 
 /**

--- a/services/platform/backend/integration-check.ts
+++ b/services/platform/backend/integration-check.ts
@@ -1557,6 +1557,18 @@ async function checkProjects(
   const listAfterArchive = z
     .object({ projects: z.array(z.object({ id: z.string() })) })
     .safeParse(await get(`?orgId=${orgId}`));
+  // #2999: the list hides an archived project, search still finds it and the
+  // row carries the stamp the palette turns into an "Archived" badge.
+  const searchWhileArchived = z
+    .object({
+      projects: z.array(
+        z.object({ id: z.string(), archivedAt: z.number().nullish() }).loose(),
+      ),
+    })
+    .safeParse(await get(`/search?orgId=${orgId}&q=Integration`));
+  const archivedRow = searchWhileArchived.success
+    ? searchWhileArchived.data.projects.find((p) => p.id === projectId)
+    : undefined;
   const restored = await send('POST', `/${projectId}/restore?orgId=${orgId}`);
   const searched = z
     .object({ projects: z.array(z.object({ id: z.string() })) })
@@ -1566,10 +1578,12 @@ async function checkProjects(
     archived.ok &&
       listAfterArchive.success &&
       !listAfterArchive.data.projects.some((p) => p.id === projectId) &&
+      archivedRow !== undefined &&
+      typeof archivedRow.archivedAt === 'number' &&
       restored.ok &&
       searched.success &&
       searched.data.projects.some((p) => p.id === projectId),
-    `archive → ${archived.status}, hidden=${listAfterArchive.success ? !listAfterArchive.data.projects.some((p) => p.id === projectId) : 'ERR'}, search hits=${searched.success ? searched.data.projects.length : 'ERR'}`,
+    `archive → ${archived.status}, hidden=${listAfterArchive.success ? !listAfterArchive.data.projects.some((p) => p.id === projectId) : 'ERR'}, whileArchived=${JSON.stringify(archivedRow)}, search hits=${searched.success ? searched.data.projects.length : 'ERR'}`,
   );
 
   // --- Project secrets: write-only values, metadata listings, atomic pair.
@@ -2438,6 +2452,82 @@ async function checkTasks(
       fromIssue.success &&
       folderBound.success,
     `search=${searchFields.success ? searchFields.data.results.length : 'ERR'}, comment-hit=${searchComment.success ? searchComment.data.results.length : 'ERR'}, mention=${mentionPreview.success ? JSON.stringify(mentionPreview.data.previews[0]) : 'ERR'}, latest=${latestRun.success}, live=${liveAutomation.success}, listing=${appListing.success}, wf=${wfStart.success}/${wfCancel.success}/${bCancelled.success}, fromIssue=${fromIssue.success ? 'ok' : 'ERR'}, folderBound=${folderBound.success}`,
+  );
+
+  // --- #2999 in the palette: archived work is searchable and says so.
+  // Its own project, so archiving it cannot disturb the lanes above.
+  const archProj = z.object({ projectId: z.string() }).safeParse(
+    await (
+      await send('POST', `/api/app/projects?orgId=${orgId}`, {
+        name: 'Archivable Project',
+      })
+    ).json(),
+  );
+  const archProjectId = archProj.success ? archProj.data.projectId : '';
+  const mkTask = async (title: string): Promise<string> => {
+    const made = z.object({ taskId: z.string() }).safeParse(
+      await (
+        await send('POST', `/api/app/tasks?orgId=${orgId}`, {
+          projectId: archProjectId,
+          title,
+          status: 'todo',
+        })
+      ).json(),
+    );
+    return made.success ? made.data.taskId : '';
+  };
+  const archivedTaskId = await mkTask('Zephyrine archived task');
+  const liveTaskId = await mkTask('Zephyrine live task');
+
+  const hitSchema = z.object({
+    results: z.array(
+      z.object({ taskId: z.string(), title: z.string() }).loose(),
+    ),
+  });
+  const searchZephyrine = async (): Promise<
+    {
+      taskId: string;
+      title: string;
+      archived?: unknown;
+      projectArchived?: unknown;
+    }[]
+  > => {
+    const parsed = hitSchema.safeParse(
+      await get(`/api/app/tasks/search?q=Zephyrine&orgId=${orgId}`),
+    );
+    return parsed.success ? parsed.data.results : [];
+  };
+
+  await send('POST', `/api/app/tasks/${archivedTaskId}/archive?orgId=${orgId}`);
+  const afterTaskArchive = await searchZephyrine();
+  const archivedHit = afterTaskArchive.find((h) => h.taskId === archivedTaskId);
+  const liveHit = afterTaskArchive.find((h) => h.taskId === liveTaskId);
+  // The page is capped, so a live row must never sort behind an archived one.
+  const liveSortsFirst =
+    afterTaskArchive.findIndex((h) => h.taskId === liveTaskId) <
+    afterTaskArchive.findIndex((h) => h.taskId === archivedTaskId);
+
+  await send(
+    'POST',
+    `/api/app/projects/${archProjectId}/archive?orgId=${orgId}`,
+  );
+  const afterProjectArchive = await searchZephyrine();
+  const liveInArchived = afterProjectArchive.find(
+    (h) => h.taskId === liveTaskId,
+  );
+
+  record(
+    'archived tasks and archived projects stay searchable, labelled (#2999)',
+    archivedHit?.archived === true &&
+      archivedHit.projectArchived === undefined &&
+      liveHit !== undefined &&
+      liveHit.archived === undefined &&
+      liveSortsFirst &&
+      // The case #3007 named: live work in a retired project stays findable.
+      liveInArchived?.projectArchived === true &&
+      liveInArchived.archived === undefined &&
+      afterProjectArchive.some((h) => h.taskId === archivedTaskId),
+    `archivedHit=${JSON.stringify(archivedHit)}, liveHit=${JSON.stringify(liveHit)}, liveFirst=${liveSortsFirst}, afterProjectArchive=${JSON.stringify(afterProjectArchive.map((h) => [h.taskId === liveTaskId ? 'live' : 'archived', h.archived, h.projectArchived]))}`,
   );
 }
 

--- a/services/platform/messages/de.yml
+++ b/services/platform/messages/de.yml
@@ -2017,6 +2017,8 @@ dialogs:
     scopeLabel: Suchbereich
     scopeChats: Chats
     scopeEverything: Alles
+    badgeArchived: Archiviert
+    badgeProjectArchived: Archiviertes Projekt
   thisMember: dieses Mitglied
   confirmRemoveMember: '{name} aus dem Team entfernen? Die Person verliert den Zugriff auf diese Organisation und alle zugehörigen Ressourcen.'
   toSend: zum Senden

--- a/services/platform/messages/en.yml
+++ b/services/platform/messages/en.yml
@@ -1953,6 +1953,8 @@ dialogs:
     scopeLabel: Search scope
     scopeChats: Chats
     scopeEverything: Everything
+    badgeArchived: Archived
+    badgeProjectArchived: Archived project
   thisMember: this member
   confirmRemoveMember: Remove {name} from the team? They'll lose access to this organization and all associated resources.
   toSend: to send

--- a/services/platform/messages/fr.yml
+++ b/services/platform/messages/fr.yml
@@ -2031,6 +2031,8 @@ dialogs:
     scopeLabel: Portée de la recherche
     scopeChats: Chats
     scopeEverything: Tout
+    badgeArchived: Archivé
+    badgeProjectArchived: Projet archivé
   thisMember: ce membre
   confirmRemoveMember: Retirer {name} de l'équipe ? Cette personne perdra l'accès à cette organisation et à toutes les ressources associées.
   toSend: pour envoyer

--- a/services/platform/tests/manual/suites/navigation.md
+++ b/services/platform/tests/manual/suites/navigation.md
@@ -134,6 +134,16 @@ is hidden when the org has no teams.
   Separately, the benign one-off toast **"Tale is ready to work offline."**
   (`pwa.offlineReady`) fires on first SW install — expected, do **not** file
   it (it can photobomb unrelated screenshots)
+- [ ] `NAV-F15` · **Archived work in the palette** — Needs a project with one
+  archived task and one live task, plus a second project that is itself
+  archived and still holds a live task. Press **Cmd/Ctrl+K** on **Everything**
+  (`dialogs.search.scopeEverything`) and search a term all four share → Every
+  row appears. The archived task carries the **Archived** badge
+  (`dialogs.search.badgeArchived`); the live task in the archived project
+  carries **Archived project** (`dialogs.search.badgeProjectArchived`); the
+  live task in the live project carries neither. Live rows list above archived
+  ones. The badge reads as a quiet chip beside the title, not a second
+  heading, and stays legible in dark mode and at 400px width.
 
 ## Boundary & error tests
 

--- a/services/platform/tests/manual/suites/projects.md
+++ b/services/platform/tests/manual/suites/projects.md
@@ -158,6 +158,13 @@ projects-list row ⋯ menu.
   (`common.actions.openMenu`) → **Archive**; toggle the archived view;
   **Unarchive** → Archived project leaves the active list and appears under
   archived; unarchive returns it to the active list (survives reload)
+- [ ] `PROJ-F22` · **Archived project says so on every tab** — Archive a
+  project, then open it and walk its tabs (Overview, Chats, Tasks, Knowledge,
+  Agents) → An **Archived** badge (`projects.archived.badge`) sits beside the
+  project name in the breadcrumb on every tab, and stays legible in dark mode
+  and at 400px. Unarchive → the badge is gone. Previously an archived project
+  announced itself only in the Projects list, so a retired project looked live
+  from inside.
 - [ ] `PROJ-F15` · **Cascade delete** — Projects list → row ⋯
   (`common.actions.openMenu`) → **Delete** (`projects.rowActions.delete`) → in
   the **Delete project** dialog (`projects.settings.deleteDialogTitle`) tick

--- a/services/platform/tests/manual/suites/tasks.md
+++ b/services/platform/tests/manual/suites/tasks.md
@@ -73,6 +73,12 @@ Mentions/assignment notifications need a second member (SETUP.md extras).
   DnD; the collapse state survives reload (persisted per project); archived
   tasks appear only with the toggle on, wearing the **Archived** badge
   (`tasks.archived.badge`)
+- [ ] `TASK-F18` · **Show archived survives a search** — With **Show archived**
+  on and an archived task visible, type part of its title into **Search tasks**
+  (`tasks.searchPlaceholder`) → The archived task stays in the results. Clear
+  the search, turn **Show archived** off, search again → it is gone. The page
+  renders the board read narrowed by the search read, so the toggle has to
+  govern both or typing silently drops rows the toggle just revealed.
 - [ ] `TASK-F6` · **Backlog lane semantics** — **Create task** → open the
   **Status** picker (`tasks.fields.status`) in the dialog → **Backlog**; later
   open the task and promote it to **To do** → The task lands in the Backlog


### PR DESCRIPTION
The ⌘K palette now returns archived tasks and projects, and rows belonging to an archived project, each labelled **Archived** or **Archived project**. Live rows still list first.

## Why

#2999 decided that archived material stays searchable and that results say they are archived. #3007 shipped the two labels for it, `archived` and `projectArchived`, and scoped the UI out: "Not included: any UI change." Nothing tracked the rest, so the palette kept the pre-decision predicate while the agent path implemented the decision. The same query answered differently depending on who asked.

The wider effect was the project set. `searchTasks` built its readable projects from `listProjects`, which defaults `includeArchived` to false, so a live task in an archived project was unfindable. That is the case #3007 named: "A live task in a retired project may still be work nobody closed." `searchDocumentsView` resolved projects the same way, so those files went too.

## What changed

- `SearchResult` gains `badge`, rendered as a chip beside the title. The contract had no field a hit could say this in.
- `searchTasks` returns archived tasks, reads archived projects, and stamps both labels in one place so its two legs cannot disagree.
- `searchProjects` returns archived projects. `PROJECT_COLUMNS` already carried `archived_at_ms`.
- `searchDocumentsView` reads archived projects and stamps `projectArchived`. Trash is untouched: `lifecycle_status` stays a hard fence.
- Live rows sort ahead of archived ones, in the SQL page order and again in the merge. Archiving bumps `updated_at_ms`, so under a recency-only sort an archived row takes the freshest slot on a page capped at 25.
- Badge copy in en, de and fr.

Archived work also says so where it lives, not only in search:

- A board card and a list row carry the **Archived** badge. Colour was the sole cue (`opacity-70` at `task-card.tsx:121` and `tasks-list.tsx:326`), which WCAG 2.1 AA 1.4.1 does not allow. `TASK-F5` already claimed the rows wore this badge; now they do.
- An archived project carries the badge beside its breadcrumb name on every tab. It previously announced itself only in the Projects list, so a retired project looked live from inside.

The tasks page is affected by the same defect through a different route. It renders `board ∩ search` (`tasks-workspace.tsx:166`), so the board read is a ceiling the search read can only narrow. With **Show archived** on, the board returned archived tasks and `searchTasks` did not, so typing in **Search tasks** silently removed the rows the toggle had just revealed. Widening `searchTasks` makes the two agree; the toggle still governs.

## Risk

A search page is capped at 25 rows and archived rows now compete for it. The two sort keys keep that from costing live results. The lane `a capped page keeps live tasks and drops the archived one` pins it at exactly the cap.

Chats and contacts are unchanged. `searchChats` excludes archived threads under its own vocabulary and #2999 never covered it; contact trash is a fence #3007 left alone.

## Tests

Real Postgres, 630/631 checks across 147/147 lanes. The one failure is `tasks: a burst of serializable commenters`, which fails on clean `origin/main` too and varies run to run (`attempts` 26 and 28 against a `≤24` bound; once `landed=10/12`).

| Assertion | Mutation that turned it red |
| --- | --- |
| An archived task is returned and labelled | Restore `AND t.archived_at_ms IS NULL` in the field leg |
| A live task in an archived project is returned | Restore `listProjects(sql, auth)` without `includeArchived` |
| Live rows sort ahead of archived ones | Drop the band from the merge sort |
| A capped page keeps live rows | Drop the band from the SQL page order |
| An archived project is returned by project search | — |
| A row renders its badge | Render the badge never |
| A row without one renders none | Render the badge always |
| Show archived plus a query keeps the task | Make the board ignore `includeArchived` |
| A board card badges when archived | Force the card condition false, then true |
| A list row badges when archived | Force the row condition false, then true |
| A project breadcrumb badges when archived | Force the breadcrumb condition false, then true |

The third mutation showed the merge sort masks the SQL order in a two-row fixture, so the fourth assertion builds 25 live rows plus one archived to pin the SQL key on its own.

That lane asserts both reads parsed before reading them. Its first draft required an `_id` the board does not return, so both parses failed and the `want false` half passed while proving nothing.

The card's negative case needed a second pass. Forcing the badge to always render did not fail it: the fixture had no project key, so `formatTaskIdentifier` returned null, the identifier row was skipped, and the badge could not appear either way. Both fixtures now render that row, and the permissive mutation fails.

Manual boxes `NAV-F15`, `TASK-F18` and `PROJ-F22` cover what a headless run cannot judge: the chip's weight beside the title, dark mode, and 400px.

## Scope

Closes #3325. Does not close #2999, which is already closed.

Gate: `bun run check` green (43/43) apart from two pre-existing failures reproduced on clean `origin/main` — `@tale/docs` `deploy-sim.test.ts` under concurrency (passes in isolation, 206/206) and two `@tale/sandbox-runtime-daemon` host-dependent tests, in a workspace this branch does not touch. `knip:check` green; `lint:manual` 777 boxes; `lint:sast` 0 findings in changed files.


🤖 Generated with [Claude Code](https://claude.com/claude-code)