### PR TITLE
fix(cli): repair on-prem deploy provision and credential path

### DIFF
--- a/.github/actions/setup-cli/action.yml
+++ b/.github/actions/setup-cli/action.yml
@@ -70,6 +70,12 @@ runs:
         bun install --frozen-lockfile --filter @tale/cli
         # Generation records the clean source commit in the executable.
         bun run --filter @tale/cli generate
+        # The backend-local provision phase runs inside the target's backend
+        # container, where a compiled executable cannot resolve the backend's
+        # own node_modules (postgres, better-auth) that it dynamically imports.
+        # Ship an interpreted bundle beside the executable; the container's own
+        # bun runs it so those imports resolve. See copyDeploymentCli / apply.
+        bun run --filter @tale/cli build:backend-local
         case "$RUNNER_OS/$RUNNER_ARCH/${TALE_CLI_LINUX_BASELINE:-false}" in
           Linux/X64/true) bun run --filter @tale/cli build:linux-baseline ;;
           Linux/X64/false) bun run --filter @tale/cli build:linux ;;

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "generate": "bun run scripts/generate-embedded.ts",
     "setup": "bun run generate",
-    "build": "bun run generate && bun run build:linux && bun run build:mac && bun run check:bundle",
+    "build": "bun run generate && bun run build:backend-local && bun run build:linux && bun run build:mac && bun run check:bundle",
+    "build:backend-local": "bun build --bundle --target=bun --outfile=dist/tale.mjs src/index.ts",
     "build:linux": "bun build --compile --define TALE_COMPILED=true --target=bun-linux-x64 --outfile=dist/tale src/index.ts",
     "build:linux-baseline": "bun build --compile --define TALE_COMPILED=true --target=bun-linux-x64-baseline --outfile=dist/tale src/index.ts",
     "build:linux-arm64": "bun build --compile --define TALE_COMPILED=true --target=bun-linux-arm64 --outfile=dist/tale src/index.ts",

--- a/tools/cli/src/lib/config/platform-apply.test.ts
+++ b/tools/cli/src/lib/config/platform-apply.test.ts
@@ -92,7 +92,7 @@ async function fixture(
         };
       }
       let id: string;
-      if (url.pathname === '/api/app/provider-credentials/' && method === 'GET')
+      if (url.pathname === '/api/app/provider-credentials' && method === 'GET')
         return {
           credentials: [...entries]
             .filter(([key]) => key.startsWith('provider-credential/'))
@@ -106,14 +106,13 @@ async function fixture(
               }),
             ),
         };
-      if (url.pathname.startsWith('/api/app/provider-credentials/')) {
+      if (url.pathname === '/api/app/provider-credentials')
+        id = `provider-credential/${payload!.providerSlug}/${encodeURIComponent(String(payload!.name))}`;
+      else if (url.pathname.startsWith('/api/app/provider-credentials/')) {
         const credentialId = url.pathname.slice(
           '/api/app/provider-credentials/'.length,
         );
-        if (credentialId)
-          id = [...entries].find(([, entry]) => entry.id === credentialId)![0];
-        else
-          id = `provider-credential/${payload!.providerSlug}/${encodeURIComponent(String(payload!.name))}`;
+        id = [...entries].find(([, entry]) => entry.id === credentialId)![0];
       } else if (url.pathname.startsWith('/api/app/providers/definitions/'))
         id = `provider/${url.pathname.split('/').at(-1)}`;
       else if (url.pathname.startsWith('/api/app/governance/policies/'))
@@ -529,7 +528,7 @@ describe('one general native configuration lifecycle', () => {
     f.client.request = async (path, method, body) => {
       const result = await request(path, method, body);
       if (
-        path === '/api/app/provider-credentials/' &&
+        path === '/api/app/provider-credentials' &&
         (!method || method === 'GET')
       ) {
         const view = result as { credentials: Record<string, unknown>[] };
@@ -603,5 +602,38 @@ describe('one general native configuration lifecycle', () => {
     ).rejects.toThrow('explicit declaration');
     expect(f.writes.every((id) => id.startsWith('provider/'))).toBe(true);
     expect(JSON.parse(await readFile(f.receipt, 'utf8')).phase).toBe('pending');
+  });
+
+  test('addresses the provider-credentials collection without a trailing slash', async () => {
+    // The Hono backend serves the collection at `/api/app/provider-credentials`;
+    // a trailing slash is a 404. Only the per-credential address keeps a segment
+    // after the slash. Reading, creating and reading back a credential must use
+    // the slashless collection route.
+    const f = await fixture();
+    const paths: string[] = [];
+    const request = f.client.request;
+    f.client.request = async (path, method, body) => {
+      paths.push(path);
+      return request(path, method, body);
+    };
+    const plan = await planPlatformConfiguration(f.configuration, f.client);
+    await applyPlatformConfiguration(
+      f.configuration,
+      plan,
+      f.client,
+      f.receipt,
+    );
+    const collection = paths.filter((path) =>
+      path.startsWith('/api/app/provider-credentials'),
+    );
+    expect(collection).toContain('/api/app/provider-credentials');
+    expect(collection).not.toContain('/api/app/provider-credentials/');
+    expect(
+      collection.every(
+        (path) =>
+          path === '/api/app/provider-credentials' ||
+          /^\/api\/app\/provider-credentials\/[^/]+$/.test(path),
+      ),
+    ).toBe(true);
   });
 });

--- a/tools/cli/src/lib/config/platform-resources.ts
+++ b/tools/cli/src/lib/config/platform-resources.ts
@@ -89,7 +89,7 @@ export async function readResource(
     }
     case 'provider-credential': {
       const rows = credentials.parse(
-        await client.request('/api/app/provider-credentials/'),
+        await client.request('/api/app/provider-credentials'),
       ).credentials;
       const matches = rows.filter(
         (row) =>
@@ -136,7 +136,7 @@ export async function checkResourceChange(
   if (resourceConverged(resource, current.config)) return;
   if (resource.kind === 'provider-credential' && resource.config.isDefault) {
     const rows = credentials.parse(
-      await client.request('/api/app/provider-credentials/'),
+      await client.request('/api/app/provider-credentials'),
     ).credentials;
     for (const row of rows) {
       if (
@@ -244,7 +244,7 @@ export async function writeResource(
           },
         );
       } else {
-        await client.request('/api/app/provider-credentials/', 'POST', {
+        await client.request('/api/app/provider-credentials', 'POST', {
           ...fields,
           providerSlug,
           authMethod,

--- a/tools/cli/src/lib/deployment/apply.test.ts
+++ b/tools/cli/src/lib/deployment/apply.test.ts
@@ -53,6 +53,9 @@ async function create(legacy = false, identity = true) {
   executable.set([0x7f, 0x45, 0x4c, 0x46, 2, 1]);
   executable.writeUInt16LE(62, 18);
   writeFileSync(binary, executable);
+  // Ship the interpreted bundle beside the executable: copyDeploymentCli
+  // requires it, and the backend-local provision phase runs it under bun.
+  writeFileSync(`${binary}.mjs`, '#!/usr/bin/env bun\nprocess.exit(0);\n');
   const spec = deploymentSpecSchema.parse({
     schemaVersion: 1,
     name: fixture.options.name,
@@ -200,6 +203,10 @@ async function create(legacy = false, identity = true) {
         expect(args.indexOf('--user')).toBeGreaterThan(0);
         expect(args[args.indexOf('--user') + 1]).toBe('1001:1001');
         expect(args.indexOf('--user')).toBeLessThan(args.indexOf('deploy'));
+        // Interpreted under the container's own bun, never the compiled
+        // executable: `bun <temp>/cli/tale.mjs deploy provision …`.
+        expect(args[args.indexOf('deploy') - 2]).toBe('bun');
+        expect(args[args.indexOf('deploy') - 1]).toMatch(/\/cli\/tale\.mjs$/);
         expect(owned).toBe(true);
         expect(JSON.parse(options?.stdin ?? '{}')).toMatchObject({
           password: 'synthetic-operator-password',
@@ -222,6 +229,9 @@ async function create(legacy = false, identity = true) {
         if (cleanupFailure) throw new Error('synthetic-cleanup-secret');
       } else if (args[0] === 'cp') {
         copied = true;
+        // The interpreted bundle rides in the same private copy, so the
+        // backend-local phase can run it under bun.
+        expect(existsSync(join(args[1], 'cli/tale.mjs'))).toBe(true);
         nativeCopies.push({
           source: args[1],
           binary: readFileSync(join(args[1], 'cli/tale')),

--- a/tools/cli/src/lib/deployment/apply.ts
+++ b/tools/cli/src/lib/deployment/apply.ts
@@ -263,6 +263,13 @@ async function provisionBackend(
       owner,
       temporary,
     ]);
+    // Run the backend-local phase INTERPRETED, under the container's own bun,
+    // not the compiled executable. The phase dynamically imports the backend's
+    // own db/auth modules, which import node_modules (postgres, better-auth); a
+    // compiled bun executable resolves bare imports against its embedded
+    // filesystem, so those are `Cannot find package` there. The interpreted
+    // bundle shipped beside the executable resolves them from the backend's
+    // node_modules the same way the running backend does.
     const result = await run(
       [
         'exec',
@@ -272,7 +279,8 @@ async function provisionBackend(
         '--user',
         owner,
         runtime.backendContainer,
-        `${temporary}/cli/tale`,
+        'bun',
+        `${temporary}/cli/tale.mjs`,
         'deploy',
         'provision',
         '--bundle',

--- a/tools/cli/src/lib/deployment/bundle.ts
+++ b/tools/cli/src/lib/deployment/bundle.ts
@@ -262,4 +262,21 @@ export async function copyDeploymentCli(
   await mkdir(target, { mode: 0o755 });
   await writeFile(join(target, 'tale'), bytes, { mode: 0o755, flag: 'wx' });
   await chmod(join(target, 'tale'), 0o755);
+  // Beside the executable, ship the interpreted bundle the backend-local
+  // provision runs under the target's OWN bun. A compiled executable cannot
+  // resolve the backend's dynamically imported node_modules (postgres,
+  // better-auth), so that phase must run interpreted. It is the same reviewed
+  // source, and its bytes ride the same manifest hashes as every other file.
+  const interpreted = await readFile(`${binary}.mjs`);
+  if (
+    interpreted.length === 0 ||
+    interpreted.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))
+  )
+    throw preconditionError(
+      'Prepare this bundle with the interpreted Tale bundle beside the executable.',
+    );
+  await writeFile(join(target, 'tale.mjs'), interpreted, {
+    mode: 0o644,
+    flag: 'wx',
+  });
 }

--- a/tools/cli/src/lib/deployment/inputs.test.ts
+++ b/tools/cli/src/lib/deployment/inputs.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, expect, test } from 'bun:test';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { mkdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -192,10 +198,16 @@ function binary(machine = 62): Buffer<ArrayBuffer> {
   bytes.writeUInt16LE(machine, 18);
   return bytes;
 }
+// The interpreted bundle that rides beside the executable; the backend-local
+// provision phase runs it under the target's own bun. Non-empty and not ELF.
+const interpretedBundle = Buffer.from(
+  '#!/usr/bin/env bun\n// interpreted tale bundle\nprocess.exit(0);\n',
+);
 async function bundleFixture() {
   const root = temporary();
   const executable = join(temporary(), 'tale');
   writeFileSync(executable, binary());
+  writeFileSync(`${executable}.mjs`, interpretedBundle);
   await copyDeploymentCli(executable, root, 'linux/amd64');
   await mkdir(join(root, 'runtime'));
   await writeFile(join(root, 'runtime', 'runtime.json'), '{}\n');
@@ -221,6 +233,7 @@ testPosix(
     });
     expect(verified.files.map((file) => file.path)).toEqual([
       'cli/tale',
+      'cli/tale.mjs',
       'runtime/compose.yml',
       'runtime/runtime.json',
     ]);
@@ -260,8 +273,36 @@ test('plain runtimes and the wrong executable architecture are never shipped', a
     copyDeploymentCli(executable, temporary(), 'linux/amd64'),
   ).rejects.toThrow('architecture');
   const root = temporary();
+  writeFileSync(`${executable}.mjs`, interpretedBundle);
   await copyDeploymentCli(executable, root, 'linux/arm64');
   expect(readFileSync(join(root, 'cli/tale'))).toEqual(binary(183));
+  expect(readFileSync(join(root, 'cli/tale.mjs'))).toEqual(interpretedBundle);
+});
+
+test('refuses a deployment CLI without a valid interpreted bundle beside it', async () => {
+  const executable = join(temporary(), 'tale');
+  writeFileSync(executable, binary());
+  // The interpreted bundle must exist beside the executable.
+  await expect(
+    copyDeploymentCli(executable, temporary(), 'linux/amd64'),
+  ).rejects.toThrow();
+  // An empty file or an ELF executable is not an interpreted bundle.
+  writeFileSync(`${executable}.mjs`, Buffer.alloc(0));
+  await expect(
+    copyDeploymentCli(executable, temporary(), 'linux/amd64'),
+  ).rejects.toThrow('interpreted Tale bundle');
+  writeFileSync(`${executable}.mjs`, binary());
+  await expect(
+    copyDeploymentCli(executable, temporary(), 'linux/amd64'),
+  ).rejects.toThrow('interpreted Tale bundle');
+  // A valid bundle lands beside the executable: exact bytes, world-readable,
+  // never executable.
+  writeFileSync(`${executable}.mjs`, interpretedBundle);
+  const root = temporary();
+  await copyDeploymentCli(executable, root, 'linux/amd64');
+  expect(readFileSync(join(root, 'cli/tale.mjs'))).toEqual(interpretedBundle);
+  if (process.platform !== 'win32')
+    expect(statSync(join(root, 'cli/tale.mjs')).mode & 0o777).toBe(0o644);
 });
 
 test('local source selection reads real Git without a network call or worktree edits', async () => {

--- a/tools/cli/src/lib/deployment/prepare-config.test.ts
+++ b/tools/cli/src/lib/deployment/prepare-config.test.ts
@@ -35,6 +35,12 @@ describePosix('managed preparation native-owner binding', () => {
       elf.set([0x7f, 0x45, 0x4c, 0x46, 2, 1]);
       elf.writeUInt16LE(62, 18);
       await writeFile(binary, elf);
+      // The interpreted bundle rides beside the executable for the
+      // backend-local provision phase; copyDeploymentCli requires it.
+      await writeFile(
+        `${binary}.mjs`,
+        '#!/usr/bin/env bun\nprocess.exit(0);\n',
+      );
       const spec = {
         schemaVersion: 1,
         name: 'fresh-team',


### PR DESCRIPTION
## Summary

Two defects that broke managed on-prem Tale deployments, both root-caused and
verified live on a real on-prem backend, then locked with regression tests.

## Bug 1 — backend-local `deploy provision` cannot resolve the backend's node_modules

The managed on-prem `deploy provision` phase runs **inside** the backend
container and dynamically imports the backend's own modules
(`/app/backend/db/sql.ts`, `/app/backend/auth/auth.ts`) via `withBackendAuth`;
those import `node_modules` (`postgres`, `better-auth`). We shipped that phase
as a **compiled** `bun` executable, which on Linux resolves bare imports against
its embedded filesystem — so they fail with `Cannot find package 'postgres'`.
The error was swallowed twice and mis-surfaced as *"operator email attestation
failed"*, which sent debugging in the wrong direction.

**Fix:** build an interpreted `bun build --bundle` of the CLI (`dist/tale.mjs`)
and ship it beside the compiled executable; run the provision phase under the
container's **own** `bun` (`bun cli/tale.mjs deploy provision …`) so those
imports resolve from the backend's `node_modules` exactly as the running backend
does. The interpreted bundle rides the same reviewed manifest hashes as every
other bundled file.

- `tools/cli/package.json`: new `build:backend-local`, chained into `build`.
- `.github/actions/setup-cli`: build the interpreted bundle after `generate`.
- `bundle.ts` `copyDeploymentCli`: also copy `${binary}.mjs` → `cli/tale.mjs`,
  validated non-empty and not ELF.
- `apply.ts` `provisionBackend`: exec `bun cli/tale.mjs` instead of the
  compiled `cli/tale`.

## Bug 2 — provider-credentials collection requested with a trailing slash

`platform-resources.ts` requested `/api/app/provider-credentials/` (trailing
slash) for the credential collection; the Hono backend serves
`/api/app/provider-credentials` (no slash), so the request 404s.
**Verified live:** no-slash → 200, slash → 404. The per-credential
`/{credentialId}` address is correct and unchanged.

**Fix:** drop the trailing slash on the three collection calls (read, default
check, create).

## Tests

- `inputs.test.ts`: `copyDeploymentCli` fixtures now provide `${binary}.mjs`;
  assert `cli/tale.mjs` lands (bytes + mode 0o644) and is manifested; new
  regression that it refuses a missing/empty/ELF interpreted bundle.
- `apply.test.ts` / `prepare-config.test.ts`: fixtures ship the interpreted
  bundle; provision exec asserts `bun` + `cli/tale.mjs` and that the bundle
  rides in the private copy.
- `platform-apply.test.ts`: fixture serves the slashless collection route; new
  regression asserts the collection is addressed without a trailing slash.
- `bun run --filter @tale/cli build:backend-local` succeeds;
  `bun dist/tale.mjs --version` → `1.0.0-dev` (non-ELF `#!/usr/bin/env bun`).

## Gate

`@tale/cli` is fully green: lint (0 errors), typecheck (0 errors), `bun test`
(all pass), `oxfmt --check` clean. Full `bun run check` is red on one unrelated
task, `@tale/sandbox-runtime-daemon#test` (two I/O/timing tests: a URL-stall
deadline and a partial-HTTP-exec body). That workspace has no dependency on
`@tale/cli` and is untouched by this PR (diff is confined to `tools/cli/**` plus
one CI action file), and the two tests fail identically without these changes —
a pre-existing/environmental failure, not introduced here.
